### PR TITLE
Harden private-key storage: OS-enforced, durable biometric keychain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.worktrees
 dist
 dist-ssr
 *.local

--- a/__tests__/localStorageProvider.test.tsx
+++ b/__tests__/localStorageProvider.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Contract tests for the secure-storage accessors in LocalStorageProvider.
+ *
+ * These assert the JS-visible contract only: which options are passed to
+ * expo-secure-store, that there is NO in-JS auth latch (the OS enforces auth
+ * per read), and how invalidated (null) vs cancelled (reject) reads are
+ * surfaced. Actual native biometric enforcement is covered by on-device
+ * verification, not Jest.
+ */
+import React from 'react'
+import { renderHook, act } from '@testing-library/react-native'
+
+// --- mocks -----------------------------------------------------------------
+
+jest.mock('expo-secure-store', () => ({
+  __esModule: true,
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY'
+}))
+import * as SecureStore from 'expo-secure-store'
+const mockSecureStore = SecureStore as unknown as {
+  setItemAsync: jest.Mock
+  getItemAsync: jest.Mock
+  deleteItemAsync: jest.Mock
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: string
+}
+
+// If the implementation still imports expo-local-authentication we want the
+// test to prove it is never invoked (OS handles auth now).
+const mockAuthenticate = jest.fn(async () => ({ success: true }))
+jest.mock('expo-local-authentication', () => ({
+  authenticateAsync: mockAuthenticate
+}))
+
+// In-memory AsyncStorage.
+const memStore: Record<string, string> = {}
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async (k: string) => (k in memStore ? memStore[k] : null)),
+    setItem: jest.fn(async (k: string, v: string) => {
+      memStore[k] = v
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      delete memStore[k]
+    })
+  }
+}))
+
+jest.mock('@/context/i18n/translations', () => ({
+  __esModule: true,
+  default: { t: (key: string) => key }
+}))
+
+import LocalStorageProvider, { useLocalStorage } from '@/context/LocalStorageProvider'
+
+const SECURE_KEYCHAIN_SERVICE = 'bsv-wallet-secure'
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <LocalStorageProvider>{children}</LocalStorageProvider>
+)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  for (const k of Object.keys(memStore)) delete memStore[k]
+  mockSecureStore.getItemAsync.mockResolvedValue(null)
+})
+
+describe('LocalStorageProvider secure accessors', () => {
+  it('stores the mnemonic OS-auth-bound to a dedicated keychain service', async () => {
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.setMnemonic('correct horse battery staple')
+    })
+
+    expect(ok).toBe(true)
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      'mnemonic',
+      'correct horse battery staple',
+      expect.objectContaining({
+        requireAuthentication: true,
+        keychainService: SECURE_KEYCHAIN_SERVICE,
+        keychainAccessible: mockSecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY
+      })
+    )
+    expect(memStore['hasWalletKeys']).toBe('true')
+  })
+
+  it('reads the mnemonic with requireAuthentication + a custom prompt', async () => {
+    memStore['hasWalletKeys'] = 'true'
+    mockSecureStore.getItemAsync.mockResolvedValue('my phrase')
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+
+    let value: string | null = null
+    await act(async () => {
+      value = await result.current.getMnemonic()
+    })
+
+    expect(value).toBe('my phrase')
+    expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(
+      'mnemonic',
+      expect.objectContaining({
+        requireAuthentication: true,
+        keychainService: SECURE_KEYCHAIN_SERVICE,
+        authenticationPrompt: expect.any(String)
+      })
+    )
+  })
+
+  it('does NOT use an in-JS auth latch — never calls LocalAuthentication and hits the keychain every read', async () => {
+    memStore['hasWalletKeys'] = 'true'
+    mockSecureStore.getItemAsync.mockResolvedValue('phrase')
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+
+    await act(async () => {
+      await result.current.getMnemonic()
+      await result.current.getMnemonic()
+    })
+
+    expect(mockAuthenticate).not.toHaveBeenCalled()
+    expect(mockSecureStore.getItemAsync).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null (does not throw) when the item was invalidated but the flag is still set', async () => {
+    memStore['hasWalletKeys'] = 'true'
+    mockSecureStore.getItemAsync.mockResolvedValue(null) // invalidated → SDK returns null
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+
+    let value: string | null = 'sentinel'
+    await act(async () => {
+      value = await result.current.getMnemonic()
+    })
+
+    expect(value).toBeNull()
+  })
+
+  it('rethrows when the user cancels the biometric prompt (getItemAsync rejects)', async () => {
+    memStore['hasWalletKeys'] = 'true'
+    mockSecureStore.getItemAsync.mockRejectedValue(new Error('User canceled the authentication'))
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+
+    await expect(
+      act(async () => {
+        await result.current.getMnemonic()
+      })
+    ).rejects.toThrow(/cancel/i)
+  })
+
+  it('short-circuits to null without touching the keychain when no wallet exists', async () => {
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+
+    let value: string | null = 'sentinel'
+    await act(async () => {
+      value = await result.current.getMnemonic()
+    })
+
+    expect(value).toBeNull()
+    expect(mockSecureStore.getItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('no longer exposes the dead WAB password accessors', () => {
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+    expect((result.current as unknown as Record<string, unknown>).getPassword).toBeUndefined()
+    expect((result.current as unknown as Record<string, unknown>).setPassword).toBeUndefined()
+    expect((result.current as unknown as Record<string, unknown>).deletePassword).toBeUndefined()
+  })
+
+  it('no longer exposes the dead plaintext snapshot accessors', () => {
+    const { result } = renderHook(() => useLocalStorage(), { wrapper })
+    expect((result.current as unknown as Record<string, unknown>).setSnap).toBeUndefined()
+    expect((result.current as unknown as Record<string, unknown>).getSnap).toBeUndefined()
+  })
+})

--- a/__tests__/mnemonicWallet.test.ts
+++ b/__tests__/mnemonicWallet.test.ts
@@ -1,0 +1,20 @@
+import * as mnemonicWallet from '@/utils/mnemonicWallet'
+import { generateRandomMnemonic, getMnemonicWordCount } from '@/utils/mnemonicWallet'
+
+describe('generateRandomMnemonic', () => {
+  it('defaults to a 12-word (128-bit) phrase', () => {
+    expect(getMnemonicWordCount(generateRandomMnemonic())).toBe(12)
+  })
+
+  it('honors the requested entropy strength instead of ignoring it', () => {
+    expect(getMnemonicWordCount(generateRandomMnemonic(256))).toBe(24)
+    expect(getMnemonicWordCount(generateRandomMnemonic(160))).toBe(15)
+  })
+})
+
+describe('dead base64 helpers', () => {
+  it('are removed (they were an unencrypted footgun)', () => {
+    expect((mnemonicWallet as Record<string, unknown>).encodeMnemonicForStorage).toBeUndefined()
+    expect((mnemonicWallet as Record<string, unknown>).decodeMnemonicFromStorage).toBeUndefined()
+  })
+})

--- a/__tests__/secureClipboard.test.ts
+++ b/__tests__/secureClipboard.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the auto-clearing secret clipboard helper. The raw recovery phrase
+ * must not linger on the clipboard, but we must never clobber something the
+ * user copied afterwards.
+ */
+jest.mock('expo-clipboard', () => ({
+  __esModule: true,
+  setStringAsync: jest.fn(),
+  getStringAsync: jest.fn()
+}))
+
+import * as Clipboard from 'expo-clipboard'
+import { copySecretToClipboard } from '@/utils/secureClipboard'
+
+const mockClipboard = Clipboard as unknown as {
+  setStringAsync: jest.Mock
+  getStringAsync: jest.Mock
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.useFakeTimers()
+  mockClipboard.setStringAsync.mockResolvedValue(true)
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe('copySecretToClipboard', () => {
+  it('writes the secret to the clipboard immediately', async () => {
+    await copySecretToClipboard('seed words', { clearAfterMs: 60_000 })
+    expect(mockClipboard.setStringAsync).toHaveBeenCalledWith('seed words')
+  })
+
+  it('clears the clipboard after the delay when it still holds the secret', async () => {
+    mockClipboard.getStringAsync.mockResolvedValue('seed words')
+    await copySecretToClipboard('seed words', { clearAfterMs: 60_000 })
+
+    mockClipboard.setStringAsync.mockClear()
+    await jest.advanceTimersByTimeAsync(60_000)
+
+    expect(mockClipboard.getStringAsync).toHaveBeenCalled()
+    expect(mockClipboard.setStringAsync).toHaveBeenCalledWith('')
+  })
+
+  it('does NOT clear when the user has since copied something else', async () => {
+    mockClipboard.getStringAsync.mockResolvedValue('a different thing the user copied')
+    await copySecretToClipboard('seed words', { clearAfterMs: 60_000 })
+
+    mockClipboard.setStringAsync.mockClear()
+    await jest.advanceTimersByTimeAsync(60_000)
+
+    expect(mockClipboard.setStringAsync).not.toHaveBeenCalledWith('')
+  })
+
+  it('does not clear before the delay elapses', async () => {
+    mockClipboard.getStringAsync.mockResolvedValue('seed words')
+    await copySecretToClipboard('seed words', { clearAfterMs: 60_000 })
+
+    mockClipboard.setStringAsync.mockClear()
+    await jest.advanceTimersByTimeAsync(59_000)
+
+    expect(mockClipboard.setStringAsync).not.toHaveBeenCalledWith('')
+  })
+})

--- a/app/auth/mnemonic.tsx
+++ b/app/auth/mnemonic.tsx
@@ -19,7 +19,7 @@ import { useWallet } from '@/context/WalletContext'
 import { PrivateKey } from '@bsv/sdk'
 import { generateMnemonicWallet, validateMnemonic, recoverMnemonicWallet } from '@/utils/mnemonicWallet'
 import { generateBackupShares, generatePrintHTML } from '@/utils/backupShares'
-import * as Clipboard from 'expo-clipboard'
+import { copySecretToClipboard } from '@/utils/secureClipboard'
 import * as Print from 'expo-print'
 import { Paths, File as ExpoFile } from 'expo-file-system'
 import * as Sharing from 'expo-sharing'
@@ -111,8 +111,8 @@ export default function MnemonicScreen() {
 
   // Copy mnemonic to clipboard
   const handleCopyMnemonic = async () => {
-    await Clipboard.setStringAsync(mnemonic)
-    showToast('Copied', { type: 'success' })
+    await copySecretToClipboard(mnemonic)
+    showToast(t('clipboard_will_clear'), { type: 'success' })
     setCopied(true)
     setTimeout(() => {
       setCopied(false)

--- a/app/wallet-config.tsx
+++ b/app/wallet-config.tsx
@@ -25,7 +25,7 @@ import { ListRow } from '@/components/ui/ListRow'
 import { showAlert } from '@/components/ui/AlertCard'
 import { showToast } from '@/components/ui/Toast'
 import { router } from 'expo-router'
-import Clipboard from '@react-native-clipboard/clipboard'
+import { copySecretToClipboard } from '@/utils/secureClipboard'
 import { exportAllWalletDatabases } from '@/utils/exportDatabases'
 import { importWalletDatabase } from '@/utils/importDatabases'
 import { PrivateKey } from '@bsv/sdk'
@@ -113,12 +113,13 @@ export default function WalletConfigScreen() {
       // Copy mnemonic if available, otherwise fall back to primary key hex
       const mnemonic = await getMnemonic()
       if (mnemonic) {
-        Clipboard.setString(mnemonic)
+        await copySecretToClipboard(mnemonic)
       } else {
         const wif = await getRecoveredKey()
         if (!wif) return
-        Clipboard.setString(PrivateKey.fromWif(wif).toHex())
+        await copySecretToClipboard(PrivateKey.fromWif(wif).toHex())
       }
+      showToast(t('clipboard_will_clear'), { type: 'success' })
       setCopiedMnemonic(true)
       setTimeout(() => setCopiedMnemonic(false), 2000)
     } catch (error) {

--- a/context/LocalStorageProvider.tsx
+++ b/context/LocalStorageProvider.tsx
@@ -1,19 +1,10 @@
-import React, { createContext, useCallback, useContext, useMemo, useRef } from 'react'
+import React, { createContext, useCallback, useContext, useMemo } from 'react'
 import * as SecureStore from 'expo-secure-store'
-import * as LocalAuthentication from 'expo-local-authentication'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import i18n from '@/context/i18n/translations'
 
 export interface LocalStorageContextType {
-  /* non-secure */
-  setSnap: (snap: number[]) => Promise<void>
-  getSnap: () => Promise<number[] | null>
-  deleteSnap: () => Promise<void>
-
   /* secure */
-  setPassword: (password: string) => Promise<boolean>
-  getPassword: () => Promise<string | null>
-  deletePassword: () => Promise<void>
   setMnemonic: (mnemonic: string) => Promise<boolean>
   getMnemonic: () => Promise<string | null>
   deleteMnemonic: () => Promise<void>
@@ -27,22 +18,43 @@ export interface LocalStorageContextType {
   deleteItem: (item: string) => Promise<void>
 }
 
-const SNAP_KEY = 'snap'
-const PASSWORD_KEY = 'password'
 const MNEMONIC_KEY = 'mnemonic'
 const RECOVERED_KEY = 'recoveredKey'
-const HAS_WALLET_KEYS = 'hasWalletKeys'
+// Fast-path hint (plaintext AsyncStorage): "a wallet secret was stored". Lets us
+// avoid a pointless biometric prompt when there is genuinely no wallet, and lets
+// callers tell "no wallet" apart from "wallet exists but its key is unreadable".
+export const HAS_WALLET_KEYS = 'hasWalletKeys'
+
+// Dedicated keychain service for the auth-bound secrets. This MUST stay
+// separate from the app's non-authenticated SecureStore usage (e.g. the
+// WalletConnect sequence counters): expo-secure-store cannot mix authenticated
+// and unauthenticated items under the same keychainService.
+const SECURE_KEYCHAIN_SERVICE = 'bsv-wallet-secure'
+
+// Auth is enforced by the OS and bound to the keychain item via
+// requireAuthentication — Face ID / Touch ID / device credential fires on every
+// read, not a JS-side check a debugger or direct getItemAsync could skip. The
+// library is patched (patches/expo-secure-store) so the item uses biometryAny /
+// setInvalidatedByBiometricEnrollment(false) and survives biometric enrollment
+// changes instead of being wiped.
+const SECURE_WRITE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainService: SECURE_KEYCHAIN_SERVICE,
+  requireAuthentication: true,
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY
+}
+
+const secureReadOptions = (): SecureStore.SecureStoreOptions => ({
+  keychainService: SECURE_KEYCHAIN_SERVICE,
+  requireAuthentication: true,
+  authenticationPrompt: i18n.t('biometric_load_wallet')
+})
+
+const SECURE_DELETE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainService: SECURE_KEYCHAIN_SERVICE
+}
 
 export const LocalStorageContext = createContext<LocalStorageContextType>({
-  /* non-secure */
-  setSnap: async () => {},
-  getSnap: async () => null,
-  deleteSnap: async () => {},
-
   /* secure */
-  setPassword: async () => false,
-  getPassword: async () => null,
-  deletePassword: async () => {},
   setMnemonic: async () => false,
   getMnemonic: async () => null,
   deleteMnemonic: async () => {},
@@ -50,6 +62,7 @@ export const LocalStorageContext = createContext<LocalStorageContextType>({
   getRecoveredKey: async () => null,
   deleteRecoveredKey: async () => {},
 
+  /* general */
   getItem: AsyncStorage.getItem,
   setItem: AsyncStorage.setItem,
   deleteItem: AsyncStorage.removeItem
@@ -58,201 +71,71 @@ export const LocalStorageContext = createContext<LocalStorageContextType>({
 export const useLocalStorage = () => useContext(LocalStorageContext)
 
 export default function LocalStorageProvider({ children }: { children: React.ReactNode }) {
-  /* --------------------------------- SECURE -------------------------------- */
-
-  // keep "am I already biometrically unlocked?" in memory for this session
-  const authenticatedRef = useRef(false)
-  const authInProgress = useRef<Promise<boolean> | null>(null)
-
-  const ensureAuth = useCallback(async (promptMessage: string): Promise<boolean> => {
-    // If we already asked this frame, reuse the same promise so we don't show
-    // the Face ID modal twice in parallel.
-    if (authInProgress.current) return authInProgress.current
-
-    const doAuth = async () => {
-      // Use ref so the check is always up-to-date, even before React re-renders.
-      if (authenticatedRef.current) return true
-
-      const { success } = await LocalAuthentication.authenticateAsync({
-        promptMessage,
-        cancelLabel: 'Cancel',
-        disableDeviceFallback: false
-      })
-
-      authenticatedRef.current = success
-      authInProgress.current = null // reset latch
-      return success
-    }
-
-    authInProgress.current = doAuth()
-    return authInProgress.current
-  }, [])
-
-  /* ------------------------------- non-secure ------------------------------ */
-
-  const setSnap = useCallback(async (snap: number[]): Promise<void> => {
-    try {
-      const snapAsJSON = typeof snap === 'string' ? snap : JSON.stringify(snap)
-      await AsyncStorage.setItem(SNAP_KEY, snapAsJSON)
-    } catch (err) {
-      console.warn('[setSnap]', err)
-    }
-  }, [])
-
-  const getSnap = useCallback(async (): Promise<number[] | null> => {
-    try {
-      const raw = await AsyncStorage.getItem(SNAP_KEY)
-      return raw ? (JSON.parse(raw) as number[]) : null
-    } catch (err) {
-      console.warn('[getSnap]', err)
-      return null
-    }
-  }, [])
-
-  const deleteSnap = useCallback(async (): Promise<void> => {
-    try {
-      await AsyncStorage.removeItem(SNAP_KEY)
-    } catch (err) {
-      console.warn('[deleteSnap]', err)
-    }
-  }, [])
-
   /* -------------------------------- secure --------------------------------- */
 
-  const setMnemonic = useCallback(
-    async (mnemonic: string): Promise<boolean> => {
-      try {
-        if (!(await ensureAuth(i18n.t('biometric_store_wallet')))) return false
-        await SecureStore.setItemAsync(MNEMONIC_KEY, mnemonic, {
-          keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
-        })
-        await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
-        return true
-      } catch (err) {
-        console.warn('[setMnemonic]', err)
-        return false
-      }
-    },
-    [ensureAuth]
-  )
+  const setMnemonic = useCallback(async (mnemonic: string): Promise<boolean> => {
+    try {
+      await SecureStore.setItemAsync(MNEMONIC_KEY, mnemonic, SECURE_WRITE_OPTIONS)
+      await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
+      return true
+    } catch (err) {
+      console.warn('[setMnemonic]', err)
+      return false
+    }
+  }, [])
 
   const getMnemonic = useCallback(async (): Promise<string | null> => {
-    try {
-      const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
-      if (!hasKeys) return null
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return null
-      return await SecureStore.getItemAsync(MNEMONIC_KEY)
-    } catch (err) {
-      console.warn('[getMnemonic]', err)
-      return null
-    }
-  }, [ensureAuth])
+    // Fast path: never trigger a biometric prompt when there is genuinely no
+    // wallet. Absence/invalidation resolves to null; an auth cancel rejects and
+    // is allowed to propagate so callers can keep the wallet locked and retry
+    // rather than mistaking a cancel for "no wallet".
+    const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
+    if (!hasKeys) return null
+    return await SecureStore.getItemAsync(MNEMONIC_KEY, secureReadOptions())
+  }, [])
 
   const deleteMnemonic = useCallback(async (): Promise<void> => {
     try {
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return
-      await SecureStore.deleteItemAsync(MNEMONIC_KEY)
+      await SecureStore.deleteItemAsync(MNEMONIC_KEY, SECURE_DELETE_OPTIONS)
       await AsyncStorage.removeItem(HAS_WALLET_KEYS)
     } catch (err) {
       console.warn('[deleteMnemonic]', err)
     }
-  }, [ensureAuth])
-
-  /* -------------------------------- secure --------------------------------- */
-
-  const setPassword = useCallback(
-    async (password: string): Promise<boolean> => {
-      try {
-        if (!(await ensureAuth(i18n.t('biometric_store_wallet')))) return false
-        await SecureStore.setItemAsync(PASSWORD_KEY, password, {
-          keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
-        })
-        await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
-        return true
-      } catch (err) {
-        console.warn('[setPassword]', err)
-        return false
-      }
-    },
-    [ensureAuth]
-  )
-
-  const getPassword = useCallback(async (): Promise<string | null> => {
-    try {
-      const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
-      if (!hasKeys) return null
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return null
-      return await SecureStore.getItemAsync(PASSWORD_KEY)
-    } catch (err) {
-      console.warn('[getPassword]', err)
-      return null
-    }
-  }, [ensureAuth])
-
-  const deletePassword = useCallback(async (): Promise<void> => {
-    try {
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return
-      await SecureStore.deleteItemAsync(PASSWORD_KEY)
-      await AsyncStorage.removeItem(HAS_WALLET_KEYS)
-    } catch (err) {
-      console.warn('[deletePassword]', err)
-    }
-  }, [ensureAuth])
+  }, [])
 
   /* ----------------------------- recovered key ------------------------------ */
 
-  const setRecoveredKey = useCallback(
-    async (wif: string): Promise<boolean> => {
-      try {
-        if (!(await ensureAuth(i18n.t('biometric_store_wallet')))) return false
-        await SecureStore.setItemAsync(RECOVERED_KEY, wif, {
-          keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
-        })
-        await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
-        return true
-      } catch (err) {
-        console.warn('[setRecoveredKey]', err)
-        return false
-      }
-    },
-    [ensureAuth]
-  )
+  const setRecoveredKey = useCallback(async (wif: string): Promise<boolean> => {
+    try {
+      await SecureStore.setItemAsync(RECOVERED_KEY, wif, SECURE_WRITE_OPTIONS)
+      await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
+      return true
+    } catch (err) {
+      console.warn('[setRecoveredKey]', err)
+      return false
+    }
+  }, [])
 
   const getRecoveredKey = useCallback(async (): Promise<string | null> => {
-    try {
-      const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
-      if (!hasKeys) return null
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return null
-      return await SecureStore.getItemAsync(RECOVERED_KEY)
-    } catch (err) {
-      console.warn('[getRecoveredKey]', err)
-      return null
-    }
-  }, [ensureAuth])
+    const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
+    if (!hasKeys) return null
+    return await SecureStore.getItemAsync(RECOVERED_KEY, secureReadOptions())
+  }, [])
 
   const deleteRecoveredKey = useCallback(async (): Promise<void> => {
     try {
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return
-      await SecureStore.deleteItemAsync(RECOVERED_KEY)
+      await SecureStore.deleteItemAsync(RECOVERED_KEY, SECURE_DELETE_OPTIONS)
       await AsyncStorage.removeItem(HAS_WALLET_KEYS)
     } catch (err) {
       console.warn('[deleteRecoveredKey]', err)
     }
-  }, [ensureAuth])
+  }, [])
 
   /* -------------------------------- output --------------------------------- */
 
   const value: LocalStorageContextType = useMemo(
     () => ({
-      /* non-secure */
-      setSnap,
-      getSnap,
-      deleteSnap,
-
       /* secure */
-      setPassword,
-      getPassword,
-      deletePassword,
       setMnemonic,
       getMnemonic,
       deleteMnemonic,
@@ -265,20 +148,7 @@ export default function LocalStorageProvider({ children }: { children: React.Rea
       setItem: AsyncStorage.setItem,
       deleteItem: AsyncStorage.removeItem
     }),
-    [
-      setSnap,
-      getSnap,
-      deleteSnap,
-      setPassword,
-      getPassword,
-      deletePassword,
-      setMnemonic,
-      getMnemonic,
-      deleteMnemonic,
-      setRecoveredKey,
-      getRecoveredKey,
-      deleteRecoveredKey
-    ]
+    [setMnemonic, getMnemonic, deleteMnemonic, setRecoveredKey, getRecoveredKey, deleteRecoveredKey]
   )
 
   return <LocalStorageContext.Provider value={value}>{children}</LocalStorageContext.Provider>

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -41,7 +41,7 @@ import { DEFAULT_STORAGE_URL, DEFAULT_CHAIN, ADMIN_ORIGINATOR, toWalletChain } f
 import { DEFAULT_AUTO_APPROVE_THRESHOLD, AUTO_APPROVE_COOLDOWN_MS, AUTO_APPROVE_STORAGE_KEY } from '@/shared/constants'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { UserContext } from './UserContext'
-import { useLocalStorage } from '@/context/LocalStorageProvider'
+import { useLocalStorage, HAS_WALLET_KEYS } from '@/context/LocalStorageProvider'
 import { usePermissionQueue } from '@/hooks/usePermissionQueue'
 import { createServices } from '@/services/walletServiceConfig'
 import { configureNewHeaderPolling } from '@/utils/walletMonitor'
@@ -350,8 +350,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
   }, [])
 
   const {
-    getSnap,
-    deleteSnap,
     getItem,
     setItem,
     setMnemonic,
@@ -560,6 +558,10 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
   const [configStatus, setConfigStatus] = useState<ConfigStatus>('initial')
   // Used to trigger a re-render after snapshot load completes.
   const [snapshotLoaded, setSnapshotLoaded] = useState<boolean>(false)
+  // Set when a wallet secret was stored but is no longer readable from the
+  // keychain (e.g. invalidated). Drives a redirect to the re-import flow so the
+  // user can restore from their recovery phrase instead of getting stuck.
+  const [walletNeedsRecovery, setWalletNeedsRecovery] = useState<boolean>(false)
 
   const finalizeConfig = useCallback((wabConfig: WABConfig): boolean => {
     const { method, network, storageUrl } = wabConfig
@@ -977,18 +979,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
     ]
   )
 
-  // Watch for wallet authentication state
-  useEffect(() => {
-    ;(async () => {
-      const snap = await getSnap()
-      if (managers?.walletManager?.authenticated && snap) {
-        setSnapshotLoaded(true)
-      } else if (!snap && snapshotLoaded) {
-        setSnapshotLoaded(false)
-      }
-    })()
-  }, [managers?.walletManager?.authenticated, snapshotLoaded, getSnap])
-
   // TODO: Re-add WAB (WalletAuthenticationManager) support in future version
 
   const buildWalletFromMnemonic = useCallback(
@@ -1015,6 +1005,9 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         const mnemonic = providedMnemonic || (await getMnemonic())
         if (__DEV__) console.warn(`[perf] getMnemonic (auth/keychain): ${(performance.now() - __tMnemonicStart).toFixed(0)}ms`)
         if (!mnemonic) {
+          // No mnemonic available. Whether this means "no wallet" or "wallet
+          // exists but its key is currently unreadable" is decided by the
+          // auto-build effect once the recovered-key fallback is also exhausted.
           walletBuildingRef.current = false
           setWalletBuilding(false)
           return
@@ -1029,9 +1022,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         const privilegedKeyManager = new PrivilegedKeyManager(async () => rootKey)
 
         // Create SimpleWalletManager and provide keys for authentication
-        const snap = await getSnap()
-
-        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet, snap || undefined)
+        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet)
 
         // Provide the primary key and privileged key manager to authenticate the wallet
         await swm.providePrimaryKey(primaryKey)
@@ -1043,10 +1034,17 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
           walletManager: swm
         }))
         setWalletBuilt(true)
+        setWalletNeedsRecovery(false)
         walletBuildingRef.current = false
         setWalletBuilding(false)
 
-        await setMnemonic(mnemonic)
+        // Only re-persist when a NEW mnemonic was supplied (create/import). On a
+        // cold-start build the mnemonic was just read from the keychain, so
+        // writing it back would fire a second biometric prompt on iOS (an
+        // update, unlike a create, prompts).
+        if (providedMnemonic) {
+          await setMnemonic(mnemonic)
+        }
         logWithTimestamp(F, 'Mnemonic wallet build completed')
       } catch (error: any) {
         walletBuildingRef.current = false
@@ -1054,7 +1052,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         console.error('[WalletContext] Error building mnemonic wallet:', error)
       }
     },
-    [walletBuilt, configStatus, getMnemonic, getSnap, setMnemonic, buildWallet]
+    [walletBuilt, configStatus, getMnemonic, setMnemonic, buildWallet]
   )
 
   // Build wallet from a recovered PrivateKey (WIF) obtained via backup share scanning
@@ -1074,8 +1072,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         // Use the recovered primary key as both the signing key and the privileged key
         const privilegedKeyManager = new PrivilegedKeyManager(async () => recoveredKey)
 
-        const snap = await getSnap()
-        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet, snap || undefined)
+        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet)
 
         await swm.providePrimaryKey(primaryKey)
 
@@ -1086,6 +1083,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
           walletManager: swm
         }))
         setWalletBuilt(true)
+        setWalletNeedsRecovery(false)
         walletBuildingRef.current = false
         setWalletBuilding(false)
 
@@ -1097,7 +1095,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         console.error('[WalletContext] Error building wallet from recovered key:', error)
       }
     },
-    [walletBuilt, configStatus, getSnap, setRecoveredKey, buildWallet]
+    [walletBuilt, configStatus, setRecoveredKey, buildWallet]
   )
 
   // Tear down the current wallet and re-trigger auto-build.
@@ -1130,6 +1128,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
     walletBuildingRef.current = false
     setWalletBuilding(false)
     setSnapshotLoaded(false)
+    setWalletNeedsRecovery(false)
 
     // Re-finalize with current config — triggers auto-build effect
     const config = { wabUrl: 'noWAB', method: 'mnemonic', network: selectedNetwork, storageUrl: 'local' }
@@ -1167,6 +1166,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
       walletBuildingRef.current = false
       setWalletBuilding(false)
       setSnapshotLoaded(false)
+      setWalletNeedsRecovery(false)
 
       // Persist new config
       const newConfig = { wabUrl: 'noWAB', method: 'mnemonic', network, storageUrl: 'local' }
@@ -1201,12 +1201,25 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         if (recoveredWif) {
           await buildWalletFromRecoveredKey(recoveredWif)
         } else {
-          // No mnemonic and no recovered key — genuinely no wallet to build
+          // Neither key source produced a value. If a wallet secret was
+          // previously stored (flag set) but is now unreadable — e.g. keychain
+          // invalidated — the user must re-import their phrase rather than land
+          // in a silently broken state. Otherwise there is genuinely no wallet.
+          const hadWallet = (await getItem(HAS_WALLET_KEYS)) === 'true'
+          if (hadWallet) setWalletNeedsRecovery(true)
           setWalletBuilding(false)
         }
       }
     })()
-  }, [configStatus, walletBuilt, buildWalletFromMnemonic, buildWalletFromRecoveredKey, getRecoveredKey])
+  }, [configStatus, walletBuilt, buildWalletFromMnemonic, buildWalletFromRecoveredKey, getRecoveredKey, getItem])
+
+  // A stored wallet is no longer readable (e.g. keychain invalidated) — send the
+  // user to the recovery-phrase re-import flow rather than leaving them stuck.
+  useEffect(() => {
+    if (walletNeedsRecovery) {
+      router.replace('/auth/mnemonic')
+    }
+  }, [walletNeedsRecovery])
 
   // Settings are AsyncStorage-only — no on-chain sync needed
 
@@ -1241,20 +1254,19 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
 
   const logout = useCallback(() => {
     logWithTimestamp(F, 'Logout')
-    deleteSnap().then(async () => {
-      setManagers({})
-      setConfigStatus('initial')
-      setSnapshotLoaded(false)
-      setWalletBuilt(false)
-      walletBuildingRef.current = false
-      setWalletBuilding(false)
-      deleteMnemonic()
-      deleteRecoveredKey()
+    setManagers({})
+    setConfigStatus('initial')
+    setSnapshotLoaded(false)
+    setWalletBuilt(false)
+    setWalletNeedsRecovery(false)
+    walletBuildingRef.current = false
+    setWalletBuilding(false)
+    deleteMnemonic()
+    deleteRecoveredKey()
 
-      router.dismissAll()
-      router.push('/')
-    })
-  }, [deleteSnap, deleteMnemonic, deleteRecoveredKey])
+    router.dismissAll()
+    router.push('/')
+  }, [deleteMnemonic, deleteRecoveredKey])
 
   const refreshProof = useCallback(async (txid: string): Promise<void> => {
     if (!storage) throw new Error('Storage not available')

--- a/context/i18n/translations.tsx
+++ b/context/i18n/translations.tsx
@@ -327,6 +327,7 @@ const resources = {
       // Biometric prompts
       biometric_store_wallet: 'Securely Store Your Wallet',
       biometric_load_wallet: 'Securely Load Your Wallet',
+      clipboard_will_clear: 'Copied — clipboard clears in 60s',
 
       // Connections screen
       connections: 'Connections',

--- a/patches/expo-secure-store+55.0.14.patch
+++ b/patches/expo-secure-store+55.0.14.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt b/node_modules/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt
+index 3a12dc9..912649f 100644
+--- a/node_modules/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt
++++ b/node_modules/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt
+@@ -61,6 +61,15 @@ class AESEncryptor : KeyBasedEncryptor<KeyStore.SecretKeyEntry> {
+       .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+       .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+       .setUserAuthenticationRequired(options.requireAuthentication)
++      // Keep the key usable after the user adds/changes a biometric instead of
++      // wiping it (the Android default). The stored secret is a convenience
++      // cache over the user's recovery phrase; enrolling a fingerprint must not
++      // destroy wallet access. Requires API 24+ (Expo minSdk is 24).
++      .apply {
++        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
++          setInvalidatedByBiometricEnrollment(false)
++        }
++      }
+       .build()
+ 
+     val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, keyStore.provider)
+diff --git a/node_modules/expo-secure-store/ios/SecureStoreModule.swift b/node_modules/expo-secure-store/ios/SecureStoreModule.swift
+index 584df21..d90eca2 100644
+--- a/node_modules/expo-secure-store/ios/SecureStoreModule.swift
++++ b/node_modules/expo-secure-store/ios/SecureStoreModule.swift
+@@ -102,7 +102,7 @@ public final class SecureStoreModule: Module {
+       }
+ 
+       var error: Unmanaged<CFError>? = nil
+-      guard let accessOptions = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibility, .biometryCurrentSet, &error) else {
++      guard let accessOptions = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibility, .biometryAny, &error) else {
+         let errorCode = error.map { CFErrorGetCode($0.takeRetainedValue()) }
+         throw SecAccessControlError(errorCode)
+       }

--- a/utils/mnemonicWallet.ts
+++ b/utils/mnemonicWallet.ts
@@ -90,9 +90,9 @@ export function validateMnemonic(mnemonic: string): boolean {
  * @param strength Entropy bits: 128 (12 words), 160 (15 words), 192 (18 words), 224 (21 words), 256 (24 words)
  */
 export function generateRandomMnemonic(strength: 128 | 160 | 192 | 224 | 256 = 128): string {
-  // For now, @bsv/sdk Mnemonic.fromRandom() generates 128 bits (12 words)
-  // If you need different strengths, you may need to generate entropy manually
-  const mnemonic = Mnemonic.fromRandom()
+  // Mnemonic.fromRandom(bits) honors the requested entropy (128 → 12 words,
+  // 256 → 24 words, etc.).
+  const mnemonic = Mnemonic.fromRandom(strength)
   return mnemonic.toString()
 }
 
@@ -156,25 +156,4 @@ export function parseMnemonic(mnemonic: string): MnemonicValidationResult {
  */
 export function formatMnemonicForDisplay(mnemonic: string): string[] {
   return mnemonic.trim().split(/\s+/)
-}
-
-/**
- * Helper to securely store mnemonic (should be encrypted in production)
- * Returns base64 encoded mnemonic
- */
-export function encodeMnemonicForStorage(mnemonic: string): string {
-  // In production, this should encrypt the mnemonic
-  // For now, just base64 encode
-  return btoa(mnemonic)
-}
-
-/**
- * Helper to retrieve stored mnemonic
- */
-export function decodeMnemonicFromStorage(encoded: string): string {
-  try {
-    return atob(encoded)
-  } catch {
-    throw new Error('Failed to decode stored mnemonic')
-  }
 }

--- a/utils/secureClipboard.ts
+++ b/utils/secureClipboard.ts
@@ -1,0 +1,33 @@
+import * as Clipboard from 'expo-clipboard'
+
+export const DEFAULT_CLIPBOARD_CLEAR_MS = 60_000
+
+export interface CopySecretOptions {
+  /** How long the secret is allowed to sit on the clipboard before it is wiped. */
+  clearAfterMs?: number
+}
+
+/**
+ * Copy a secret (recovery phrase / private key) to the clipboard and schedule an
+ * automatic clear so it does not linger indefinitely. The clear only fires if
+ * the clipboard STILL holds our secret — if the user copied something else in
+ * the meantime we leave their clipboard alone.
+ */
+export async function copySecretToClipboard(
+  secret: string,
+  options: CopySecretOptions = {}
+): Promise<void> {
+  const { clearAfterMs = DEFAULT_CLIPBOARD_CLEAR_MS } = options
+  await Clipboard.setStringAsync(secret)
+
+  setTimeout(async () => {
+    try {
+      const current = await Clipboard.getStringAsync()
+      if (current === secret) {
+        await Clipboard.setStringAsync('')
+      }
+    } catch {
+      // Best-effort hygiene; a failed read/clear must not crash anything.
+    }
+  }, clearAfterMs)
+}


### PR DESCRIPTION
## Problem

The BIP39 mnemonic and recovered WIF key were stored in `expo-secure-store`, but the biometric gate was **JS-only**:

- **`requireAuthentication` was never set** — the Face ID check ran in JavaScript *before* a plain `getItemAsync`. On a jailbroken/rooted/imaged device the item was readable after first unlock with **no** biometry, and any direct `getItemAsync` bypassed the gate.
- **The in-JS auth latch never reset** — after one unlock, every later reveal (copy/print) returned the secret with **no prompt** for the whole app-process lifetime.
- The raw recovery phrase was copied to the clipboard with no expiry; dead `password`/WAB and plaintext-snapshot code widened the surface.

## Changes

- **OS-enforced auth bound to the item** — `requireAuthentication: true` + `authenticationPrompt` on a dedicated `keychainService` (`bsv-wallet-secure`, isolated from the non-auth WalletConnect counters). The JS gate (`ensureAuth`/`authenticatedRef`/`expo-local-authentication`) is **deleted** — the OS now prompts exactly when a secret is read: once on cold-start build, **every** reveal. Cancel propagates; invalidated/absent returns `null`.
- **Durable across biometric changes** — `patches/expo-secure-store+55.0.14.patch`: iOS `biometryAny`, Android `setInvalidatedByBiometricEnrollment(false)`. Stock behaviour wipes the key when the user adds/changes a biometric; the keychain is a convenience cache over the user's written phrase, so a new fingerprint must not destroy wallet access. A present-but-unreadable key routes to the re-import flow.
- **No double-prompt** — the cold-start re-persist is guarded to provided-mnemonic-only (iOS prompts on update, not create).
- **Clipboard hygiene** — `utils/secureClipboard.ts` auto-clears 60s after copying a secret, only if the clipboard still holds our value.
- **Cleanup** — `generateRandomMnemonic` now honors its `strength` arg; removed unused base64 encode/decode helpers and dead `password`/snapshot code.

## Prompt cadence (no usability regression)

| Flow | Before | After |
|---|---|---|
| Cold start (returning) | 1 prompt | 1 prompt |
| Onboarding | 1 prompt | 1 prompt |
| Background → resume | none | none |
| **Reveal phrase** | **silent (vuln)** | **1 prompt every time (fix)** |

## Verification

- Full Jest suite green (57/57; new suites for the provider contract, clipboard hygiene, mnemonic entropy — TDD).
- `tsc` clean on touched files; ESLint 0 errors; patch applies cleanly on fresh install.

### Requires on-device verification (Jest can't cover native biometry)
1. Cold start → one Face ID during build; cancel keeps wallet locked + retry works.
2. Background/resume → no new prompt.
3. Reveal phrase → prompt every time.
4. Clipboard clears after 60s; not clobbered if you copy something else first.
5. **Enroll a new fingerprint / re-add Face ID on both iOS and Android → phrase still readable** (the patch's whole point).

## Note
`expo-local-authentication` is now unused but left in `package.json` to avoid churning the lockfile/prebuild — optional follow-up cleanup.