### PR TITLE
fix: preserve BRC-100 bytes across the WebView bridge

### DIFF
--- a/__tests__/walletByteJson.test.ts
+++ b/__tests__/walletByteJson.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { normalizeWalletByteFields, stringifyWalletPayload } from '../utils/webview/walletByteJson'
+
+const mangled = (bytes: number[]) => JSON.parse(JSON.stringify(new Uint8Array(bytes)))
+
+describe('WebView wallet byte JSON compatibility', () => {
+  it('keeps both directions of the CWI bridge on the compatibility boundary', () => {
+    // Outbound now flows through buildWalletResponseScript (the master refactor
+    // that replaced getInjectableJSMessage); inbound stays at the parse site.
+    const index = readFileSync(resolve(process.cwd(), 'app/index.tsx'), 'utf8')
+    const response = readFileSync(resolve(process.cwd(), 'utils/webview/walletResponseScript.ts'), 'utf8')
+
+    expect(response).toContain('const messageString = stringifyWalletPayload(message)')
+    expect(index).toContain('msg = normalizeWalletByteFields(JSON.parse(eventData))')
+  })
+
+  it('keeps valid number arrays on the identity fast path', () => {
+    const tx = [1, 2, 3]
+    const payload = { tx }
+
+    expect(normalizeWalletByteFields(payload)).toBe(payload)
+    expect(payload.tx).toBe(tx)
+  })
+
+  it('serializes nested typed arrays and subclasses as portable arrays', () => {
+    class ForeignBytes extends Uint8Array {}
+    const json = stringifyWalletPayload({
+      signableTransaction: { tx: new ForeignBytes([1, 2, 3]) },
+      encrypted: new Uint8Array([4, 5])
+    })
+
+    expect(JSON.parse(json)).toEqual({
+      signableTransaction: { tx: [1, 2, 3] },
+      encrypted: [4, 5]
+    })
+  })
+
+  it('repairs historical numeric-key arguments recursively', () => {
+    const payload = {
+      inputBEEF: mangled([1, 2]),
+      nested: { transaction: mangled([3, 4]) }
+    }
+
+    expect(normalizeWalletByteFields(payload)).toEqual({
+      inputBEEF: [1, 2],
+      nested: { transaction: [3, 4] }
+    })
+  })
+
+  it('repairs historical numeric-key wallet results while serializing', () => {
+    expect(JSON.parse(stringifyWalletPayload({ tx: mangled([5, 6]) }))).toEqual({
+      tx: [5, 6]
+    })
+  })
+
+  it('preserves unrelated numeric records and ambiguous empty containers', () => {
+    const unrelated = mangled([9, 8])
+    const payload = {
+      unrelated,
+      data: {},
+      payload: { transaction: mangled([1, 2, 3]) }
+    }
+
+    expect(normalizeWalletByteFields(payload)).toEqual({
+      unrelated,
+      data: {},
+      payload: { transaction: [1, 2, 3] }
+    })
+  })
+
+  it('leaves malformed byte records intact so validation fails instead of truncating', () => {
+    const malformed = { 0: 1, 2: 3 }
+    const outOfRange = { 0: 256 }
+    const payload = { tx: malformed, signature: outOfRange }
+
+    normalizeWalletByteFields(payload)
+    expect(payload.tx).toBe(malformed)
+    expect(payload.signature).toBe(outOfRange)
+  })
+
+  it('does not mistake other binary views for empty byte arrays', () => {
+    const view = new DataView(new ArrayBuffer(4))
+    const buffer = new ArrayBuffer(4)
+    const payload = { tx: view, signature: buffer }
+
+    normalizeWalletByteFields(payload)
+    expect(payload.tx).toBe(view)
+    expect(payload.signature).toBe(buffer)
+  })
+})

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -61,6 +61,7 @@ import { nativeSpoofSetup, mediaSourcePolyfill } from '@/utils/webview/mediaSour
 import { buildWalletDocumentStartScript } from '@/utils/webview/documentStartScript'
 import { walletFrameIdentityFromUrl } from '@/utils/webview/walletOrigin'
 import { buildWalletResponseScript } from '@/utils/webview/walletResponseScript'
+import { normalizeWalletByteFields } from '@/utils/webview/walletByteJson'
 import { getPaymentHandler } from '@/utils/webview/bsvPaymentHandler'
 import { getErrorPage, getNativeErrorInfo, paymentLoadingPage, navigationLoadingPage, escapeForTemplateLiteral, escapeForJsSingleQuote } from '@/utils/webview/errorPages'
 
@@ -1212,7 +1213,7 @@ const Browser = observer(function Browser() {
       let msg
       const endParse = perf.mark('webview.message.parse')
       try {
-        msg = JSON.parse(eventData)
+        msg = normalizeWalletByteFields(JSON.parse(eventData))
       } catch {
         endParse()
         return

--- a/utils/webview/walletByteJson.ts
+++ b/utils/webview/walletByteJson.ts
@@ -1,0 +1,119 @@
+const byteFieldNames = new Set([
+  'BEEF',
+  'atomicBEEF',
+  'beef',
+  'ciphertext',
+  'competingBeef',
+  'data',
+  'encryptedLinkage',
+  'encryptedLinkageProof',
+  'hashToDirectlySign',
+  'hashToDirectlyVerify',
+  'hmac',
+  'inputBEEF',
+  'payload',
+  'plaintext',
+  'signature',
+  'transaction',
+  'tx'
+])
+
+const ambiguousContainerFieldNames = new Set(['data', 'payload'])
+const hasOwn = Object.prototype.hasOwnProperty
+
+function isByte(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0 && (value as number) <= 255
+}
+
+function isUint8Array(value: unknown): value is Uint8Array {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof ArrayBuffer !== 'undefined' &&
+    ArrayBuffer.isView(value) &&
+    Object.prototype.toString.call(value) === '[object Uint8Array]'
+  )
+}
+
+function isUnsupportedBinaryView(value: unknown): boolean {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof ArrayBuffer !== 'undefined' &&
+    (ArrayBuffer.isView(value) || Object.prototype.toString.call(value) === '[object ArrayBuffer]')
+  )
+}
+
+function normalizeByteArray(value: unknown): number[] | Uint8Array | undefined {
+  if (isUint8Array(value)) return value
+  if (isUnsupportedBinaryView(value)) return undefined
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      if (!hasOwn.call(value, index) || !isByte(value[index])) return undefined
+    }
+    return value
+  }
+  if (value == null || typeof value !== 'object') return undefined
+  try {
+    const keys = Object.keys(value)
+    const bytes = new Array<number>(keys.length)
+    for (let index = 0; index < keys.length; index += 1) {
+      if (keys[index] !== String(index)) return undefined
+      const byte = (value as Record<string, unknown>)[keys[index]]
+      if (!isByte(byte)) return undefined
+      bytes[index] = byte
+    }
+    return bytes
+  } catch {
+    return undefined
+  }
+}
+
+function isAmbiguousEmptyContainer(key: string, value: unknown): boolean {
+  return (
+    ambiguousContainerFieldNames.has(key) &&
+    value != null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    !isUint8Array(value) &&
+    Object.keys(value).length === 0
+  )
+}
+
+export function normalizeWalletByteFields<T>(value: T): T {
+  const seen = new WeakSet<object>()
+  const visit = (candidate: unknown): void => {
+    if (candidate == null || typeof candidate !== 'object' || isUint8Array(candidate)) return
+    if (seen.has(candidate)) return
+    seen.add(candidate)
+    if (Array.isArray(candidate)) {
+      candidate.forEach(visit)
+      return
+    }
+    for (const [key, child] of Object.entries(candidate)) {
+      if (byteFieldNames.has(key)) {
+        const bytes = isAmbiguousEmptyContainer(key, child) ? undefined : normalizeByteArray(child)
+        if (bytes != null) (candidate as Record<string, unknown>)[key] = bytes
+        else visit(child)
+      } else {
+        visit(child)
+      }
+    }
+  }
+  visit(value)
+  return value
+}
+
+export function stringifyWalletPayload(value: unknown): string {
+  const serialized = JSON.stringify(value, function (key, child) {
+    const original = (this as Record<string, unknown>)[key]
+    if (byteFieldNames.has(key)) {
+      const candidate = original ?? child
+      const bytes = isAmbiguousEmptyContainer(key, candidate) ? undefined : normalizeByteArray(candidate)
+      if (bytes != null) return Array.from(bytes)
+    }
+    return isUint8Array(original) ? Array.from(original) : isUint8Array(child) ? Array.from(child) : child
+  })
+  if (serialized === undefined) throw new TypeError('Wallet payload is not JSON serializable')
+  return serialized
+}

--- a/utils/webview/walletResponseScript.ts
+++ b/utils/webview/walletResponseScript.ts
@@ -3,8 +3,13 @@
  * originated the request. Native injection executes in the top document, so a
  * child-frame response must cross back through postMessage.
  */
+import { stringifyWalletPayload } from './walletByteJson'
+
 export function buildWalletResponseScript(message: unknown, responseOrigin?: string): string {
-  const messageString = JSON.stringify(message)
+  // stringifyWalletPayload, not JSON.stringify: wallet results can carry
+  // Uint8Array (and historically numeric-keyed) byte fields, which plain
+  // JSON.stringify mangles into {"0":..} records the page cannot use.
+  const messageString = stringifyWalletPayload(message)
   const responseOriginString = JSON.stringify(responseOrigin ?? null)
   return `
     (function() {


### PR DESCRIPTION
## Summary

- normalize BRC-100 request arguments entering the native wallet from WebView CWI
- serialize wallet results as portable byte arrays before JavaScript injection
- recover historical numeric-key objects without rewriting unrelated application data
- add two-direction recurrence and edge-case tests

## Validation

- focused compatibility tests: 8/8
- full Jest suite: 54 suites, 604/604 tests
- changed-file lint: zero errors, two pre-existing hook warnings in app/index.tsx
- iOS and Android production exports pass

Repository-wide lint still has three pre-existing display-name errors in unrelated browser components. Expo Doctor reports four existing dependency/configuration findings, and root TypeScript checking reaches an unrelated funding-app missing-dev-dependency error. This patch introduces none of those findings. It keeps the current SDK 2.1.x bridge compatible with historical clients and with the shared fix proposed in bsv-blockchain/ts-stack#482.