### PR TITLE
feat(secrets): put the wallet mnemonic behind OS-enforced biometrics

### DIFF
--- a/__tests__/__mocks__/localAuthFake.js
+++ b/__tests__/__mocks__/localAuthFake.js
@@ -1,0 +1,52 @@
+/* global jest */
+/**
+ * Fake expo-local-authentication.
+ *
+ * authenticateAsync throws on purpose. It is not a mistake in the fake: the
+ * scheme's central rule is that a LocalAuthentication prompt authorises nothing
+ * — it builds a throwaway context the keychain never sees — so any code path
+ * that calls it to gate a secret is a bug, and these tests should fail loudly
+ * rather than quietly pass with two prompts.
+ */
+const SecurityLevel = {
+  NONE: 0,
+  SECRET: 1,
+  BIOMETRIC_WEAK: 2,
+  BIOMETRIC_STRONG: 3
+}
+
+const AuthenticationType = {
+  FINGERPRINT: 1,
+  FACIAL_RECOGNITION: 2,
+  IRIS: 3
+}
+
+let level = SecurityLevel.BIOMETRIC_STRONG
+let types = [AuthenticationType.FACIAL_RECOGNITION]
+
+const fake = {
+  SecurityLevel,
+  AuthenticationType,
+  getEnrolledLevelAsync: jest.fn(async () => level),
+  supportedAuthenticationTypesAsync: jest.fn(async () => types),
+  hasHardwareAsync: jest.fn(async () => level > SecurityLevel.SECRET),
+  isEnrolledAsync: jest.fn(async () => level >= SecurityLevel.BIOMETRIC_WEAK),
+  authenticateAsync: jest.fn(async () => {
+    throw new Error('authenticateAsync must never gate a secret — it authorises nothing')
+  }),
+
+  __setLevel(next) {
+    level = next
+  },
+  __setTypes(next) {
+    types = next
+  },
+  __reset() {
+    level = SecurityLevel.BIOMETRIC_STRONG
+    types = [AuthenticationType.FACIAL_RECOGNITION]
+    fake.getEnrolledLevelAsync.mockClear()
+    fake.authenticateAsync.mockClear()
+  }
+}
+
+module.exports = { fake }

--- a/__tests__/__mocks__/secureStoreFake.js
+++ b/__tests__/__mocks__/secureStoreFake.js
@@ -1,0 +1,142 @@
+/* global jest */
+/**
+ * A fake expo-secure-store that models the parts of the real native modules
+ * that this scheme depends on. A naive record<string,string> fake cannot prove
+ * anything here, because the properties under test are all about *how* items
+ * are stored:
+ *
+ *  - entries are keyed by (keychainService, key, authMode), so an
+ *    unauthenticated item can shadow an authenticated one under the same key —
+ *    this is what makes distinct KEK key names load-bearing rather than
+ *    cosmetic;
+ *  - reads probe unauthenticated first, then authenticated, mirroring iOS;
+ *  - authenticated reads AND authenticated writes each cost one prompt, so
+ *    tests can assert exact prompt totals;
+ *  - a biometric-enrolment change makes authenticated reads resolve null
+ *    (never throw), which is how both platforms actually report it;
+ *  - cancellation and lockout reject with the platforms' real message strings.
+ */
+const AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY = 'afudo'
+const WHEN_UNLOCKED_THIS_DEVICE_ONLY = 'wudo'
+
+const state = {
+  entries: new Map(),
+  optionsSeen: [],
+  prompts: 0,
+  outcome: 'ok',
+  invalidated: false,
+  readOverrides: new Map()
+}
+
+const svc = options => (options && options.keychainService) || 'app'
+const mode = options => (options && options.requireAuthentication ? 'auth' : 'noauth')
+const id = (service, key, m) => `${service}|${key}|${m}`
+
+function prompt() {
+  state.prompts++
+  if (state.outcome === 'cancel') {
+    throw new Error('User canceled the operation.')
+  }
+  if (state.outcome === 'lockout') {
+    throw new Error('Could not Authenticate the user: Lockout. Too many attempts.')
+  }
+}
+
+const fake = {
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  WHEN_UNLOCKED: 'wu',
+  AFTER_FIRST_UNLOCK: 'afu',
+
+  getItemAsync: jest.fn(async (key, options) => {
+    const service = svc(options)
+    state.optionsSeen.push({ op: 'get', key, options })
+
+    if (state.readOverrides.has(key)) return state.readOverrides.get(key)
+
+    // Unauthenticated entries win, exactly as iOS's alias probing does.
+    const plain = state.entries.get(id(service, key, 'noauth'))
+    if (plain !== undefined) return plain
+
+    const authed = state.entries.get(id(service, key, 'auth'))
+    if (authed === undefined) return null
+
+    // The OS destroyed the key: reported as a plain null, not an error.
+    if (state.invalidated) return null
+
+    prompt()
+    return authed
+  }),
+
+  setItemAsync: jest.fn(async (key, value, options) => {
+    const service = svc(options)
+    const m = mode(options)
+    state.optionsSeen.push({ op: 'set', key, options })
+
+    if (m === 'auth') {
+      // Minting/using an auth-bound key requires a ceremony on Android.
+      prompt()
+      // Writing re-creates the key, which clears a prior invalidation.
+      state.invalidated = false
+    }
+    state.entries.set(id(service, key, m), value)
+    // The native modules drop the opposite-mode entry on a successful write.
+    state.entries.delete(id(service, key, m === 'auth' ? 'noauth' : 'auth'))
+  }),
+
+  deleteItemAsync: jest.fn(async (key, options) => {
+    const service = svc(options)
+    state.optionsSeen.push({ op: 'delete', key, options })
+    // Deletion never prompts, and clears every alias for the key.
+    state.entries.delete(id(service, key, 'auth'))
+    state.entries.delete(id(service, key, 'noauth'))
+  }),
+
+  /* ------------------------------ test surface ----------------------------- */
+
+  __reset() {
+    state.entries.clear()
+    state.readOverrides.clear()
+    state.optionsSeen = []
+    state.prompts = 0
+    state.outcome = 'ok'
+    state.invalidated = false
+    fake.getItemAsync.mockClear()
+    fake.setItemAsync.mockClear()
+    fake.deleteItemAsync.mockClear()
+  },
+  /** Force a key's read to return a fixed value, e.g. to simulate a blob
+   * that came back corrupted from storage. */
+  __overrideRead(key, value) {
+    state.readOverrides.set(key, value)
+  },
+  __prompts: () => state.prompts,
+  /** Zero the counter without touching stored entries, so a test can set up an
+   * install and then measure only what a subsequent cold start costs. */
+  __clearPrompts() {
+    state.prompts = 0
+  },
+  __setOutcome(outcome) {
+    state.outcome = outcome
+  },
+  /** Simulates a biometric enrolment change / screen-lock removal. */
+  __invalidateBiometrics() {
+    state.invalidated = true
+  },
+  __seed(key, value, { service = 'app', auth = false } = {}) {
+    state.entries.set(id(service, key, auth ? 'auth' : 'noauth'), value)
+  },
+  __get(key, { service = 'app', auth = false } = {}) {
+    return state.entries.get(id(service, key, auth ? 'auth' : 'noauth'))
+  },
+  __has(key, opts) {
+    return fake.__get(key, opts) !== undefined
+  },
+  __keys: () => [...state.entries.keys()],
+  __optionsFor(op, key) {
+    return state.optionsSeen.filter(o => o.op === op && o.key === key).map(o => o.options)
+  },
+  __ops: () => state.optionsSeen.map(o => `${o.op}:${o.key}`)
+}
+
+module.exports = { fake }

--- a/__tests__/secrets/envelope.test.ts
+++ b/__tests__/secrets/envelope.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Envelope crypto — pure, no mocks needed.
+ */
+import { Random, Utils } from '@bsv/sdk'
+import { openSecret, sealSecret, assertKekId, generateKek } from '../../services/secrets/envelope'
+import { EnvelopeError } from '../../services/secrets/types'
+
+const KEK_ID = 'a1b2c3d4e5f60718'
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+describe('secret envelope', () => {
+  it('round-trips ascii, a full mnemonic and multi-byte utf-8', () => {
+    const kek = generateKek()
+    for (const plaintext of [MNEMONIC, 'hello', 'garçon 🔐 çà et là', '한국어 테스트']) {
+      const blob = sealSecret(kek, KEK_ID, 'mnemonic', plaintext)
+      expect(openSecret(kek, 'mnemonic', blob)).toBe(plaintext)
+    }
+  })
+
+  it('produces a fresh salt and ciphertext per seal', () => {
+    const kek = generateKek()
+    const a = sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC)
+    const b = sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC)
+    expect(a.salt).not.toBe(b.salt)
+    expect(a.c).not.toBe(b.c)
+  })
+
+  it('domain-separates by secret name', () => {
+    const kek = generateKek()
+    const blob = sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC)
+    // A blob sealed as one secret must not open as another, even with the
+    // right KEK — this stands in for AAD, which SymmetricKey does not expose.
+    expect(() => openSecret(kek, 'recoveredKey', blob)).toThrow(EnvelopeError)
+    try {
+      openSecret(kek, 'recoveredKey', blob)
+    } catch (e) {
+      expect((e as EnvelopeError).code).toBe('corrupt')
+    }
+  })
+
+  it('fails to open under a different KEK', () => {
+    const blob = sealSecret(generateKek(), KEK_ID, 'mnemonic', MNEMONIC)
+    expect(() => openSecret(generateKek(), 'mnemonic', blob)).toThrow(EnvelopeError)
+  })
+
+  it('reports a stale kekId as kek-mismatch, not corrupt', () => {
+    const kek = generateKek()
+    const blob = sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC)
+    try {
+      assertKekId(blob, 'ffffffffffffffff')
+      throw new Error('expected assertKekId to throw')
+    } catch (e) {
+      expect((e as EnvelopeError).code).toBe('kek-mismatch')
+    }
+  })
+
+  it('rejects an unknown version', () => {
+    const kek = generateKek()
+    const blob = { ...sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC), v: 2 }
+    try {
+      openSecret(kek, 'mnemonic', blob)
+      throw new Error('expected openSecret to throw')
+    } catch (e) {
+      expect((e as EnvelopeError).code).toBe('bad-version')
+    }
+  })
+
+  it('maps tampered ciphertext to corrupt and never leaks a bare crypto Error', () => {
+    const kek = generateKek()
+    const blob = sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC)
+    const flipped = blob.c.slice(0, -1) + (blob.c.endsWith('0') ? '1' : '0')
+    try {
+      openSecret(kek, 'mnemonic', { ...blob, c: flipped })
+      throw new Error('expected openSecret to throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvelopeError)
+      expect((e as EnvelopeError).code).toBe('corrupt')
+      expect((e as Error).message).not.toMatch(/Decryption failed/)
+    }
+  })
+
+  it('rejects a truncated ciphertext rather than throwing from the primitive', () => {
+    const kek = generateKek()
+    const blob = sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC)
+    try {
+      openSecret(kek, 'mnemonic', { ...blob, c: blob.c.slice(0, 40) })
+      throw new Error('expected openSecret to throw')
+    } catch (e) {
+      expect((e as EnvelopeError).code).toBe('corrupt')
+    }
+  })
+
+  it('rejects malformed and non-object blobs', () => {
+    const kek = generateKek()
+    for (const bad of [null, 'nope', {}, { v: 1, kekId: 'x' }]) {
+      expect(() => openSecret(kek, 'mnemonic', bad)).toThrow(EnvelopeError)
+    }
+  })
+
+  it('round-trips a KEK with a leading zero byte', () => {
+    // SymmetricKey extends BigNumber; a KEK whose first byte is zero happens
+    // 1-in-256 of the time and must not lose a byte on re-serialisation.
+    const kek = [0, ...Random(31)]
+    const blob = sealSecret(kek, KEK_ID, 'mnemonic', MNEMONIC)
+    expect(openSecret(kek, 'mnemonic', blob)).toBe(MNEMONIC)
+  })
+
+  it('generates 32-byte keys and 32-byte salts', () => {
+    expect(generateKek()).toHaveLength(32)
+    const blob = sealSecret(generateKek(), KEK_ID, 'mnemonic', 'x')
+    expect(Utils.toArray(blob.salt, 'hex')).toHaveLength(32)
+  })
+})

--- a/__tests__/secrets/kek.test.ts
+++ b/__tests__/secrets/kek.test.ts
@@ -1,0 +1,241 @@
+/**
+ * KEK lifecycle: the prompt-count and never-mint-over-a-sentinel guarantees.
+ *
+ * These are the tests that encode the actual product constraint — one OS
+ * ceremony per process — and the actual security constraint — a missing key is
+ * reported as lost, never replaced with a fresh one.
+ */
+jest.mock('expo-secure-store', () => require('../__mocks__/secureStoreFake').fake)
+jest.mock('expo-local-authentication', () => require('../__mocks__/localAuthFake').fake)
+
+import { fake as secureStore } from '../__mocks__/secureStoreFake'
+import { fake as localAuth } from '../__mocks__/localAuthFake'
+import {
+  __resetForTests,
+  autoUnlockKek,
+  destroyKek,
+  provisionKek,
+  readSentinel,
+  recordSecretName,
+  unlockKek
+} from '../../services/secrets/kek'
+import { KEK_AUTH_KEY, KEK_PLAIN_KEY } from '../../services/secrets/policy'
+
+const KEK_SERVICE = 'bsvb.kek.v1'
+const ENV_SERVICE = 'bsvb.secrets.v1'
+
+/** provisionKek writes a sentinel with no names; a sentinel only counts as a
+ * committed wallet once it names a secret, which is how a half-finished
+ * migration stays invisible. */
+async function provisionWithSecret() {
+  const state = await provisionKek()
+  await recordSecretName('mnemonic')
+  return state
+}
+
+describe('KEK lifecycle', () => {
+  beforeEach(() => {
+    secureStore.__reset()
+    localAuth.__reset()
+    __resetForTests()
+    ;(global as any).__DEV__ = false
+  })
+
+  it('provisions with exactly one ceremony and no read-back', async () => {
+    const state = await provisionKek()
+    expect(state.status).toBe('unlocked')
+    // One authenticated write. Reading back what we just wrote would be a
+    // second prompt on every fresh install.
+    expect(secureStore.__prompts()).toBe(1)
+    expect(secureStore.getItemAsync).not.toHaveBeenCalledWith(KEK_AUTH_KEY, expect.anything())
+    expect(secureStore.__has(KEK_AUTH_KEY, { service: KEK_SERVICE, auth: true })).toBe(true)
+  })
+
+  it('stores the KEK authenticated and the sentinel unauthenticated', async () => {
+    await provisionWithSecret()
+    const [kekOpts] = secureStore.__optionsFor('set', KEK_AUTH_KEY)
+    expect(kekOpts).toMatchObject({ keychainService: KEK_SERVICE, requireAuthentication: true })
+
+    const sentinelOpts = secureStore.__optionsFor('set', 'secretsSentinelV1')
+    expect(sentinelOpts[0]).toMatchObject({
+      keychainService: ENV_SERVICE,
+      requireAuthentication: false
+    })
+  })
+
+  it('unlocks once per process no matter how many callers ask', async () => {
+    await provisionWithSecret()
+    __resetForTests() // simulate a fresh process with storage intact
+    secureStore.__clearPrompts() // count only what the cold start costs
+
+    const first = await unlockKek()
+    expect(first.status).toBe('unlocked')
+    for (let i = 0; i < 5; i++) await unlockKek()
+
+    expect(secureStore.__prompts()).toBe(1)
+  })
+
+  it('single-flights concurrent unlocks', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    secureStore.__clearPrompts()
+
+    // Android throws outright if a second prompt is requested while one is up.
+    const results = await Promise.all([unlockKek(), unlockKek(), unlockKek(), unlockKek()])
+    expect(results.every(r => r.status === 'unlocked')).toBe(true)
+    expect(secureStore.__prompts()).toBe(1)
+  })
+
+  it('reports absent without touching SecureStore on a fresh install', async () => {
+    const state = await unlockKek()
+    expect(state.status).toBe('absent')
+    expect(secureStore.getItemAsync).not.toHaveBeenCalledWith(KEK_AUTH_KEY, expect.anything())
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('treats an orphan sentinel with no secrets as absent, so logout does not leave a prompt behind', async () => {
+    await provisionKek() // sentinel written, no names recorded
+    __resetForTests()
+    secureStore.__clearPrompts()
+
+    const state = await unlockKek()
+    expect(state.status).toBe('absent')
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('reports lost — and never mints a replacement — when the OS destroyed the key', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    secureStore.__invalidateBiometrics()
+    secureStore.setItemAsync.mockClear()
+
+    const state = await unlockKek()
+    expect(state.status).toBe('lost')
+    // The single most important negative assertion here: silently re-minting
+    // would strand the user's ciphertexts behind a key nobody can match.
+    expect(secureStore.setItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('distinguishes a cancelled prompt from a lost key', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    secureStore.__setOutcome('cancel')
+    secureStore.setItemAsync.mockClear()
+
+    const state = await unlockKek()
+    expect(state.status).toBe('cancelled')
+    expect(secureStore.setItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('classifies lockout as unavailable', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    secureStore.__setOutcome('lockout')
+
+    const state = await unlockKek()
+    expect(state).toEqual({ status: 'unavailable', reason: 'lockout' })
+  })
+
+  it('auto-unlocks at most once, so a cancellation cannot become a prompt loop', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    secureStore.__setOutcome('cancel')
+
+    expect((await autoUnlockKek()).status).toBe('cancelled')
+    const promptsAfterFirst = secureStore.__prompts()
+    await autoUnlockKek()
+    await autoUnlockKek()
+    expect(secureStore.__prompts()).toBe(promptsAfterFirst)
+  })
+
+  it('ignores an unauthenticated item squatting on the authenticated key name', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    secureStore.__clearPrompts()
+    // An unauthenticated entry squatting on the authenticated key name shadows
+    // the real one on read — which is exactly why the two policies use
+    // different key names rather than the same name with a different flag.
+    secureStore.__seed(KEK_AUTH_KEY, 'de'.repeat(32), { service: KEK_SERVICE, auth: false })
+
+    const state = await unlockKek()
+    expect(state.status).toBe('unlocked')
+    // A biometric install never reads the plain key name at all, so a planted
+    // plain KEK under *that* name is unreachable.
+    expect(secureStore.__optionsFor('get', KEK_PLAIN_KEY)).toHaveLength(0)
+  })
+
+  it('a tampered sentinel yields lost, never an unauthenticated read of the real key', async () => {
+    await provisionWithSecret()
+    const sentinel = await readSentinel()
+    __resetForTests()
+    // Rewrite the sentinel as if the install were degraded. The KEK still only
+    // exists under the authenticated key name, so this buys the attacker a
+    // failed lookup, not a decryption.
+    secureStore.__seed(
+      'secretsSentinelV1',
+      JSON.stringify({ ...sentinel, policy: 'degraded' }),
+      { service: ENV_SERVICE }
+    )
+    secureStore.setItemAsync.mockClear()
+
+    const state = await unlockKek()
+    expect(state.status).toBe('lost')
+    expect(secureStore.setItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('re-wraps a dev-provisioned KEK when a production build finds biometrics', async () => {
+    // A dev build and a release build share a keychain, so a release binary
+    // can legitimately find an unauthenticated KEK left by a dev build.
+    ;(global as any).__DEV__ = true
+    localAuth.__setLevel(localAuth.SecurityLevel.NONE)
+    await provisionWithSecret()
+    expect(secureStore.__has(KEK_PLAIN_KEY, { service: KEK_SERVICE, auth: false })).toBe(true)
+
+    __resetForTests()
+    ;(global as any).__DEV__ = false
+    localAuth.__setLevel(localAuth.SecurityLevel.BIOMETRIC_STRONG)
+
+    const state = await unlockKek()
+    expect(state.status).toBe('unlocked')
+    expect(state).toMatchObject({ policy: 'biometric' })
+    // The plain copy must be gone, not merely ignored.
+    expect(secureStore.__has(KEK_PLAIN_KEY, { service: KEK_SERVICE, auth: false })).toBe(false)
+    expect(secureStore.__has(KEK_AUTH_KEY, { service: KEK_SERVICE, auth: true })).toBe(true)
+    expect((await readSentinel())?.policy).toBe('biometric')
+  })
+
+  it('keeps a degraded install degraded on a device with no biometrics', async () => {
+    localAuth.__setLevel(localAuth.SecurityLevel.SECRET)
+    const state = await provisionWithSecret()
+    expect(state).toMatchObject({ policy: 'degraded' })
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('treats Android weak biometrics as degraded, since the keystore key requires strong', async () => {
+    localAuth.__setLevel(localAuth.SecurityLevel.BIOMETRIC_WEAK)
+    const state = await provisionWithSecret()
+    expect(state).toMatchObject({ policy: 'degraded' })
+  })
+
+  it('destroys the KEK and the sentinel without a ceremony, even while lost', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    secureStore.__invalidateBiometrics()
+    expect((await unlockKek()).status).toBe('lost')
+
+    const before = secureStore.__prompts()
+    await destroyKek()
+    expect(secureStore.__prompts()).toBe(before)
+    expect(await readSentinel()).toBeNull()
+    expect(secureStore.__has(KEK_AUTH_KEY, { service: KEK_SERVICE, auth: true })).toBe(false)
+  })
+
+  it('never authenticates through expo-local-authentication', async () => {
+    await provisionWithSecret()
+    __resetForTests()
+    await unlockKek()
+    // A LocalAuthentication prompt authorises nothing at the OS level; using
+    // one to gate a secret is the exact bug this whole change removes.
+    expect(localAuth.authenticateAsync).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/secrets/migration.test.ts
+++ b/__tests__/secrets/migration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Migration off the legacy plaintext scheme.
+ *
+ * The ordering assertions here are the point: the legacy plaintext must
+ * survive every failure mode, and must only be deleted after the envelope has
+ * been written, read back and decrypted.
+ */
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+)
+jest.mock('expo-secure-store', () => require('../__mocks__/secureStoreFake').fake)
+jest.mock('expo-local-authentication', () => require('../__mocks__/localAuthFake').fake)
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { fake as secureStore } from '../__mocks__/secureStoreFake'
+import { fake as localAuth } from '../__mocks__/localAuthFake'
+import { __resetForTests, readSentinel, unlockKek } from '../../services/secrets/kek'
+import { migrateLegacySecrets } from '../../services/secrets/migration'
+import { getSecret, hasSecret } from '../../services/secrets/store'
+
+const ENV_SERVICE = 'bsvb.secrets.v1'
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const WIF = 'L1uyy5qTuGrVXrmrsvHWHgVzW9kKdrp27wBC7Vs6nZDTF2BRUVwy'
+
+/** Recreate what the pre-envelope provider left on disk. */
+function seedLegacyInstall({ mnemonic = MNEMONIC, recoveredKey = '', password = '' } = {}) {
+  if (mnemonic) secureStore.__seed('mnemonic', mnemonic)
+  if (recoveredKey) secureStore.__seed('recoveredKey', recoveredKey)
+  if (password) secureStore.__seed('password', password)
+  return AsyncStorage.setItem('hasWalletKeys', 'true')
+}
+
+describe('legacy secret migration', () => {
+  beforeEach(async () => {
+    secureStore.__reset()
+    localAuth.__reset()
+    __resetForTests()
+    await AsyncStorage.clear()
+    ;(global as any).__DEV__ = false
+  })
+
+  it('migrates a legacy wallet and removes the plaintext', async () => {
+    await seedLegacyInstall({ recoveredKey: WIF, password: 'hunter2' })
+
+    const result = await migrateLegacySecrets()
+    expect(result).toEqual({ outcome: 'migrated', names: ['mnemonic', 'recoveredKey'] })
+
+    expect(secureStore.__has('mnemonic')).toBe(false)
+    expect(secureStore.__has('recoveredKey')).toBe(false)
+    expect(await AsyncStorage.getItem('hasWalletKeys')).toBeNull()
+    expect(await hasSecret('mnemonic')).toBe(true)
+    expect(await getSecret('mnemonic')).toBe(MNEMONIC)
+    expect(await getSecret('recoveredKey')).toBe(WIF)
+  })
+
+  it('deletes the legacy password without ever sealing it', async () => {
+    await seedLegacyInstall({ password: 'hunter2' })
+    await migrateLegacySecrets()
+
+    expect(secureStore.__has('password')).toBe(false)
+    expect(secureStore.__has('envV1.password', { service: ENV_SERVICE })).toBe(false)
+    expect((await readSentinel())?.names).toEqual(['mnemonic'])
+  })
+
+  it('verifies the envelope before it deletes anything', async () => {
+    await seedLegacyInstall()
+    await migrateLegacySecrets()
+
+    const ops = secureStore.__ops()
+    const wroteBlob = ops.indexOf('set:envV1.mnemonic')
+    const readBack = ops.indexOf('get:envV1.mnemonic')
+    const wroteSentinel = ops.lastIndexOf('set:secretsSentinelV1')
+    const deletedLegacy = ops.indexOf('delete:mnemonic')
+
+    expect(wroteBlob).toBeGreaterThanOrEqual(0)
+    expect(readBack).toBeGreaterThan(wroteBlob)
+    expect(wroteSentinel).toBeGreaterThan(readBack)
+    expect(deletedLegacy).toBeGreaterThan(wroteSentinel)
+  })
+
+  it('keeps the plaintext and writes no sentinel when verification fails', async () => {
+    await seedLegacyInstall()
+    // Corrupt only the verification read-back, as a storage-layer bug would.
+    secureStore.__overrideRead(
+      'envV1.mnemonic',
+      JSON.stringify({ v: 1, kekId: 'x', salt: 'aa', c: 'bb' })
+    )
+
+    const result = await migrateLegacySecrets()
+
+    expect(result).toMatchObject({ outcome: 'failed', stage: 'verify' })
+    // The user still has a working wallet on the old scheme.
+    expect(secureStore.__get('mnemonic')).toBe(MNEMONIC)
+    expect(await readSentinel()).toBeNull()
+    expect(secureStore.__has('envV1.mnemonic', { service: ENV_SERVICE })).toBe(false)
+  })
+
+  it('keeps the plaintext when the user cancels the provisioning prompt', async () => {
+    await seedLegacyInstall()
+    secureStore.__setOutcome('cancel')
+
+    const result = await migrateLegacySecrets()
+
+    expect(result).toMatchObject({ outcome: 'failed', stage: 'provision', retryable: true })
+    expect(secureStore.__get('mnemonic')).toBe(MNEMONIC)
+    expect(await readSentinel()).toBeNull()
+  })
+
+  it('retries on the next launch after a cancellation', async () => {
+    await seedLegacyInstall()
+    secureStore.__setOutcome('cancel')
+    expect((await migrateLegacySecrets()).outcome).toBe('failed')
+
+    secureStore.__setOutcome('ok')
+    __resetForTests()
+    expect((await migrateLegacySecrets()).outcome).toBe('migrated')
+    expect(await getSecret('mnemonic')).toBe(MNEMONIC)
+  })
+
+  it('stops retrying after three failures instead of prompting every launch', async () => {
+    await seedLegacyInstall()
+    secureStore.__setOutcome('cancel')
+    for (let i = 0; i < 3; i++) {
+      __resetForTests()
+      expect((await migrateLegacySecrets()).outcome).toBe('failed')
+    }
+
+    __resetForTests()
+    secureStore.__clearPrompts()
+    const result = await migrateLegacySecrets()
+    expect(result).toMatchObject({ outcome: 'failed', stage: 'attempts-exhausted', retryable: false })
+    expect(secureStore.__prompts()).toBe(0)
+    expect(secureStore.__get('mnemonic')).toBe(MNEMONIC)
+  })
+
+  it('sweeps the plaintext on the next launch if it crashed after committing', async () => {
+    await seedLegacyInstall()
+    await migrateLegacySecrets()
+    // Simulate the crash window: committed sentinel, legacy item still present.
+    secureStore.__seed('mnemonic', MNEMONIC)
+
+    __resetForTests()
+    const result = await migrateLegacySecrets()
+
+    expect(result).toEqual({ outcome: 'not-needed' })
+    expect(secureStore.__has('mnemonic')).toBe(false)
+  })
+
+  it('is a no-op on a fresh install and never prompts', async () => {
+    const result = await migrateLegacySecrets()
+    expect(result).toEqual({ outcome: 'not-needed' })
+    expect(await readSentinel()).toBeNull()
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('is idempotent and prompt-free on an already-migrated install', async () => {
+    await seedLegacyInstall()
+    await migrateLegacySecrets()
+
+    __resetForTests()
+    secureStore.__clearPrompts()
+    expect(await migrateLegacySecrets()).toEqual({ outcome: 'not-needed' })
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('migrates a recovered-key-only wallet', async () => {
+    await seedLegacyInstall({ mnemonic: '', recoveredKey: WIF })
+
+    expect(await migrateLegacySecrets()).toEqual({ outcome: 'migrated', names: ['recoveredKey'] })
+    expect(await getSecret('recoveredKey')).toBe(WIF)
+  })
+
+  it('costs one ceremony to migrate and one per launch thereafter', async () => {
+    await seedLegacyInstall({ recoveredKey: WIF })
+    await migrateLegacySecrets()
+    expect(secureStore.__prompts()).toBe(1) // the provisioning write
+
+    __resetForTests()
+    secureStore.__clearPrompts()
+    await migrateLegacySecrets()
+    expect((await unlockKek()).status).toBe('unlocked')
+    expect(await getSecret('mnemonic')).toBe(MNEMONIC)
+    expect(await getSecret('recoveredKey')).toBe(WIF)
+    expect(secureStore.__prompts()).toBe(1)
+  })
+})

--- a/__tests__/secrets/store.test.ts
+++ b/__tests__/secrets/store.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Secret store: everything after the one unlock must be prompt-free, and
+ * deletion must work without a key.
+ */
+jest.mock('expo-secure-store', () => require('../__mocks__/secureStoreFake').fake)
+jest.mock('expo-local-authentication', () => require('../__mocks__/localAuthFake').fake)
+
+import { fake as secureStore } from '../__mocks__/secureStoreFake'
+import { fake as localAuth } from '../__mocks__/localAuthFake'
+import { __resetForTests, readSentinel, unlockKek } from '../../services/secrets/kek'
+import {
+  deleteAllSecrets,
+  deleteSecret,
+  getSecret,
+  hasSecret,
+  putSecret
+} from '../../services/secrets/store'
+
+const ENV_SERVICE = 'bsvb.secrets.v1'
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const WIF = 'L1uyy5qTuGrVXrmrsvHWHgVzW9kKdrp27wBC7Vs6nZDTF2BRUVwy'
+
+describe('secret store', () => {
+  beforeEach(() => {
+    secureStore.__reset()
+    localAuth.__reset()
+    __resetForTests()
+    ;(global as any).__DEV__ = false
+  })
+
+  it('stores ciphertext, never the plaintext', async () => {
+    expect(await putSecret('mnemonic', MNEMONIC)).toBe(true)
+    const stored = secureStore.__get('envV1.mnemonic', { service: ENV_SERVICE })
+    expect(stored).toBeDefined()
+    expect(stored).not.toContain('abandon')
+    const blob = JSON.parse(stored as string)
+    expect(blob).toMatchObject({ v: 1 })
+    expect(typeof blob.c).toBe('string')
+  })
+
+  it('writes envelopes unauthenticated, so reading them never prompts', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    for (const opts of secureStore.__optionsFor('set', 'envV1.mnemonic')) {
+      expect(opts).toMatchObject({ keychainService: ENV_SERVICE, requireAuthentication: false })
+    }
+  })
+
+  it('costs exactly one ceremony for a whole session of reads and writes', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    await putSecret('recoveredKey', WIF)
+    __resetForTests() // fresh process, storage intact
+    secureStore.__clearPrompts()
+
+    expect((await unlockKek()).status).toBe('unlocked')
+    expect(await getSecret('mnemonic')).toBe(MNEMONIC)
+    expect(await getSecret('recoveredKey')).toBe(WIF)
+    expect(await getSecret('mnemonic')).toBe(MNEMONIC)
+    await putSecret('mnemonic', MNEMONIC)
+    await hasSecret('mnemonic')
+
+    expect(secureStore.__prompts()).toBe(1)
+  })
+
+  it('returns null while locked and does not unlock implicitly', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    __resetForTests()
+    secureStore.__clearPrompts()
+
+    // The one automatic unlock belongs to the wallet-build path, not to
+    // whichever screen happens to read a secret first.
+    expect(await getSecret('mnemonic')).toBeNull()
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('answers hasSecret while locked, without a ceremony', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    __resetForTests()
+    secureStore.__clearPrompts()
+
+    expect(await hasSecret('mnemonic')).toBe(true)
+    expect(await hasSecret('recoveredKey')).toBe(false)
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('refuses to open a blob sealed by a different KEK', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    const blob = JSON.parse(secureStore.__get('envV1.mnemonic', { service: ENV_SERVICE }) as string)
+    secureStore.__seed('envV1.mnemonic', JSON.stringify({ ...blob, kekId: 'ffffffffffffffff' }), {
+      service: ENV_SERVICE
+    })
+    expect(await getSecret('mnemonic')).toBeNull()
+  })
+
+  it('deletes a secret without a ceremony and forgets it in the sentinel', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    await putSecret('recoveredKey', WIF)
+    secureStore.__clearPrompts()
+
+    await deleteSecret('recoveredKey')
+    expect(await hasSecret('recoveredKey')).toBe(false)
+    expect(await hasSecret('mnemonic')).toBe(true)
+    expect((await readSentinel())?.names).toEqual(['mnemonic'])
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('logs out a user whose biometrics changed — deletion needs no key', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    __resetForTests()
+    secureStore.__invalidateBiometrics()
+    expect((await unlockKek()).status).toBe('lost')
+    secureStore.__clearPrompts()
+
+    await deleteAllSecrets()
+
+    expect(await hasSecret('mnemonic')).toBe(false)
+    expect(await readSentinel()).toBeNull()
+    expect(secureStore.__prompts()).toBe(0)
+  })
+
+  it('leaves the next launch looking like a clean install after a wipe', async () => {
+    await putSecret('mnemonic', MNEMONIC)
+    await deleteAllSecrets()
+    __resetForTests()
+    secureStore.__clearPrompts()
+
+    // No orphan sentinel means no biometric sheet on the create-wallet screen.
+    expect((await unlockKek()).status).toBe('absent')
+    expect(secureStore.__prompts()).toBe(0)
+  })
+})

--- a/app/auth/mnemonic.tsx
+++ b/app/auth/mnemonic.tsx
@@ -407,11 +407,16 @@ export default function MnemonicScreen() {
             </PressableScale>
           </View>
 
-          {/* Biometric protection note */}
+          {/* Biometric protection note. Keep this claim accurate: the phrase is
+              encrypted on this device under a key the OS releases only after a
+              biometric match — and if those biometrics change, the OS destroys
+              that key, which is why the written copy matters. */}
           <View style={[s.biometricNote, { backgroundColor: colors.fillTertiary, borderColor: colors.separator }]}>
             <Ionicons name="finger-print" size={32} color={colors.textSecondary} style={s.biometricIcon} />
             <Text style={[s.biometricText, { color: colors.textSecondary }]}>
-              Your recovery phrase is protected by Face ID / device biometrics.
+              On this device your recovery phrase is encrypted with a key that Face ID or your
+              fingerprint unlocks. Write the phrase down anyway — if your biometrics change, the
+              key is destroyed and the phrase is the only way back in.
             </Text>
           </View>
 

--- a/app/wallet.tsx
+++ b/app/wallet.tsx
@@ -41,6 +41,7 @@ import { exportTransactionsAsCsv } from '@/utils/exportTransactions'
 import { findOfflineActions, type OfflineActionRow } from '@/storage/methods/offlineActions'
 import { txStatusView, toneColor, tonePill } from '@/utils/txStatus'
 import tabStore from '@/stores/TabStore'
+import WalletLockNotice from '@/components/security/WalletLockNotice'
 
 const PAGE_SIZE = 30
 
@@ -532,6 +533,11 @@ export default function WalletScreen() {
           <Ionicons name="settings-outline" size={22} color={colors.textSecondary} />
         </TouchableOpacity>
       </View>
+
+      {/* Renders only when the keys could not be released — a destroyed key, a
+          dismissed prompt, or biometric lockout. Previously all three looked
+          identical to "you have no wallet". */}
+      <WalletLockNotice />
 
       <FlatList
         data={actions}

--- a/components/security/WalletLockNotice.tsx
+++ b/components/security/WalletLockNotice.tsx
@@ -1,0 +1,106 @@
+/**
+ * The states the app previously had no way to show.
+ *
+ * Before the envelope, a failed key read was indistinguishable from having no
+ * wallet: the build silently bailed and the user landed in the browser as if
+ * they were new. Now that the OS genuinely holds the key, three outcomes need
+ * to be visible and told apart:
+ *
+ *  - `lost`        the OS destroyed the key (biometrics re-enrolled, screen
+ *                  lock removed, app reinstalled). Unrecoverable on-device.
+ *  - `cancelled`   the user dismissed the sheet. Nothing was touched; retry.
+ *  - `unavailable` biometric lockout or no usable hardware.
+ *
+ * Nothing here wipes anything on its own. Restoring is an explicit, confirmed
+ * act, because the alternative — auto-wiping on a read failure — would destroy
+ * a wallet over a transient prompt error.
+ */
+import React, { useCallback } from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { router } from 'expo-router'
+import { useTheme } from '@/context/theme/ThemeContext'
+import { spacing, radii, typography } from '@/context/theme/tokens'
+import PressableScale from '@/components/ui/PressableScale'
+import { showAlert } from '@/components/ui/AlertCard'
+import { useLocalStorage } from '@/context/LocalStorageProvider'
+import i18n from '@/context/i18n/translations'
+
+const t = (k: string, o?: Record<string, unknown>) => i18n.t(k, o) as string
+
+export default function WalletLockNotice() {
+  const { colors } = useTheme()
+  const { unlockState, unlock, deleteAllWalletKeys } = useLocalStorage()
+
+  const onRestore = useCallback(async () => {
+    const choice = await showAlert({
+      title: t('wallet_lost_title'),
+      message: t('wallet_lost_body'),
+      buttons: [
+        { text: t('wallet_lost_later'), style: 'cancel', key: 'cancel' },
+        { text: t('wallet_lost_restore'), style: 'destructive', key: 'restore' }
+      ]
+    })
+    if (choice !== 'restore') return
+    // The ciphertexts are already unopenable; clearing them is what lets
+    // onboarding start clean instead of tripping over an orphan sentinel.
+    await deleteAllWalletKeys()
+    router.replace('/auth/mnemonic')
+  }, [deleteAllWalletKeys])
+
+  const status = unlockState.status
+  if (status !== 'lost' && status !== 'cancelled' && status !== 'unavailable') return null
+
+  const lost = status === 'lost'
+  const body = lost
+    ? t('wallet_lost_body')
+    : status === 'unavailable' && unlockState.reason === 'lockout'
+      ? t('wallet_lockout_body')
+      : status === 'unavailable'
+        ? t('wallet_no_biometrics_body')
+        : t('wallet_locked_body')
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.backgroundSecondary, borderColor: colors.separator }]}>
+      <Ionicons
+        name={lost ? 'alert-circle-outline' : 'lock-closed-outline'}
+        size={40}
+        color={lost ? colors.textPrimary : colors.textTertiary}
+      />
+      <Text style={[styles.title, { color: colors.textPrimary }]}>
+        {lost ? t('wallet_lost_title') : t('wallet_locked_title')}
+      </Text>
+      <Text style={[styles.body, { color: colors.textSecondary }]}>{body}</Text>
+
+      <PressableScale
+        haptic="confirm"
+        onPress={lost ? onRestore : unlock}
+        style={[styles.primary, { backgroundColor: colors.accent }]}
+      >
+        <Text style={styles.primaryText}>
+          {lost ? t('wallet_lost_restore') : t('wallet_unlock_retry')}
+        </Text>
+      </PressableScale>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.xl,
+    margin: spacing.lg,
+    borderRadius: radii.lg,
+    borderWidth: StyleSheet.hairlineWidth
+  },
+  title: { ...typography.title3, textAlign: 'center' },
+  body: { ...typography.subhead, textAlign: 'center' },
+  primary: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.xl,
+    borderRadius: radii.pill,
+    marginTop: spacing.xs
+  },
+  primaryText: { ...typography.headline, color: '#fff' }
+})

--- a/context/LocalStorageProvider.tsx
+++ b/context/LocalStorageProvider.tsx
@@ -1,25 +1,60 @@
-import React, { createContext, useCallback, useContext, useMemo, useRef } from 'react'
-import * as SecureStore from 'expo-secure-store'
-import * as LocalAuthentication from 'expo-local-authentication'
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import i18n from '@/context/i18n/translations'
+import {
+  autoUnlockKek,
+  deleteAllSecrets,
+  deleteSecret,
+  getSecret,
+  getUnlockState,
+  hasSecret,
+  isUnlocked,
+  migrateLegacySecrets,
+  putSecret,
+  readLegacySecret,
+  subscribeUnlockState,
+  unlockKek,
+  type MigrationResult,
+  type UnlockState
+} from '@/services/secrets'
 
+/**
+ * Wallet secrets are held by services/secrets, which wraps them in AES-256-GCM
+ * under a key the OS will only release after a biometric match. This provider
+ * is the React surface over that: it runs the one-time migration off the old
+ * plaintext scheme, exposes the unlock state to the UI, and keeps the
+ * historical get/set/delete shape so callers did not have to change.
+ *
+ * The biometric prompt happens at most once per process, when the wallet is
+ * first instantiated — but unlike the previous design, skipping it does not
+ * yield the mnemonic, because there is nothing to read without the key.
+ */
 export interface LocalStorageContextType {
-  /* non-secure */
-  setSnap: (snap: number[]) => Promise<void>
-  getSnap: () => Promise<number[] | null>
-  deleteSnap: () => Promise<void>
-
   /* secure */
-  setPassword: (password: string) => Promise<boolean>
-  getPassword: () => Promise<string | null>
-  deletePassword: () => Promise<void>
   setMnemonic: (mnemonic: string) => Promise<boolean>
   getMnemonic: () => Promise<string | null>
   deleteMnemonic: () => Promise<void>
   setRecoveredKey: (wif: string) => Promise<boolean>
   getRecoveredKey: () => Promise<string | null>
   deleteRecoveredKey: () => Promise<void>
+  deleteAllWalletKeys: () => Promise<void>
+
+  /* unlock */
+  /** False until the legacy migration has settled. Reading a secret before
+   * this flips would report "no wallet" for an existing user. */
+  secretsReady: boolean
+  unlockState: UnlockState
+  /** Explicit user-initiated unlock, for the lock screen's retry button. */
+  unlock: () => Promise<UnlockState>
+  migration: MigrationResult | null
 
   /* general */
   setItem: (item: string, value: string) => Promise<void>
@@ -27,29 +62,23 @@ export interface LocalStorageContextType {
   deleteItem: (item: string) => Promise<void>
 }
 
-const SNAP_KEY = 'snap'
-const PASSWORD_KEY = 'password'
-const MNEMONIC_KEY = 'mnemonic'
-const RECOVERED_KEY = 'recoveredKey'
-const HAS_WALLET_KEYS = 'hasWalletKeys'
-
 export const LocalStorageContext = createContext<LocalStorageContextType>({
-  /* non-secure */
-  setSnap: async () => {},
-  getSnap: async () => null,
-  deleteSnap: async () => {},
-
   /* secure */
-  setPassword: async () => false,
-  getPassword: async () => null,
-  deletePassword: async () => {},
   setMnemonic: async () => false,
   getMnemonic: async () => null,
   deleteMnemonic: async () => {},
   setRecoveredKey: async () => false,
   getRecoveredKey: async () => null,
   deleteRecoveredKey: async () => {},
+  deleteAllWalletKeys: async () => {},
 
+  /* unlock */
+  secretsReady: false,
+  unlockState: { status: 'locked' },
+  unlock: async () => ({ status: 'locked' }),
+  migration: null,
+
+  /* general */
   getItem: AsyncStorage.getItem,
   setItem: AsyncStorage.setItem,
   deleteItem: AsyncStorage.removeItem
@@ -58,226 +87,122 @@ export const LocalStorageContext = createContext<LocalStorageContextType>({
 export const useLocalStorage = () => useContext(LocalStorageContext)
 
 export default function LocalStorageProvider({ children }: { children: React.ReactNode }) {
-  /* --------------------------------- SECURE -------------------------------- */
+  const [secretsReady, setSecretsReady] = useState(false)
+  const [migration, setMigration] = useState<MigrationResult | null>(null)
+  const [unlockState, setUnlockState] = useState<UnlockState>(getUnlockState)
+  /** Set when migration failed: this session keeps serving the legacy plaintext
+   * so the user still has a working wallet, and we retry on the next launch. */
+  const legacyFallback = useRef(false)
 
-  // keep "am I already biometrically unlocked?" in memory for this session
-  const authenticatedRef = useRef(false)
-  const authInProgress = useRef<Promise<boolean> | null>(null)
+  useEffect(() => subscribeUnlockState(setUnlockState), [])
 
-  const ensureAuth = useCallback(async (promptMessage: string): Promise<boolean> => {
-    // If we already asked this frame, reuse the same promise so we don't show
-    // the Face ID modal twice in parallel.
-    if (authInProgress.current) return authInProgress.current
-
-    const doAuth = async () => {
-      // Use ref so the check is always up-to-date, even before React re-renders.
-      if (authenticatedRef.current) return true
-
-      const { success } = await LocalAuthentication.authenticateAsync({
-        promptMessage,
-        cancelLabel: 'Cancel',
-        disableDeviceFallback: false
-      })
-
-      authenticatedRef.current = success
-      authInProgress.current = null // reset latch
-      return success
-    }
-
-    authInProgress.current = doAuth()
-    return authInProgress.current
-  }, [])
-
-  /* ------------------------------- non-secure ------------------------------ */
-
-  const setSnap = useCallback(async (snap: number[]): Promise<void> => {
-    try {
-      const snapAsJSON = typeof snap === 'string' ? snap : JSON.stringify(snap)
-      await AsyncStorage.setItem(SNAP_KEY, snapAsJSON)
-    } catch (err) {
-      console.warn('[setSnap]', err)
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      let result: MigrationResult
+      try {
+        result = await migrateLegacySecrets()
+      } catch (err) {
+        console.warn('[LocalStorageProvider] migration threw', (err as Error)?.message)
+        result = { outcome: 'failed', stage: 'unknown', retryable: true }
+      }
+      if (cancelled) return
+      legacyFallback.current = result.outcome === 'failed'
+      setMigration(result)
+      setSecretsReady(true)
+    })()
+    return () => {
+      cancelled = true
     }
   }, [])
 
-  const getSnap = useCallback(async (): Promise<number[] | null> => {
-    try {
-      const raw = await AsyncStorage.getItem(SNAP_KEY)
-      return raw ? (JSON.parse(raw) as number[]) : null
-    } catch (err) {
-      console.warn('[getSnap]', err)
-      return null
-    }
-  }, [])
+  /* --------------------------------- unlock -------------------------------- */
 
-  const deleteSnap = useCallback(async (): Promise<void> => {
-    try {
-      await AsyncStorage.removeItem(SNAP_KEY)
-    } catch (err) {
-      console.warn('[deleteSnap]', err)
-    }
+  const unlock = useCallback(
+    () => unlockKek(i18n.t('biometric_unlock_wallet')),
+    []
+  )
+
+  /**
+   * The single implicit ceremony. Called on the read path so the returning
+   * user sees exactly what they see today — one sheet at wallet build, no
+   * extra tap — while `autoUnlockKek` guarantees we never initiate a second
+   * one after a cancellation.
+   */
+  const ensureUnlocked = useCallback(async (): Promise<boolean> => {
+    if (isUnlocked()) return true
+    const state = await autoUnlockKek(i18n.t('biometric_unlock_wallet'))
+    return state.status === 'unlocked'
   }, [])
 
   /* -------------------------------- secure --------------------------------- */
 
   const setMnemonic = useCallback(
-    async (mnemonic: string): Promise<boolean> => {
-      try {
-        if (!(await ensureAuth(i18n.t('biometric_store_wallet')))) return false
-        await SecureStore.setItemAsync(MNEMONIC_KEY, mnemonic, {
-          keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
-        })
-        await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
-        return true
-      } catch (err) {
-        console.warn('[setMnemonic]', err)
-        return false
-      }
-    },
-    [ensureAuth]
+    (mnemonic: string) => putSecret('mnemonic', mnemonic),
+    []
   )
 
   const getMnemonic = useCallback(async (): Promise<string | null> => {
-    try {
-      const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
-      if (!hasKeys) return null
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return null
-      return await SecureStore.getItemAsync(MNEMONIC_KEY)
-    } catch (err) {
-      console.warn('[getMnemonic]', err)
-      return null
-    }
-  }, [ensureAuth])
+    if (legacyFallback.current) return readLegacySecret('mnemonic')
+    if (!(await hasSecret('mnemonic'))) return null
+    if (!(await ensureUnlocked())) return null
+    return getSecret('mnemonic')
+  }, [ensureUnlocked])
 
-  const deleteMnemonic = useCallback(async (): Promise<void> => {
-    try {
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return
-      await SecureStore.deleteItemAsync(MNEMONIC_KEY)
-      await AsyncStorage.removeItem(HAS_WALLET_KEYS)
-    } catch (err) {
-      console.warn('[deleteMnemonic]', err)
-    }
-  }, [ensureAuth])
-
-  /* -------------------------------- secure --------------------------------- */
-
-  const setPassword = useCallback(
-    async (password: string): Promise<boolean> => {
-      try {
-        if (!(await ensureAuth(i18n.t('biometric_store_wallet')))) return false
-        await SecureStore.setItemAsync(PASSWORD_KEY, password, {
-          keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
-        })
-        await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
-        return true
-      } catch (err) {
-        console.warn('[setPassword]', err)
-        return false
-      }
-    },
-    [ensureAuth]
-  )
-
-  const getPassword = useCallback(async (): Promise<string | null> => {
-    try {
-      const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
-      if (!hasKeys) return null
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return null
-      return await SecureStore.getItemAsync(PASSWORD_KEY)
-    } catch (err) {
-      console.warn('[getPassword]', err)
-      return null
-    }
-  }, [ensureAuth])
-
-  const deletePassword = useCallback(async (): Promise<void> => {
-    try {
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return
-      await SecureStore.deleteItemAsync(PASSWORD_KEY)
-      await AsyncStorage.removeItem(HAS_WALLET_KEYS)
-    } catch (err) {
-      console.warn('[deletePassword]', err)
-    }
-  }, [ensureAuth])
-
-  /* ----------------------------- recovered key ------------------------------ */
+  const deleteMnemonic = useCallback(() => deleteSecret('mnemonic'), [])
 
   const setRecoveredKey = useCallback(
-    async (wif: string): Promise<boolean> => {
-      try {
-        if (!(await ensureAuth(i18n.t('biometric_store_wallet')))) return false
-        await SecureStore.setItemAsync(RECOVERED_KEY, wif, {
-          keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
-        })
-        await AsyncStorage.setItem(HAS_WALLET_KEYS, 'true')
-        return true
-      } catch (err) {
-        console.warn('[setRecoveredKey]', err)
-        return false
-      }
-    },
-    [ensureAuth]
+    (wif: string) => putSecret('recoveredKey', wif),
+    []
   )
 
   const getRecoveredKey = useCallback(async (): Promise<string | null> => {
-    try {
-      const hasKeys = await AsyncStorage.getItem(HAS_WALLET_KEYS)
-      if (!hasKeys) return null
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return null
-      return await SecureStore.getItemAsync(RECOVERED_KEY)
-    } catch (err) {
-      console.warn('[getRecoveredKey]', err)
-      return null
-    }
-  }, [ensureAuth])
+    if (legacyFallback.current) return readLegacySecret('recoveredKey')
+    if (!(await hasSecret('recoveredKey'))) return null
+    if (!(await ensureUnlocked())) return null
+    return getSecret('recoveredKey')
+  }, [ensureUnlocked])
 
-  const deleteRecoveredKey = useCallback(async (): Promise<void> => {
-    try {
-      if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return
-      await SecureStore.deleteItemAsync(RECOVERED_KEY)
-      await AsyncStorage.removeItem(HAS_WALLET_KEYS)
-    } catch (err) {
-      console.warn('[deleteRecoveredKey]', err)
-    }
-  }, [ensureAuth])
+  const deleteRecoveredKey = useCallback(() => deleteSecret('recoveredKey'), [])
+
+  /** Wipes the secrets and the key protecting them, so the next launch reads as
+   * a clean install instead of prompting for a wallet that no longer exists.
+   * Works while locked or lost — deleting ciphertext needs no key. */
+  const deleteAllWalletKeys = useCallback(() => deleteAllSecrets(), [])
 
   /* -------------------------------- output --------------------------------- */
 
   const value: LocalStorageContextType = useMemo(
     () => ({
-      /* non-secure */
-      setSnap,
-      getSnap,
-      deleteSnap,
-
-      /* secure */
-      setPassword,
-      getPassword,
-      deletePassword,
       setMnemonic,
       getMnemonic,
       deleteMnemonic,
       setRecoveredKey,
       getRecoveredKey,
       deleteRecoveredKey,
+      deleteAllWalletKeys,
 
-      /* general */
+      secretsReady,
+      unlockState,
+      unlock,
+      migration,
+
       getItem: AsyncStorage.getItem,
       setItem: AsyncStorage.setItem,
       deleteItem: AsyncStorage.removeItem
     }),
     [
-      setSnap,
-      getSnap,
-      deleteSnap,
-      setPassword,
-      getPassword,
-      deletePassword,
       setMnemonic,
       getMnemonic,
       deleteMnemonic,
       setRecoveredKey,
       getRecoveredKey,
-      deleteRecoveredKey
+      deleteRecoveredKey,
+      deleteAllWalletKeys,
+      secretsReady,
+      unlockState,
+      unlock,
+      migration
     ]
   )
 

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -117,7 +117,6 @@ export interface WalletContextValue {
   // Logout
   logout: () => void
   adminOriginator: string
-  snapshotLoaded: boolean
   basketRequests: BasketAccessRequest[]
   certificateRequests: CertificateAccessRequest[]
   protocolRequests: ProtocolAccessRequest[]
@@ -178,7 +177,6 @@ export const WalletContext = createContext<WalletContextValue>({
   updateSettings: async () => {},
   logout: () => {},
   adminOriginator: ADMIN_ORIGINATOR,
-  snapshotLoaded: false,
   basketRequests: [],
   certificateRequests: [],
   protocolRequests: [],
@@ -416,16 +414,12 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
   }, [])
 
   const {
-    getSnap,
-    deleteSnap,
     getItem,
     setItem,
-    setMnemonic,
     getMnemonic,
-    deleteMnemonic,
-    setRecoveredKey,
     getRecoveredKey,
-    deleteRecoveredKey
+    deleteAllWalletKeys,
+    secretsReady
   } = useLocalStorage()
 
   const {
@@ -621,8 +615,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
   // Flag that indicates configuration is complete. For returning users,
   // if a snapshot exists we auto-mark configComplete.
   const [configStatus, setConfigStatus] = useState<ConfigStatus>('initial')
-  // Used to trigger a re-render after snapshot load completes.
-  const [snapshotLoaded, setSnapshotLoaded] = useState<boolean>(false)
 
   const finalizeConfig = useCallback((wabConfig: WABConfig): boolean => {
     const { method, network, storageUrl } = wabConfig
@@ -1183,17 +1175,10 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
     ]
   )
 
-  // Watch for wallet authentication state
-  useEffect(() => {
-    ;(async () => {
-      const snap = await getSnap()
-      if (managers?.walletManager?.authenticated && snap) {
-        setSnapshotLoaded(true)
-      } else if (!snap && snapshotLoaded) {
-        setSnapshotLoaded(false)
-      }
-    })()
-  }, [managers?.walletManager?.authenticated, snapshotLoaded, getSnap])
+  // NOTE: SimpleWalletManager snapshots are deliberately not persisted. Its
+  // snapshot format prepends the encryption key to the ciphertext, so the blob
+  // is plaintext-equivalent for anyone who can read it — storing one would hand
+  // out the primary key and undo the biometric protection on the mnemonic.
 
   // TODO: Re-add WAB (WalletAuthenticationManager) support in future version
 
@@ -1246,9 +1231,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         vaultPkmRef.current = privilegedKeyManager
 
         // Create SimpleWalletManager and provide keys for authentication
-        const snap = await getSnap()
-
-        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet, snap || undefined)
+        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet)
 
         // Provide the primary key and privileged key manager to authenticate the wallet
         await swm.providePrimaryKey(primaryKey)
@@ -1263,7 +1246,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         walletBuildingRef.current = false
         setWalletBuilding(false)
 
-        await setMnemonic(mnemonic)
         logWithTimestamp(F, 'Mnemonic wallet build completed')
       } catch (error: any) {
         walletBuildingRef.current = false
@@ -1271,7 +1253,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         console.error('[WalletContext] Error building mnemonic wallet:', error)
       }
     },
-    [walletBuilt, configStatus, getMnemonic, getSnap, setMnemonic, buildWallet]
+    [walletBuilt, configStatus, getMnemonic, buildWallet]
   )
 
   // Build wallet from a recovered PrivateKey (WIF) obtained via backup share scanning
@@ -1300,8 +1282,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         )
         vaultPkmRef.current = privilegedKeyManager
 
-        const snap = await getSnap()
-        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet, snap || undefined)
+        const swm = new SimpleWalletManager(ADMIN_ORIGINATOR, buildWallet)
 
         await swm.providePrimaryKey(primaryKey)
 
@@ -1315,7 +1296,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         walletBuildingRef.current = false
         setWalletBuilding(false)
 
-        await setRecoveredKey(wif)
         logWithTimestamp(F, 'Recovered key wallet build completed')
       } catch (error: any) {
         walletBuildingRef.current = false
@@ -1323,7 +1303,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         console.error('[WalletContext] Error building wallet from recovered key:', error)
       }
     },
-    [walletBuilt, configStatus, getSnap, setRecoveredKey, buildWallet]
+    [walletBuilt, configStatus, buildWallet]
   )
 
   // Tear down the current wallet and re-trigger auto-build.
@@ -1360,7 +1340,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
     setWalletBuilt(false)
     walletBuildingRef.current = false
     setWalletBuilding(false)
-    setSnapshotLoaded(false)
 
     // Re-finalize with current config — triggers auto-build effect
     const config = { wabUrl: 'noWAB', method: 'mnemonic', network: selectedNetwork, storageUrl: 'local' }
@@ -1401,7 +1380,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
       setWalletBuilt(false)
       walletBuildingRef.current = false
       setWalletBuilding(false)
-      setSnapshotLoaded(false)
 
       // Persist new config
       const newConfig = { wabUrl: 'noWAB', method: 'mnemonic', network, storageUrl: 'local' }
@@ -1421,7 +1399,13 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
     if (configStatus !== 'configured' || walletBuilt) return
     // Signal that a build attempt is starting. buildWalletFromMnemonic /
     // buildWalletFromRecoveredKey will clear this flag on completion or error.
+    // Set before the secretsReady gate below, so the migration window is not
+    // mistaken by the rest of the app for "this user has no wallet".
     setWalletBuilding(true)
+    // Wait for the legacy-secret migration to settle. Reading a secret before
+    // it does would report "no wallet" to an existing user on the first launch
+    // after upgrading, and this effect would not re-fire to correct it.
+    if (!secretsReady) return
     ;(async () => {
       // Try mnemonic-based build first (calls getMnemonic internally)
       await buildWalletFromMnemonic()
@@ -1441,7 +1425,14 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         }
       }
     })()
-  }, [configStatus, walletBuilt, buildWalletFromMnemonic, buildWalletFromRecoveredKey, getRecoveredKey])
+  }, [
+    configStatus,
+    walletBuilt,
+    secretsReady,
+    buildWalletFromMnemonic,
+    buildWalletFromRecoveredKey,
+    getRecoveredKey
+  ])
 
   // Settings are AsyncStorage-only — no on-chain sync needed
 
@@ -1681,21 +1672,23 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
 
   const logout = useCallback(() => {
     logWithTimestamp(F, 'Logout')
-    deleteSnap().then(async () => {
+    ;(async () => {
       setManagers({})
       setConfigStatus('initial')
-      setSnapshotLoaded(false)
       setWalletBuilt(false)
       walletBuildingRef.current = false
       setWalletBuilding(false)
       setWalletUserId(null)
-      deleteMnemonic()
-      deleteRecoveredKey()
+
+      // Awaited, and it removes the KEK along with the ciphertexts: leaving the
+      // key behind would make the next cold start prompt for a wallet that no
+      // longer exists. Works while locked, since deleting needs no key.
+      await deleteAllWalletKeys()
 
       router.dismissAll()
       router.push('/')
-    })
-  }, [deleteSnap, deleteMnemonic, deleteRecoveredKey])
+    })()
+  }, [deleteAllWalletKeys])
 
   /**
    * Reconcile ONE transaction against the network, and repair it if the local
@@ -1994,7 +1987,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
       updateSettings,
       logout,
       adminOriginator,
-      snapshotLoaded,
       basketRequests: basketQueue.requests,
       certificateRequests: certificateQueue.requests,
       protocolRequests: protocolQueue.requests,
@@ -2036,7 +2028,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
       updateSettings,
       logout,
       adminOriginator,
-      snapshotLoaded,
       basketQueue.requests,
       certificateQueue.requests,
       protocolQueue.requests,
@@ -2115,7 +2106,6 @@ export const useWallet = () => useContext(WalletContext)
 export interface WalletStatusSlice {
   walletBuilt: boolean
   walletBuilding: boolean
-  snapshotLoaded: boolean
   configStatus: ConfigStatus
   selectedNetwork: AppChain
 }
@@ -2125,11 +2115,10 @@ export const useWalletStatus = (): WalletStatusSlice => {
     () => ({
       walletBuilt: ctx.walletBuilt,
       walletBuilding: ctx.walletBuilding,
-      snapshotLoaded: ctx.snapshotLoaded,
       configStatus: ctx.configStatus,
       selectedNetwork: ctx.selectedNetwork
     }),
-    [ctx.walletBuilt, ctx.walletBuilding, ctx.snapshotLoaded, ctx.configStatus, ctx.selectedNetwork]
+    [ctx.walletBuilt, ctx.walletBuilding, ctx.configStatus, ctx.selectedNetwork]
   )
 }
 

--- a/context/i18n/translations.tsx
+++ b/context/i18n/translations.tsx
@@ -481,6 +481,16 @@ const resources = {
       // Biometric prompts
       biometric_store_wallet: 'Securely Store Your Wallet',
       biometric_load_wallet: 'Securely Load Your Wallet',
+      biometric_unlock_wallet: 'Unlock your wallet',
+      wallet_lost_title: 'Wallet key destroyed',
+      wallet_lost_body: 'This device changed its biometric settings, so the system destroyed the key protecting this wallet. Your coins are safe on the blockchain — restore this wallet with your recovery phrase.',
+      wallet_lost_restore: 'Restore with recovery phrase',
+      wallet_lost_later: 'Not now',
+      wallet_locked_title: 'Wallet locked',
+      wallet_locked_body: 'Unlock to load your wallet keys.',
+      wallet_unlock_retry: 'Unlock wallet',
+      wallet_lockout_body: 'Too many failed attempts. Unlock your phone with its passcode, then try again.',
+      wallet_no_biometrics_body: 'This device has no biometrics set up. Your wallet keys are still encrypted by the device keystore, but they are not protected by a biometric check.',
 
       // Connections screen
       connections: 'Connections',
@@ -883,6 +893,16 @@ const resources = {
 
       biometric_store_wallet: '安全存储您的钱包',
       biometric_load_wallet: '安全加载您的钱包',
+      biometric_unlock_wallet: '解锁您的钱包',
+      wallet_lost_title: '钱包密钥已被销毁',
+      wallet_lost_body: '此设备的生物识别设置已更改，系统因此销毁了保护此钱包的密钥。您的币在区块链上是安全的——请使用助记词恢复此钱包。',
+      wallet_lost_restore: '使用助记词恢复',
+      wallet_lost_later: '暂不',
+      wallet_locked_title: '钱包已锁定',
+      wallet_locked_body: '解锁以加载您的钱包密钥。',
+      wallet_unlock_retry: '解锁钱包',
+      wallet_lockout_body: '尝试次数过多。请先用密码解锁手机，然后重试。',
+      wallet_no_biometrics_body: '此设备未设置生物识别。您的钱包密钥仍由设备密钥库加密，但没有生物识别保护。',
 
       // Connections screen
       connections: '连接',
@@ -1287,6 +1307,16 @@ const resources = {
 
       biometric_store_wallet: 'अपने वॉलेट को सुरक्षित रूप से संग्रहित करें',
       biometric_load_wallet: 'अपने वॉलेट को सुरक्षित रूप से लोड करें',
+      biometric_unlock_wallet: 'अपना वॉलेट अनलॉक करें',
+      wallet_lost_title: 'वॉलेट कुंजी नष्ट हो गई',
+      wallet_lost_body: 'इस डिवाइस की बायोमेट्रिक सेटिंग्स बदल गईं, इसलिए सिस्टम ने इस वॉलेट की सुरक्षा करने वाली कुंजी नष्ट कर दी। आपके सिक्के ब्लॉकचेन पर सुरक्षित हैं — रिकवरी वाक्यांश से इस वॉलेट को पुनर्स्थापित करें।',
+      wallet_lost_restore: 'रिकवरी वाक्यांश से पुनर्स्थापित करें',
+      wallet_lost_later: 'अभी नहीं',
+      wallet_locked_title: 'वॉलेट लॉक है',
+      wallet_locked_body: 'अपनी वॉलेट कुंजियाँ लोड करने के लिए अनलॉक करें।',
+      wallet_unlock_retry: 'वॉलेट अनलॉक करें',
+      wallet_lockout_body: 'बहुत अधिक असफल प्रयास। पहले अपने फ़ोन को पासकोड से अनलॉक करें, फिर पुनः प्रयास करें।',
+      wallet_no_biometrics_body: 'इस डिवाइस पर बायोमेट्रिक्स सेट नहीं है। आपकी वॉलेट कुंजियाँ अभी भी डिवाइस कीस्टोर द्वारा एन्क्रिप्टेड हैं, लेकिन बायोमेट्रिक जाँच से सुरक्षित नहीं हैं।',
 
       // Connections screen
       connections: 'कनेक्शन',
@@ -1695,6 +1725,16 @@ const resources = {
 
       biometric_store_wallet: 'Almacene su billetera de forma segura',
       biometric_load_wallet: 'Cargue su billetera de forma segura',
+      biometric_unlock_wallet: 'Desbloquee su billetera',
+      wallet_lost_title: 'Clave de la billetera destruida',
+      wallet_lost_body: 'Este dispositivo cambió su configuración biométrica, por lo que el sistema destruyó la clave que protegía esta billetera. Sus monedas están seguras en la blockchain: restaure esta billetera con su frase de recuperación.',
+      wallet_lost_restore: 'Restaurar con la frase de recuperación',
+      wallet_lost_later: 'Ahora no',
+      wallet_locked_title: 'Billetera bloqueada',
+      wallet_locked_body: 'Desbloquee para cargar las claves de su billetera.',
+      wallet_unlock_retry: 'Desbloquear billetera',
+      wallet_lockout_body: 'Demasiados intentos fallidos. Desbloquee su teléfono con su código y vuelva a intentarlo.',
+      wallet_no_biometrics_body: 'Este dispositivo no tiene biometría configurada. Las claves de su billetera siguen cifradas por el almacén de claves del dispositivo, pero no están protegidas por una comprobación biométrica.',
 
       // Connections screen
       connections: 'Conexiones',
@@ -2097,6 +2137,16 @@ const resources = {
 
       biometric_store_wallet: 'Stocker votre portefeuille en toute sécurité',
       biometric_load_wallet: 'Charger votre portefeuille en toute sécurité',
+      biometric_unlock_wallet: 'Déverrouillez votre portefeuille',
+      wallet_lost_title: 'Clé du portefeuille détruite',
+      wallet_lost_body: 'Cet appareil a modifié ses réglages biométriques ; le système a donc détruit la clé qui protégeait ce portefeuille. Vos pièces sont en sécurité sur la blockchain — restaurez ce portefeuille avec votre phrase de récupération.',
+      wallet_lost_restore: 'Restaurer avec la phrase de récupération',
+      wallet_lost_later: 'Plus tard',
+      wallet_locked_title: 'Portefeuille verrouillé',
+      wallet_locked_body: 'Déverrouillez pour charger les clés de votre portefeuille.',
+      wallet_unlock_retry: 'Déverrouiller le portefeuille',
+      wallet_lockout_body: 'Trop de tentatives échouées. Déverrouillez votre téléphone avec son code, puis réessayez.',
+      wallet_no_biometrics_body: 'Aucune biométrie n’est configurée sur cet appareil. Vos clés restent chiffrées par le magasin de clés de l’appareil, mais elles ne sont pas protégées par une vérification biométrique.',
 
       // Connections screen
       connections: 'Connexions',
@@ -2495,6 +2545,16 @@ const resources = {
 
       biometric_store_wallet: 'تخزين محفظتك بأمان',
       biometric_load_wallet: 'تحميل محفظتك بأمان',
+      biometric_unlock_wallet: 'افتح قفل محفظتك',
+      wallet_lost_title: 'تم إتلاف مفتاح المحفظة',
+      wallet_lost_body: 'غيّر هذا الجهاز إعدادات القياسات الحيوية، لذلك أتلف النظام المفتاح الذي يحمي هذه المحفظة. عملاتك آمنة على البلوكتشين — استعد هذه المحفظة باستخدام عبارة الاسترداد.',
+      wallet_lost_restore: 'الاستعادة بعبارة الاسترداد',
+      wallet_lost_later: 'ليس الآن',
+      wallet_locked_title: 'المحفظة مقفلة',
+      wallet_locked_body: 'افتح القفل لتحميل مفاتيح محفظتك.',
+      wallet_unlock_retry: 'فتح قفل المحفظة',
+      wallet_lockout_body: 'محاولات فاشلة كثيرة. افتح قفل هاتفك برمز المرور ثم حاول مرة أخرى.',
+      wallet_no_biometrics_body: 'لا توجد قياسات حيوية مُعدّة على هذا الجهاز. لا تزال مفاتيح محفظتك مشفّرة بمخزن مفاتيح الجهاز، لكنها غير محمية بفحص حيوي.',
 
       // Connections screen
       connections: 'الاتصالات',
@@ -2895,6 +2955,16 @@ const resources = {
 
       biometric_store_wallet: 'Armazene sua carteira com segurança',
       biometric_load_wallet: 'Carregue sua carteira com segurança',
+      biometric_unlock_wallet: 'Desbloqueie sua carteira',
+      wallet_lost_title: 'Chave da carteira destruída',
+      wallet_lost_body: 'Este dispositivo alterou suas configurações biométricas, então o sistema destruiu a chave que protegia esta carteira. Suas moedas estão seguras na blockchain — restaure esta carteira com sua frase de recuperação.',
+      wallet_lost_restore: 'Restaurar com a frase de recuperação',
+      wallet_lost_later: 'Agora não',
+      wallet_locked_title: 'Carteira bloqueada',
+      wallet_locked_body: 'Desbloqueie para carregar as chaves da sua carteira.',
+      wallet_unlock_retry: 'Desbloquear carteira',
+      wallet_lockout_body: 'Muitas tentativas malsucedidas. Desbloqueie seu telefone com a senha e tente novamente.',
+      wallet_no_biometrics_body: 'Este dispositivo não tem biometria configurada. Suas chaves continuam criptografadas pelo keystore do dispositivo, mas não são protegidas por uma verificação biométrica.',
 
       // Connections screen
       connections: 'Conexões',
@@ -3295,6 +3365,16 @@ const resources = {
 
       biometric_store_wallet: 'আপনার ওয়ালেট নিরাপদে সংরক্ষণ করুন',
       biometric_load_wallet: 'আপনার ওয়ালেট নিরাপদে লোড করুন',
+      biometric_unlock_wallet: 'আপনার ওয়ালেট আনলক করুন',
+      wallet_lost_title: 'ওয়ালেট কী ধ্বংস হয়েছে',
+      wallet_lost_body: 'এই ডিভাইসের বায়োমেট্রিক সেটিংস পরিবর্তিত হয়েছে, তাই সিস্টেম এই ওয়ালেট রক্ষাকারী কী ধ্বংস করেছে। আপনার কয়েন ব্লকচেইনে নিরাপদ — রিকভারি ফ্রেজ দিয়ে এই ওয়ালেট পুনরুদ্ধার করুন।',
+      wallet_lost_restore: 'রিকভারি ফ্রেজ দিয়ে পুনরুদ্ধার করুন',
+      wallet_lost_later: 'এখন নয়',
+      wallet_locked_title: 'ওয়ালেট লক করা',
+      wallet_locked_body: 'আপনার ওয়ালেট কী লোড করতে আনলক করুন।',
+      wallet_unlock_retry: 'ওয়ালেট আনলক করুন',
+      wallet_lockout_body: 'অনেকবার ব্যর্থ চেষ্টা। প্রথমে পাসকোড দিয়ে ফোন আনলক করুন, তারপর আবার চেষ্টা করুন।',
+      wallet_no_biometrics_body: 'এই ডিভাইসে বায়োমেট্রিক সেট করা নেই। আপনার ওয়ালেট কী এখনও ডিভাইস কীস্টোর দ্বারা এনক্রিপ্ট করা, তবে বায়োমেট্রিক যাচাই দ্বারা সুরক্ষিত নয়।',
 
       // Connections screen
       connections: 'সংযোগ',
@@ -3697,6 +3777,16 @@ const resources = {
 
       biometric_store_wallet: 'Безопасно сохранить ваш кошелёк',
       biometric_load_wallet: 'Безопасно загрузить ваш кошелёк',
+      biometric_unlock_wallet: 'Разблокируйте кошелёк',
+      wallet_lost_title: 'Ключ кошелька уничтожен',
+      wallet_lost_body: 'На этом устройстве изменились биометрические настройки, поэтому система уничтожила ключ, защищавший этот кошелёк. Ваши монеты в безопасности в блокчейне — восстановите кошелёк с помощью секретной фразы.',
+      wallet_lost_restore: 'Восстановить по секретной фразе',
+      wallet_lost_later: 'Не сейчас',
+      wallet_locked_title: 'Кошелёк заблокирован',
+      wallet_locked_body: 'Разблокируйте, чтобы загрузить ключи кошелька.',
+      wallet_unlock_retry: 'Разблокировать кошелёк',
+      wallet_lockout_body: 'Слишком много неудачных попыток. Разблокируйте телефон кодом-паролем и попробуйте снова.',
+      wallet_no_biometrics_body: 'На этом устройстве не настроена биометрия. Ключи кошелька по-прежнему зашифрованы хранилищем ключей устройства, но не защищены биометрической проверкой.',
 
       // Connections screen
       connections: 'Подключения',
@@ -4098,6 +4188,16 @@ const resources = {
 
       biometric_store_wallet: 'Simpan dompet Anda dengan aman',
       biometric_load_wallet: 'Muat dompet Anda dengan aman',
+      biometric_unlock_wallet: 'Buka kunci dompet Anda',
+      wallet_lost_title: 'Kunci dompet dimusnahkan',
+      wallet_lost_body: 'Pengaturan biometrik perangkat ini berubah, sehingga sistem memusnahkan kunci yang melindungi dompet ini. Koin Anda aman di blockchain — pulihkan dompet ini dengan frasa pemulihan Anda.',
+      wallet_lost_restore: 'Pulihkan dengan frasa pemulihan',
+      wallet_lost_later: 'Nanti saja',
+      wallet_locked_title: 'Dompet terkunci',
+      wallet_locked_body: 'Buka kunci untuk memuat kunci dompet Anda.',
+      wallet_unlock_retry: 'Buka kunci dompet',
+      wallet_lockout_body: 'Terlalu banyak percobaan gagal. Buka kunci ponsel Anda dengan kode sandi, lalu coba lagi.',
+      wallet_no_biometrics_body: 'Perangkat ini tidak memiliki biometrik. Kunci dompet Anda tetap dienkripsi oleh keystore perangkat, tetapi tidak dilindungi pemeriksaan biometrik.',
 
       // Connections screen
       connections: 'Koneksi',
@@ -4516,6 +4616,16 @@ const resources = {
       // Biometric prompts
       biometric_store_wallet: 'ウォレットを安全に保存',
       biometric_load_wallet: 'ウォレットを安全に読み込み',
+      biometric_unlock_wallet: 'ウォレットのロックを解除',
+      wallet_lost_title: 'ウォレットの鍵が破棄されました',
+      wallet_lost_body: 'この端末の生体認証設定が変更されたため、システムがこのウォレットを保護していた鍵を破棄しました。コインはブロックチェーン上で安全です。リカバリーフレーズでこのウォレットを復元してください。',
+      wallet_lost_restore: 'リカバリーフレーズで復元',
+      wallet_lost_later: 'あとで',
+      wallet_locked_title: 'ウォレットはロック中',
+      wallet_locked_body: 'ウォレットの鍵を読み込むにはロックを解除してください。',
+      wallet_unlock_retry: 'ロックを解除',
+      wallet_lockout_body: '失敗が続いたため一時的にロックされました。パスコードで端末のロックを解除してから、もう一度お試しください。',
+      wallet_no_biometrics_body: 'この端末では生体認証が設定されていません。ウォレットの鍵は端末のキーストアで暗号化されていますが、生体認証では保護されていません。',
 
       // Connections screen
       connections: '接続',
@@ -4933,6 +5043,16 @@ const resources = {
       // Biometric prompts
       biometric_store_wallet: 'Bezpiecznie zapisz portfel',
       biometric_load_wallet: 'Bezpiecznie wczytaj portfel',
+      biometric_unlock_wallet: 'Odblokuj portfel',
+      wallet_lost_title: 'Klucz portfela został zniszczony',
+      wallet_lost_body: 'To urządzenie zmieniło ustawienia biometryczne, więc system zniszczył klucz chroniący ten portfel. Twoje monety są bezpieczne w blockchainie — przywróć ten portfel za pomocą frazy odzyskiwania.',
+      wallet_lost_restore: 'Przywróć z frazy odzyskiwania',
+      wallet_lost_later: 'Nie teraz',
+      wallet_locked_title: 'Portfel zablokowany',
+      wallet_locked_body: 'Odblokuj, aby wczytać klucze portfela.',
+      wallet_unlock_retry: 'Odblokuj portfel',
+      wallet_lockout_body: 'Zbyt wiele nieudanych prób. Odblokuj telefon kodem, a następnie spróbuj ponownie.',
+      wallet_no_biometrics_body: 'To urządzenie nie ma skonfigurowanej biometrii. Klucze portfela są nadal szyfrowane przez magazyn kluczy urządzenia, ale nie chroni ich weryfikacja biometryczna.',
 
       // Connections screen
       connections: 'Połączenia',

--- a/services/secrets/envelope.ts
+++ b/services/secrets/envelope.ts
@@ -1,0 +1,102 @@
+/**
+ * Secret envelope crypto — pure functions, no I/O, no logging.
+ *
+ * Scheme (`bsvb-secret-envelope-v1`):
+ *
+ *   seal : DEK = HKDF-SHA256(KEK, salt, "bsvb-secret-envelope-v1|<name>")
+ *          C   = AES-256-GCM(DEK, utf8(plaintext))
+ *   open : same derivation, then AES-GCM-decrypt.
+ *
+ * The KEK never encrypts anything directly: each secret gets its own derived
+ * DEK, so a blob sealed as `mnemonic` cannot be opened as `recoveredKey`. That
+ * is the stand-in for AAD, which @bsv/sdk's SymmetricKey does not expose.
+ *
+ * SECURITY: never log inputs or outputs of these functions.
+ */
+import { SymmetricKey, Random, Utils } from '@bsv/sdk'
+import { hkdfSha256 } from '../vault/sealing'
+import { EnvelopeBlob, EnvelopeError, SecretName } from './types'
+
+export const ENVELOPE_INFO = 'bsvb-secret-envelope-v1'
+
+const SALT_LEN = 32
+const KEK_LEN = 32
+/** SymmetricKey wire format is iv(32) || ct || tag(16). */
+const MIN_CIPHERTEXT_BYTES = 48
+
+const deriveDek = (kek: number[], salt: number[], name: SecretName): number[] =>
+  hkdfSha256(kek, salt, `${ENVELOPE_INFO}|${name}`, 32)
+
+/** Fresh 32-byte key-encryption key. Uses @bsv/sdk's Random, which routes to
+ * the platform CSPRNG — deliberately NOT services/vault/random.ts, whose
+ * expo-crypto path has a Math.random branch under remote debugging. */
+export function generateKek(): number[] {
+  return Random(KEK_LEN)
+}
+
+/** Short public identifier for a KEK, so a blob can name the key that sealed
+ * it without revealing anything about it. */
+export function generateKekId(): string {
+  return Utils.toHex(Random(8))
+}
+
+export function sealSecret(
+  kek: number[],
+  kekId: string,
+  name: SecretName,
+  plaintext: string
+): EnvelopeBlob {
+  const salt = Random(SALT_LEN)
+  const dek = deriveDek(kek, salt, name)
+  const c = new SymmetricKey(dek).encrypt(Utils.toArray(plaintext, 'utf8')) as number[]
+  return { v: 1, kekId, salt: Utils.toHex(salt), c: Utils.toHex(c) }
+}
+
+/**
+ * Open a blob. Throws EnvelopeError and never lets a bare crypto Error escape:
+ * SymmetricKey throws `Error('Decryption failed!')` / `Error('Ciphertext too
+ * short')`, which callers must not have to pattern-match on.
+ */
+export function openSecret(kek: number[], name: SecretName, blob: unknown): string {
+  const b = blob as EnvelopeBlob | null
+  if (!b || typeof b !== 'object') {
+    throw new EnvelopeError('corrupt', 'envelope: not an object')
+  }
+  if (b.v !== 1) {
+    throw new EnvelopeError('bad-version', `envelope: unsupported version ${String(b.v)}`)
+  }
+  if (typeof b.salt !== 'string' || typeof b.c !== 'string' || typeof b.kekId !== 'string') {
+    throw new EnvelopeError('corrupt', 'envelope: malformed fields')
+  }
+
+  let salt: number[]
+  let ct: number[]
+  try {
+    salt = Utils.toArray(b.salt, 'hex') as number[]
+    ct = Utils.toArray(b.c, 'hex') as number[]
+  } catch {
+    throw new EnvelopeError('corrupt', 'envelope: bad hex')
+  }
+  if (salt.length !== SALT_LEN || ct.length < MIN_CIPHERTEXT_BYTES) {
+    throw new EnvelopeError('corrupt', 'envelope: bad lengths')
+  }
+
+  const dek = deriveDek(kek, salt, name)
+  let plain: number[]
+  try {
+    plain = new SymmetricKey(dek).decrypt(ct) as number[]
+  } catch {
+    // Indistinguishable by design: wrong KEK, wrong name, or tampered bytes.
+    throw new EnvelopeError('corrupt', 'envelope: decryption failed')
+  }
+  return Utils.toUTF8(plain)
+}
+
+/** Assert the blob was sealed by the KEK we hold, before attempting to open it.
+ * Separated from openSecret so a stale blob reports `kek-mismatch` rather than
+ * the generic `corrupt`. */
+export function assertKekId(blob: EnvelopeBlob, expectedKekId: string): void {
+  if (blob.kekId !== expectedKekId) {
+    throw new EnvelopeError('kek-mismatch', 'envelope: sealed by a different KEK')
+  }
+}

--- a/services/secrets/index.ts
+++ b/services/secrets/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Wallet secret storage: OS-enforced at-rest protection for the mnemonic and
+ * the recovered key.
+ *
+ * The contract this directory exists to provide:
+ *
+ *   1. Exactly one biometric ceremony per process, at wallet instantiation.
+ *   2. Between ceremonies the secrets are AES-256-GCM ciphertext whose key the
+ *      Secure Enclave / Keystore will not release without a biometric match.
+ *
+ * (2) is the part the previous design lacked. Authentication used to be a
+ * JavaScript boolean that the read path consulted and the OS knew nothing
+ * about; now the read path *is* the ceremony.
+ *
+ * peekKek is intentionally not re-exported.
+ */
+export type {
+  EnvelopeBlob,
+  KekPolicy,
+  KekSentinel,
+  SecretName,
+  UnavailableReason,
+  UnlockState
+} from './types'
+export { EnvelopeError, SECRET_NAMES } from './types'
+
+export { openSecret, sealSecret } from './envelope'
+
+export {
+  biometricKind,
+  hasStrongBiometrics,
+  resolveProvisioningPolicy,
+  type ResolvedPolicy
+} from './policy'
+
+export {
+  autoUnlockKek,
+  destroyKek,
+  getUnlockState,
+  isUnlocked,
+  lockKek,
+  readSentinel,
+  subscribeUnlockState,
+  unlockKek
+} from './kek'
+
+export {
+  deleteAllSecrets,
+  deleteSecret,
+  getSecret,
+  hasAnySecret,
+  hasSecret,
+  putSecret
+} from './store'
+
+export {
+  hasLegacySecrets,
+  migrateLegacySecrets,
+  migrationAttemptsExhausted,
+  readLegacySecret,
+  sweepLegacyKeys,
+  type MigrationResult
+} from './migration'

--- a/services/secrets/kek.ts
+++ b/services/secrets/kek.ts
@@ -1,0 +1,274 @@
+/**
+ * The key-encryption key: the one thing on this device that the OS refuses to
+ * hand over without a biometric match.
+ *
+ * Everything else — the mnemonic, the recovered WIF — is AES-256-GCM
+ * ciphertext sitting in ordinary unauthenticated storage. Reading those costs
+ * zero prompts. Reading the KEK costs exactly one, once per process, because
+ * the value is cached in memory afterwards. That is what buys "one Face ID
+ * check at wallet instantiation, held until the process dies" without making
+ * the check ceremonial: patching JavaScript now yields ciphertext.
+ *
+ * SECURITY: never log the KEK, and never re-export peekKek outside this
+ * directory.
+ */
+import * as SecureStore from 'expo-secure-store'
+import { Utils } from '@bsv/sdk'
+import { generateKek, generateKekId } from './envelope'
+import { KEK_AUTH_KEY, KEK_PLAIN_KEY, needsUpgrade, policyFor, resolveProvisioningPolicy } from './policy'
+import { ENV_SERVICE, envOptions, kekOptions, SENTINEL_KEY } from './storage'
+import { KekPolicy, KekSentinel, SecretName, UnavailableReason, UnlockState } from './types'
+
+let cached: { kek: number[]; kekId: string; policy: KekPolicy } | null = null
+let inFlight: Promise<UnlockState> | null = null
+let state: UnlockState = { status: 'locked' }
+let listeners: ((s: UnlockState) => void)[] = []
+
+/** Latches once the user cancels or the device cannot authenticate, so we
+ * never re-prompt on our own initiative. Only an explicit UI act clears it. */
+let autoUnlockSpent = false
+
+function setState(next: UnlockState): UnlockState {
+  state = next
+  for (const fn of listeners) fn(next)
+  return next
+}
+
+export function getUnlockState(): UnlockState {
+  return state
+}
+
+export function subscribeUnlockState(fn: (s: UnlockState) => void): () => void {
+  listeners.push(fn)
+  return () => {
+    listeners = listeners.filter(l => l !== fn)
+  }
+}
+
+export function isUnlocked(): boolean {
+  return cached !== null
+}
+
+/** Internal to services/secrets. */
+export function peekKek(): { kek: number[]; kekId: string } | null {
+  return cached ? { kek: cached.kek, kekId: cached.kekId } : null
+}
+
+/* ------------------------------- sentinel -------------------------------- */
+
+export async function readSentinel(): Promise<KekSentinel | null> {
+  try {
+    const raw = await SecureStore.getItemAsync(SENTINEL_KEY, envOptions)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as KekSentinel
+    return parsed?.v === 1 && typeof parsed.kekId === 'string' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+async function writeSentinel(s: KekSentinel): Promise<void> {
+  await SecureStore.setItemAsync(SENTINEL_KEY, JSON.stringify(s), envOptions)
+}
+
+export async function recordSecretName(name: SecretName): Promise<void> {
+  const s = await readSentinel()
+  if (!s || s.names.includes(name)) return
+  await writeSentinel({ ...s, names: [...s.names, name] })
+}
+
+export async function forgetSecretName(name: SecretName): Promise<void> {
+  const s = await readSentinel()
+  if (!s || !s.names.includes(name)) return
+  await writeSentinel({ ...s, names: s.names.filter(n => n !== name) })
+}
+
+/* ----------------------------- error mapping ------------------------------ */
+
+/**
+ * Neither platform gives us a usable numeric code through this module — iOS
+ * drops the OSStatus from its message and Android collapses distinct failures
+ * into shared strings — so this is string matching, and it is brittle by
+ * necessity. Re-check it whenever expo-secure-store is bumped.
+ *
+ * The default is deliberately benign. An unrecognised error becomes
+ * `cancelled`, which renders as a retry button; classifying an unknown as
+ * `unavailable` would show a dead-end "this device can't do this" screen for
+ * something as ordinary as the app being backgrounded mid-sheet.
+ */
+export function classifyAuthError(err: unknown): UnlockState {
+  const msg = String((err as Error)?.message ?? err ?? '')
+  const unavailable = (reason: UnavailableReason): UnlockState => ({ status: 'unavailable', reason })
+
+  if (/cancel/i.test(msg)) return { status: 'cancelled' }
+  if (/lockout|too many attempts/i.test(msg)) return unavailable('lockout')
+  if (/no biometrics|not currently enrolled|no user authentication method|passcode/i.test(msg)) {
+    return unavailable('not-enrolled')
+  }
+  if (/no hardware|not available|unsupported/i.test(msg)) return unavailable('no-hardware')
+  if (/foreground|FragmentActivity/i.test(msg)) return unavailable('not-foregrounded')
+  return { status: 'cancelled' }
+}
+
+/* ------------------------------ provisioning ------------------------------ */
+
+/**
+ * Mint a KEK for a device that has none. Returns it already cached — we never
+ * read back what we just wrote, because on an authenticated item that would be
+ * a second prompt.
+ */
+export async function provisionKek(): Promise<UnlockState> {
+  const resolved = await resolveProvisioningPolicy()
+  const kek = generateKek()
+  const kekId = generateKekId()
+
+  // Delete-then-add, never blind-write: writing over an existing item takes
+  // iOS's update path, which prompts a second time on an ACL item.
+  await deleteBothKekItems()
+
+  try {
+    await SecureStore.setItemAsync(
+      resolved.keyName,
+      Utils.toHex(kek),
+      kekOptions(resolved.requireAuthentication)
+    )
+  } catch (err) {
+    return setState(classifyAuthError(err))
+  }
+
+  await writeSentinel({
+    v: 1,
+    kekId,
+    policy: resolved.policy,
+    provisionedAt: Date.now(),
+    names: []
+  })
+
+  cached = { kek, kekId, policy: resolved.policy }
+  return setState({ status: 'unlocked', kekId, policy: resolved.policy })
+}
+
+async function deleteBothKekItems(): Promise<void> {
+  // Deletion never prompts on either platform.
+  await SecureStore.deleteItemAsync(KEK_AUTH_KEY, kekOptions(true)).catch(() => {})
+  await SecureStore.deleteItemAsync(KEK_PLAIN_KEY, kekOptions(false)).catch(() => {})
+}
+
+/* --------------------------------- unlock --------------------------------- */
+
+/**
+ * Release the KEK, prompting at most once per process.
+ *
+ * Never mints a key: if a sentinel exists and the KEK does not, the OS
+ * destroyed it (biometric re-enrolment, screen-lock removal, reinstall) and the
+ * honest answer is `lost`, not a silent fresh start that would strand the
+ * user's coins behind an envelope nobody can open.
+ */
+export async function unlockKek(promptMessage?: string): Promise<UnlockState> {
+  if (cached) {
+    return setState({ status: 'unlocked', kekId: cached.kekId, policy: cached.policy })
+  }
+  // Single-flight: Android throws outright on a concurrent prompt.
+  if (inFlight) return inFlight
+
+  inFlight = doUnlock(promptMessage).finally(() => {
+    inFlight = null
+  })
+  return inFlight
+}
+
+/** Auto-unlock at most once per process. After a cancellation or an
+ * unavailable device we stop initiating, so the user is never trapped in a
+ * prompt loop — but the first cold-start unlock stays implicit, which is what
+ * keeps the existing UX (one sheet, no extra tap). */
+export async function autoUnlockKek(promptMessage?: string): Promise<UnlockState> {
+  if (cached) return unlockKek(promptMessage)
+  if (autoUnlockSpent) return state
+  autoUnlockSpent = true
+  return unlockKek(promptMessage)
+}
+
+async function doUnlock(promptMessage?: string): Promise<UnlockState> {
+  const sentinel = await readSentinel()
+  // No sentinel: nothing was ever stored. Touch SecureStore at all here and a
+  // brand-new user would get a biometric sheet on the welcome screen.
+  if (!sentinel) return setState({ status: 'absent' })
+  if (sentinel.names.length === 0) return setState({ status: 'absent' })
+
+  setState({ status: 'unlocking' })
+
+  const resolved = policyFor(sentinel.policy)
+  let raw: string | null
+  try {
+    raw = await SecureStore.getItemAsync(
+      resolved.keyName,
+      kekOptions(resolved.requireAuthentication, promptMessage)
+    )
+  } catch (err) {
+    return setState(classifyAuthError(err))
+  }
+
+  // A sentinel with no key means the OS threw the key away. Both platforms
+  // report that as a plain null, which is why the sentinel has to exist.
+  if (raw === null) return setState({ status: 'lost' })
+
+  cached = { kek: Utils.toArray(raw, 'hex') as number[], kekId: sentinel.kekId, policy: sentinel.policy }
+
+  // A production build must not keep running on a KEK that a development
+  // build provisioned without OS enforcement.
+  if (await needsUpgrade(sentinel.policy)) {
+    const upgraded = await upgradeToBiometric(sentinel)
+    if (upgraded) return setState(upgraded)
+  }
+
+  return setState({ status: 'unlocked', kekId: sentinel.kekId, policy: cached.policy })
+}
+
+/**
+ * Re-wrap the same KEK value under an authenticated item. The envelope blobs
+ * are untouched because the KEK itself does not change.
+ */
+export async function upgradeToBiometric(sentinel: KekSentinel): Promise<UnlockState | null> {
+  if (!cached) return null
+  try {
+    await SecureStore.deleteItemAsync(KEK_AUTH_KEY, kekOptions(true)).catch(() => {})
+    await SecureStore.setItemAsync(KEK_AUTH_KEY, Utils.toHex(cached.kek), kekOptions(true))
+    await writeSentinel({ ...sentinel, policy: 'biometric' })
+    await SecureStore.deleteItemAsync(KEK_PLAIN_KEY, kekOptions(false)).catch(() => {})
+    cached = { ...cached, policy: 'biometric' }
+    return { status: 'unlocked', kekId: cached.kekId, policy: 'biometric' }
+  } catch {
+    // Leave the install exactly as it was; we still hold the KEK in memory for
+    // this session and will retry the upgrade on the next launch.
+    return null
+  }
+}
+
+/* -------------------------------- teardown -------------------------------- */
+
+/** Prompt-free, and works while locked or lost — otherwise a user whose
+ * biometrics changed could never log out. */
+export async function destroyKek(): Promise<void> {
+  cached = null
+  autoUnlockSpent = false
+  await deleteBothKekItems()
+  await SecureStore.deleteItemAsync(SENTINEL_KEY, envOptions).catch(() => {})
+  setState({ status: 'absent' })
+}
+
+/** Drop the in-memory copy without touching storage (e.g. explicit re-lock). */
+export function lockKek(): void {
+  cached = null
+  autoUnlockSpent = false
+  setState({ status: 'locked' })
+}
+
+export function __resetForTests(): void {
+  cached = null
+  inFlight = null
+  listeners = []
+  autoUnlockSpent = false
+  state = { status: 'locked' }
+}
+
+export { ENV_SERVICE }

--- a/services/secrets/migration.ts
+++ b/services/secrets/migration.ts
@@ -1,0 +1,188 @@
+/**
+ * One-time migration of the plaintext-in-SecureStore wallet keys into the
+ * envelope.
+ *
+ * Ordering is the whole design here. The only irreversible step is deleting the
+ * legacy plaintext, and it happens strictly after the ciphertexts have been
+ * written AND read back AND decrypted successfully. There is no window in which
+ * the plaintext is gone and the envelope is unproven, so a crash or a denied
+ * prompt at any point leaves the user on the old scheme rather than bricked.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import * as SecureStore from 'expo-secure-store'
+import { openSecret, sealSecret } from './envelope'
+import { destroyKek, peekKek, provisionKek, readSentinel, recordSecretName } from './kek'
+import { envKey, envOptions } from './storage'
+import { EnvelopeBlob, SECRET_NAMES, SecretName } from './types'
+
+/** Keys written by the pre-envelope LocalStorageProvider. */
+const LEGACY_KEYS: Record<SecretName, string> = {
+  mnemonic: 'mnemonic',
+  recoveredKey: 'recoveredKey'
+}
+/** Had no consumers anywhere in the app: swept, never migrated. */
+const LEGACY_PASSWORD_KEY = 'password'
+const LEGACY_HAS_KEYS_FLAG = 'hasWalletKeys'
+
+const FAILURE_COUNT_KEY = 'secrets.migration.failures'
+const MAX_ATTEMPTS = 3
+
+export type MigrationResult =
+  | { outcome: 'not-needed' }
+  | { outcome: 'migrated'; names: SecretName[] }
+  | { outcome: 'failed'; stage: string; retryable: boolean }
+
+/** Reads a legacy plaintext item. Prompt-free — these were always written
+ * unauthenticated. Kept exported so the provider can still serve a session
+ * whose migration failed, instead of showing the user an empty wallet. */
+export async function readLegacySecret(name: SecretName): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(LEGACY_KEYS[name])
+  } catch {
+    return null
+  }
+}
+
+export async function hasLegacySecrets(): Promise<boolean> {
+  for (const name of SECRET_NAMES) {
+    if (await readLegacySecret(name)) return true
+  }
+  return false
+}
+
+/**
+ * Delete the legacy items and verify they are actually gone.
+ *
+ * iOS's delete discards every OSStatus and never throws, so "it returned" is
+ * not evidence. If a legacy plaintext survived here the whole migration would
+ * be cosmetic — the old unauthenticated item shadows the new one on read.
+ */
+export async function sweepLegacyKeys(): Promise<boolean> {
+  const keys = [...Object.values(LEGACY_KEYS), LEGACY_PASSWORD_KEY]
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    for (const key of keys) {
+      await SecureStore.deleteItemAsync(key).catch(() => {})
+    }
+    let remaining = 0
+    for (const key of keys) {
+      try {
+        if ((await SecureStore.getItemAsync(key)) !== null) remaining++
+      } catch {
+        /* unreadable is as good as gone */
+      }
+    }
+    if (remaining === 0) {
+      await AsyncStorage.removeItem(LEGACY_HAS_KEYS_FLAG).catch(() => {})
+      return true
+    }
+  }
+  console.warn('[secrets] legacy plaintext survived deletion')
+  return false
+}
+
+async function rollback(written: SecretName[]): Promise<void> {
+  for (const name of written) {
+    await SecureStore.deleteItemAsync(envKey(name), envOptions).catch(() => {})
+  }
+  // Removes the KEK and the sentinel; the legacy plaintext is untouched.
+  await destroyKek()
+}
+
+async function bumpFailures(): Promise<number> {
+  const raw = await AsyncStorage.getItem(FAILURE_COUNT_KEY)
+  const next = (Number(raw) || 0) + 1
+  await AsyncStorage.setItem(FAILURE_COUNT_KEY, String(next))
+  return next
+}
+
+export async function migrationAttemptsExhausted(): Promise<boolean> {
+  const raw = await AsyncStorage.getItem(FAILURE_COUNT_KEY)
+  return (Number(raw) || 0) >= MAX_ATTEMPTS
+}
+
+export async function migrateLegacySecrets(): Promise<MigrationResult> {
+  // Step 0 — idempotence. A committed sentinel means we already migrated;
+  // sweeping here is what makes a crash between commit and delete harmless.
+  const existing = await readSentinel()
+  if (existing && existing.names.length > 0) {
+    await sweepLegacyKeys()
+    return { outcome: 'not-needed' }
+  }
+
+  // Step 1 — read the legacy plaintext. Zero prompts: these are unauthenticated.
+  const legacy: Partial<Record<SecretName, string>> = {}
+  for (const name of SECRET_NAMES) {
+    const value = await readLegacySecret(name)
+    if (value) legacy[name] = value
+  }
+  const names = Object.keys(legacy) as SecretName[]
+
+  // Step 2 — nothing to migrate. Provisioning happens naturally at onboarding.
+  if (names.length === 0) {
+    await sweepLegacyKeys()
+    return { outcome: 'not-needed' }
+  }
+
+  if (await migrationAttemptsExhausted()) {
+    return { outcome: 'failed', stage: 'attempts-exhausted', retryable: false }
+  }
+
+  // Step 3 — mint the KEK. Costs one prompt on Android, none on iOS.
+  const provisioned = await provisionKek()
+  if (provisioned.status !== 'unlocked') {
+    await bumpFailures()
+    return {
+      outcome: 'failed',
+      stage: 'provision',
+      retryable: provisioned.status === 'cancelled'
+    }
+  }
+  const held = peekKek()
+  if (!held) {
+    await bumpFailures()
+    return { outcome: 'failed', stage: 'provision', retryable: true }
+  }
+
+  // Step 4 — seal and write.
+  const written: SecretName[] = []
+  try {
+    for (const name of names) {
+      const blob = sealSecret(held.kek, held.kekId, name, legacy[name] as string)
+      await SecureStore.setItemAsync(envKey(name), JSON.stringify(blob), envOptions)
+      written.push(name)
+    }
+  } catch (err) {
+    console.warn('[secrets] migration write failed', (err as Error)?.message)
+    await rollback(written)
+    await bumpFailures()
+    return { outcome: 'failed', stage: 'write', retryable: true }
+  }
+
+  // Step 5 — prove the envelope before trusting it.
+  try {
+    for (const name of names) {
+      const raw = await SecureStore.getItemAsync(envKey(name), envOptions)
+      if (!raw) throw new Error(`blob missing for ${name}`)
+      const opened = openSecret(held.kek, name, JSON.parse(raw) as EnvelopeBlob)
+      if (opened !== legacy[name]) throw new Error(`round-trip mismatch for ${name}`)
+    }
+  } catch (err) {
+    console.warn('[secrets] migration verification failed', (err as Error)?.message)
+    await rollback(written)
+    await bumpFailures()
+    return { outcome: 'failed', stage: 'verify', retryable: true }
+  }
+
+  // Step 6 — commit. A sentinel only counts once it names a secret, so this is
+  // the point of no return, and it comes after verification.
+  for (const name of names) {
+    await recordSecretName(name)
+  }
+
+  // Step 7 — the irreversible bit.
+  await sweepLegacyKeys()
+  await AsyncStorage.removeItem(FAILURE_COUNT_KEY).catch(() => {})
+
+  return { outcome: 'migrated', names }
+}

--- a/services/secrets/policy.ts
+++ b/services/secrets/policy.ts
@@ -1,0 +1,120 @@
+/**
+ * Which protection class the KEK gets on this device and this build.
+ *
+ * expo-local-authentication is used here as a *capability probe only*. It must
+ * never be used to gate access to a secret: its authenticateAsync builds a
+ * throwaway LAContext that is never handed to Security.framework, and on
+ * Android it authenticates with no CryptoObject, so it unlocks no Keystore key.
+ * A passed LocalAuthentication check proves nothing about the enclave. The only
+ * ceremony that counts is the one SecureStore itself triggers when reading an
+ * item written with requireAuthentication.
+ */
+import * as LocalAuthentication from 'expo-local-authentication'
+import { KekPolicy } from './types'
+
+/** ALWAYS written with requireAuthentication: true. */
+export const KEK_AUTH_KEY = 'kekAuthV1'
+/** ALWAYS written with requireAuthentication: false. */
+export const KEK_PLAIN_KEY = 'kekPlainV1'
+
+export interface ResolvedPolicy {
+  policy: KekPolicy
+  keyName: string
+  requireAuthentication: boolean
+  /** Show the "no biometric protection on this device" disclosure. */
+  disclose: boolean
+}
+
+const BIOMETRIC: ResolvedPolicy = {
+  policy: 'biometric',
+  keyName: KEK_AUTH_KEY,
+  requireAuthentication: true,
+  disclose: false
+}
+
+const DEGRADED: ResolvedPolicy = {
+  policy: 'degraded',
+  keyName: KEK_PLAIN_KEY,
+  requireAuthentication: false,
+  disclose: true
+}
+
+const DEV_PLAIN: ResolvedPolicy = {
+  policy: 'dev-plain',
+  keyName: KEK_PLAIN_KEY,
+  requireAuthentication: false,
+  disclose: true
+}
+
+export function policyFor(policy: KekPolicy): ResolvedPolicy {
+  switch (policy) {
+    case 'biometric':
+      return BIOMETRIC
+    case 'degraded':
+      return DEGRADED
+    case 'dev-plain':
+      return DEV_PLAIN
+  }
+}
+
+/**
+ * True when the device can actually satisfy an OS biometric ceremony.
+ *
+ * getEnrolledLevelAsync is the only correct probe here. hasHardwareAsync
+ * returns true on an unenrolled simulator, and isEnrolledAsync returns true
+ * under biometric lockout on iOS and only checks the *weak* class on Android —
+ * while the Keystore key we mint requires BIOMETRIC_STRONG, so a weak-only
+ * device would hard-fail provisioning.
+ */
+export async function hasStrongBiometrics(): Promise<boolean> {
+  try {
+    const level = await LocalAuthentication.getEnrolledLevelAsync()
+    return level === LocalAuthentication.SecurityLevel.BIOMETRIC_STRONG
+  } catch {
+    return false
+  }
+}
+
+/** Copy helper: "Face ID" vs "Touch ID" vs "fingerprint". */
+export async function biometricKind(): Promise<'face' | 'fingerprint' | 'iris' | 'unknown'> {
+  try {
+    const types = await LocalAuthentication.supportedAuthenticationTypesAsync()
+    if (types.includes(LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION)) return 'face'
+    if (types.includes(LocalAuthentication.AuthenticationType.FINGERPRINT)) return 'fingerprint'
+    if (types.includes(LocalAuthentication.AuthenticationType.IRIS)) return 'iris'
+    return 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+/**
+ * Policy for minting a NEW KEK.
+ *
+ * Production with strong biometrics is the only path that yields `biometric`;
+ * everything else degrades, and degradation is always disclosed. Development
+ * builds without biometrics get `dev-plain` so simulators and CI still work —
+ * that branch lives behind __DEV__, which Metro folds out of release bundles,
+ * so it is not merely unreachable in production, it is not present.
+ */
+export async function resolveProvisioningPolicy(): Promise<ResolvedPolicy> {
+  const strong = await hasStrongBiometrics()
+  if (strong) return BIOMETRIC
+  return __DEV__ ? DEV_PLAIN : DEGRADED
+}
+
+/**
+ * Whether an EXISTING install's recorded policy is still acceptable.
+ *
+ * This closes a hole that needs no attacker: a dev build and a release build
+ * share a bundle id, hence one keychain. A developer or internal tester who
+ * runs a dev build first legitimately provisions `dev-plain`, and the release
+ * build installed over it would otherwise read that unauthenticated KEK with
+ * no prompt at all. In production, any non-biometric policy on a device that
+ * *can* do biometrics must be re-wrapped before the KEK is honoured.
+ */
+export async function needsUpgrade(current: KekPolicy): Promise<boolean> {
+  if (current === 'biometric') return false
+  if (__DEV__) return false
+  return hasStrongBiometrics()
+}

--- a/services/secrets/storage.ts
+++ b/services/secrets/storage.ts
@@ -1,0 +1,54 @@
+/**
+ * SecureStore placement for the envelope scheme.
+ *
+ * Two separate keychain services, deliberately:
+ *
+ *  - `bsvb.kek.v1`     holds only the KEK. On Android this bounds the blast
+ *                      radius of the module's own invalidation cleanup, which
+ *                      wipes entries under a keychainService.
+ *  - `bsvb.secrets.v1` holds the inert ciphertexts and the sentinel, always
+ *                      unauthenticated so reading them never shows a prompt.
+ *
+ * Never change these constants. Changing keychainService orphans existing
+ * items, and changing keychainAccessible on an existing item is a silent no-op
+ * on iOS — the update path writes only the value.
+ */
+import * as SecureStore from 'expo-secure-store'
+
+export const KEK_SERVICE = 'bsvb.kek.v1'
+export const ENV_SERVICE = 'bsvb.secrets.v1'
+
+export const SENTINEL_KEY = 'secretsSentinelV1'
+
+export const envKey = (name: string) => `envV1.${name}`
+
+/**
+ * Options for the KEK item.
+ *
+ * WHEN_UNLOCKED_THIS_DEVICE_ONLY rather than AFTER_FIRST_UNLOCK: a biometric
+ * sheet cannot run on a locked device anyway, so the weaker class buys nothing.
+ * ALWAYS* would throw when combined with an access-control flag.
+ */
+export function kekOptions(
+  requireAuthentication: boolean,
+  authenticationPrompt?: string
+): SecureStore.SecureStoreOptions {
+  return {
+    keychainService: KEK_SERVICE,
+    requireAuthentication,
+    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    ...(authenticationPrompt ? { authenticationPrompt } : {})
+  }
+}
+
+/**
+ * Options for ciphertexts and the sentinel. requireAuthentication is false and
+ * must stay false — these are useless without the KEK, and making them
+ * authenticated would cost a prompt per read, which is the whole thing we are
+ * avoiding.
+ */
+export const envOptions: SecureStore.SecureStoreOptions = {
+  keychainService: ENV_SERVICE,
+  requireAuthentication: false,
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
+}

--- a/services/secrets/store.ts
+++ b/services/secrets/store.ts
@@ -1,0 +1,125 @@
+/**
+ * Read/write wallet secrets through the envelope.
+ *
+ * Every operation here except the first unlock is prompt-free, because the
+ * ciphertexts are unauthenticated items and the KEK is already in memory.
+ *
+ * SECURITY: never log values passed through these functions.
+ */
+import * as SecureStore from 'expo-secure-store'
+import { openSecret, sealSecret, assertKekId } from './envelope'
+import {
+  destroyKek,
+  forgetSecretName,
+  peekKek,
+  provisionKek,
+  readSentinel,
+  recordSecretName,
+  unlockKek
+} from './kek'
+import { envKey, envOptions } from './storage'
+import { EnvelopeBlob, EnvelopeError, SECRET_NAMES, SecretName } from './types'
+
+/**
+ * Is there a wrapped secret of this name? Prompt-free and works while locked.
+ *
+ * Note this is not strictly side-effect-free on Android: reading a blob whose
+ * unauthenticated Keystore alias has gone missing makes the native module drop
+ * the stale ciphertext. Harmless — it was already unopenable — but don't call
+ * it speculatively in a hot path.
+ */
+export async function hasSecret(name: SecretName): Promise<boolean> {
+  try {
+    return (await SecureStore.getItemAsync(envKey(name), envOptions)) !== null
+  } catch {
+    return false
+  }
+}
+
+export async function hasAnySecret(): Promise<boolean> {
+  for (const name of SECRET_NAMES) {
+    if (await hasSecret(name)) return true
+  }
+  return false
+}
+
+/**
+ * Returns null when locked. It deliberately does NOT unlock implicitly — the
+ * one automatic unlock per process is initiated from the wallet-build effect,
+ * where a prompt is expected, not from whichever screen happens to read a
+ * secret first.
+ */
+export async function getSecret(name: SecretName): Promise<string | null> {
+  const held = peekKek()
+  if (!held) return null
+
+  let raw: string | null
+  try {
+    raw = await SecureStore.getItemAsync(envKey(name), envOptions)
+  } catch (err) {
+    console.warn('[secrets] read failed', name, (err as Error)?.message)
+    return null
+  }
+  if (!raw) return null
+
+  try {
+    const blob = JSON.parse(raw) as EnvelopeBlob
+    assertKekId(blob, held.kekId)
+    return openSecret(held.kek, name, blob)
+  } catch (err) {
+    const code = err instanceof EnvelopeError ? err.code : 'corrupt'
+    console.warn('[secrets] could not open envelope', name, code)
+    return null
+  }
+}
+
+/**
+ * Seal and store. Provisions a KEK on first use, which is the only moment a
+ * write can prompt (and only on Android, where minting an auth-bound key
+ * requires a ceremony).
+ */
+export async function putSecret(name: SecretName, value: string): Promise<boolean> {
+  let held = peekKek()
+
+  if (!held) {
+    const sentinel = await readSentinel()
+    const result = sentinel ? await unlockKek() : await provisionKek()
+    if (result.status !== 'unlocked') return false
+    held = peekKek()
+    if (!held) return false
+  }
+
+  try {
+    const blob = sealSecret(held.kek, held.kekId, name, value)
+    await SecureStore.setItemAsync(envKey(name), JSON.stringify(blob), envOptions)
+    await recordSecretName(name)
+    return true
+  } catch (err) {
+    console.warn('[secrets] write failed', name, (err as Error)?.message)
+    return false
+  }
+}
+
+/** Prompt-free, and works while locked or lost: deleting ciphertext needs no
+ * key. This is what makes logout possible for a user whose biometrics changed. */
+export async function deleteSecret(name: SecretName): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(envKey(name), envOptions)
+    await forgetSecretName(name)
+  } catch (err) {
+    console.warn('[secrets] delete failed', name, (err as Error)?.message)
+  }
+}
+
+/** Removes every wrapped secret and the KEK itself, so the next launch reads
+ * as a clean install rather than prompting for a wallet that no longer exists. */
+export async function deleteAllSecrets(): Promise<void> {
+  for (const name of SECRET_NAMES) {
+    try {
+      await SecureStore.deleteItemAsync(envKey(name), envOptions)
+    } catch {
+      /* best effort — destroyKek below is what matters */
+    }
+  }
+  await destroyKek()
+}

--- a/services/secrets/types.ts
+++ b/services/secrets/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Wallet-secret domain types — shared by the envelope crypto, the KEK holder,
+ * the store and the migration. No React, no I/O.
+ *
+ * Threat model in one line: the mnemonic must be undecryptable without a live
+ * OS biometric ceremony, so that patching JavaScript buys an attacker nothing.
+ */
+
+/** The secrets that are wrapped under the KEK. `password` is deliberately
+ * absent — it had no consumers and is swept, not migrated. */
+export type SecretName = 'mnemonic' | 'recoveredKey'
+
+export const SECRET_NAMES: SecretName[] = ['mnemonic', 'recoveredKey']
+
+/**
+ * A wrapped secret. Mirrors the vault's SealedBlob conventions
+ * (services/vault/types.ts): version-as-literal, all binary as hex.
+ *
+ * The blob is stored unauthenticated and is inert on its own — opening it
+ * requires the KEK, which only the Secure Enclave / Keystore can release.
+ */
+export interface EnvelopeBlob {
+  v: 1
+  /** hex(8B) — which KEK sealed this, so a stale blob fails loudly. */
+  kekId: string
+  /** hex(32B) — per-blob HKDF salt. */
+  salt: string
+  /** AES-256-GCM ciphertext (SymmetricKey wire format: iv||ct||tag), hex. */
+  c: string
+}
+
+/**
+ * How the KEK is protected on this install.
+ * - `biometric`  — SecureStore item with requireAuthentication: OS-enforced.
+ * - `degraded`   — production device with no strong biometrics; keystore-only.
+ * - `dev-plain`  — development builds without biometrics. Never valid in prod.
+ */
+export type KekPolicy = 'biometric' | 'degraded' | 'dev-plain'
+
+/**
+ * Non-secret marker recording that an envelope exists.
+ *
+ * Its only jobs are to distinguish "key destroyed by the OS" from "no wallet
+ * here" and to select the KEK key name. It is NOT a security control: no
+ * sentinel value can cause an authenticated item to be read without auth.
+ *
+ * Stored in SecureStore (unauthenticated), NOT AsyncStorage, so its lifetime
+ * matches the blobs' on both platforms — an iOS reinstall keeps keychain items
+ * but wipes AsyncStorage, which would otherwise desynchronise the two.
+ */
+export interface KekSentinel {
+  v: 1
+  kekId: string
+  policy: KekPolicy
+  provisionedAt: number
+  names: SecretName[]
+}
+
+export type UnavailableReason = 'no-hardware' | 'not-enrolled' | 'lockout' | 'not-foregrounded'
+
+export type UnlockState =
+  /** No sentinel: nothing has ever been stored on this device. */
+  | { status: 'absent' }
+  /** Sentinel present, KEK not yet released this process. */
+  | { status: 'locked' }
+  | { status: 'unlocking' }
+  | { status: 'unlocked'; kekId: string; policy: KekPolicy }
+  /** User dismissed the sheet. Retryable, nothing was touched. */
+  | { status: 'cancelled' }
+  | { status: 'unavailable'; reason: UnavailableReason }
+  /** Sentinel present but the KEK is gone — the OS destroyed it. Unrecoverable
+   * on-device; the user must restore from their recovery phrase. */
+  | { status: 'lost' }
+
+export type EnvelopeErrorCode = 'bad-version' | 'kek-mismatch' | 'corrupt'
+
+export class EnvelopeError extends Error {
+  constructor(
+    public readonly code: EnvelopeErrorCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'EnvelopeError'
+  }
+}


### PR DESCRIPTION
## The problem

Biometric unlock was advisory. `ensureAuth()` called `LocalAuthentication.authenticateAsync()`, cached the boolean for the process lifetime, and the read path then called `SecureStore.getItemAsync()` unconditionally:

```ts
if (!hasKeys) return null
if (!(await ensureAuth(i18n.t('biometric_load_wallet')))) return null
return await SecureStore.getItemAsync(MNEMONIC_KEY)   // nothing about this read is gated
```

Two independent operations: ask the OS whether a human was present, then read the keychain regardless. Items were written with `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY` and `requireAuthentication` appeared nowhere in the repo, so the OS never conditioned decryption on user presence. Patching the boolean — or reading the keychain on an unlocked device — yielded the mnemonic. The `authenticatedRef` latch also never expired: no timeout, no `AppState` reset, so one unlock covered the whole process.

## The approach

`services/secrets/` stores one random 32-byte KEK with `requireAuthentication: true`, and keeps the mnemonic and recovered key as AES-256-GCM ciphertext in ordinary unauthenticated storage. The single ceremony per process is now the KEK read itself rather than a check preceding an unconditional read, so skipping it yields ciphertext.

The envelope is not stylistic. Reading the pinned native source, both platforms prompt *per authenticated operation* — iOS `searchKeyChain` sets no `kSecUseAuthenticationContext` and shares no `LAContext`; Android binds a fresh `CryptoObject` per use and sets no validity duration. Putting `requireAuthentication` directly on the mnemonic would have prompted on every read. Wrapping one key is what keeps "one check at wallet instantiation" affordable while making the check real.

## Notable decisions

- **Biometrics-only came free and is not opt-out-able.** iOS hardcodes `.biometryCurrentSet`; Android allows `BIOMETRIC_STRONG` only. Neither accepts a device PIN as a substitute, and no JS option loosens it.
- **Devices without strong biometrics** get a keystore-only KEK under a *different key name*, disclosed rather than silent. Development builds degrade the same way behind `__DEV__`, which Metro folds out of release bundles.
- **A production build refuses to honour a non-biometric KEK** on a device that can do biometrics, and re-wraps it. Dev and release builds share a bundle id and therefore one keychain, so a tester who runs a dev build first would otherwise leave a prompt-free KEK that the release build reads. This needs no attacker.
- **Distinct key names per policy, not one name with a different flag.** iOS's read path probes the unauthenticated alias first, so a plain item under the same name would shadow the authenticated one.
- **The sentinel lives in SecureStore, not AsyncStorage.** Both platforms report a destroyed key as a plain `null`, indistinguishable from "never stored", so something must record that a wallet exists. AsyncStorage would desynchronise from the blobs across an iOS reinstall, which keeps keychain items but not AsyncStorage.
- **A missing KEK reports `lost` and never mints a replacement** — silently re-minting would strand the ciphertexts behind a key nobody can match.
- **Migration** writes, reads back and decrypts the envelope before deleting any plaintext, verifies the deletion actually took (iOS's delete discards every `OSStatus` and never throws), and rolls back to the legacy scheme on any failure. The wallet-build effect waits on it, or the first launch after upgrading would report "no wallet" to an existing user and never correct itself.
- **Deletion no longer needs a key**, so a user whose biometrics changed can still log out. Logout now destroys the KEK rather than leaving an orphan that would prompt on the create-wallet screen.
- **Dropped the `SimpleWalletManager` snapshot path.** Its format prepends the encryption key to the ciphertext, so persisting one to AsyncStorage would have handed out the primary key. It had no writer anywhere in the repo's history, so nothing regresses.

## User-visible changes

Unchanged for the returning user: one Face ID / fingerprint sheet at wallet instantiation, then nothing for the rest of the process. Copying the phrase, printing shares and enrolling the vault stay prompt-free.

New, because the app previously had no failure UI at all — a failed key read silently bailed and looked like a fresh install:

- **Key destroyed** (biometrics re-enrolled, screen lock removed, reinstall) → an explicit screen offering restore-from-phrase. Nothing auto-wipes; restoring is a confirmed act.
- **Prompt dismissed** → a retry button; the browser stays usable and nothing is touched.
- **Biometric lockout** → copy telling the user to unlock their phone first.

Onboarding copy that claimed "Your recovery phrase is protected by Face ID / device biometrics" has been corrected — it now says what is true and warns that a biometric change destroys the key.

## Trade-off worth an explicit decision

Availability gets worse, deliberately. Adding a fingerprint or repairing a screen destroys the KEK, and the recovery phrase becomes the only way back in. For a low-value wallet that is the intended trade, but it rests on users actually having written the phrase down. Gating migration behind the acknowledgement checkbox the new-wallet flow already uses, and/or adding a passphrase-wrapped second envelope of the KEK, are product calls left open here.

## Testing

- 49 new tests across `__tests__/secrets/`, covering exact prompt counts, `lost` vs `cancelled` vs `absent`, sentinel tampering, the dev-KEK-in-production upgrade, and migration ordering and rollback.
- Full suite: 818 tests / 67 suites green. Typecheck and lint clean on changed files.
- The test doubles model per-`(service, key, authMode)` entries, iOS's alias probing, prompt costs on authenticated reads *and* writes, and invalidation-as-null — a plain key/value fake cannot prove any of these properties.

Not covered by unit tests and needing a device pass before release: re-enrolling Face ID reaches the `lost` screen; a PIN-only Android device completes onboarding in `degraded`; `preview-apk`/`production-apk` take the production path; and `npx expo export` confirms `__DEV__` branches are actually folded out of the release bundle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7V5EkmF6PzoFm2nBKuKf1)_