### PR TITLE
feat(backup): encrypted wallet backup log client + @bsv/sdk 2.4.0

### DIFF
--- a/__tests__/backupClient.test.ts
+++ b/__tests__/backupClient.test.ts
@@ -1,0 +1,123 @@
+import { PrivateKey } from '@bsv/sdk'
+import { BackupClient, BackupHttpError, ERR_SEQ_CONFLICT } from '@/utils/backup/client'
+import type { BackupRequestInit } from '@/utils/backup/client'
+
+const KEY = new PrivateKey(9).toArray('be', 32)
+const DEVICE = 'a'.repeat(32)
+const BASE = 'https://backup.example.test'
+
+interface Call { url: string, init: BackupRequestInit }
+
+function clientWith (
+  respond: (call: Call) => Response
+): { client: BackupClient, calls: Call[] } {
+  const calls: Call[] = []
+  const client = new BackupClient(BASE, KEY, async (url, init) => {
+    const call = { url, init }
+    calls.push(call)
+    return respond(call)
+  })
+  return { client, calls }
+}
+
+const jsonRes = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+describe('BackupClient', () => {
+  it('posts raw octet-stream, never JSON', async () => {
+    // The server rejects anything else with 415, and JSON would cost ~4x for a payload
+    // that is mostly transaction bytes.
+    const { client, calls } = clientWith(() => jsonRes({ status: 'success', seq: 1, sha256: 'ab' }, 201))
+    await client.append(DEVICE, 1, 1, undefined, [1, 2, 3])
+
+    expect(calls[0].init.headers).toMatchObject({ 'Content-Type': 'application/octet-stream' })
+    expect(calls[0].init.body).toBeInstanceOf(Uint8Array)
+    expect(Array.from(calls[0].init.body as Uint8Array)).toEqual([1, 2, 3])
+  })
+
+  it('carries seq and generation as query parameters', async () => {
+    const { client, calls } = clientWith(() => jsonRes({ status: 'success', seq: 4, sha256: 'cd' }, 201))
+    await client.append(DEVICE, 3, 4, 'prevsha', [9])
+
+    expect(calls[0].url).toContain('seq=4')
+    expect(calls[0].url).toContain('generation=3')
+    expect(calls[0].url).toContain('prevSha256=prevsha')
+  })
+
+  it('omits prevSha256 for the first entry in a generation', async () => {
+    const { client, calls } = clientWith(() => jsonRes({ status: 'success', seq: 1, sha256: 'x' }, 201))
+    await client.append(DEVICE, 1, 1, undefined, [1])
+
+    expect(calls[0].url).not.toContain('prevSha256')
+  })
+
+  it('never sends an identity parameter on any route', async () => {
+    // The server derives the account from the authenticated session alone. Sending an
+    // identity would invite the cross-tenant bug this design exists to avoid — there is
+    // deliberately no field for one.
+    const { client, calls } = clientWith(() => jsonRes({ status: 'success', devices: [], entries: [] }))
+    await client.manifest()
+    await client.index(DEVICE, 1)
+
+    for (const call of calls) {
+      expect(call.url).not.toMatch(/identity|pseudonym|pubkey|account/i)
+      expect(call.init.body).toBeUndefined()
+    }
+  })
+
+  it('surfaces a sequence conflict with its code', async () => {
+    const { client } = clientWith(() =>
+      jsonRes({ status: 'error', code: ERR_SEQ_CONFLICT, description: 'expected seq 5, got 9' }, 409))
+
+    await expect(client.append(DEVICE, 1, 9, undefined, [1])).rejects.toThrow(/ERR_SEQ_CONFLICT/)
+    await expect(client.append(DEVICE, 1, 9, undefined, [1])).rejects.toBeInstanceOf(BackupHttpError)
+  })
+
+  it('exposes the status and code on errors', async () => {
+    const { client } = clientWith(() =>
+      jsonRes({ status: 'error', code: 'ERR_BLOB_TOO_LARGE', description: 'too big' }, 413))
+
+    await expect(client.append(DEVICE, 1, 1, undefined, [1])).rejects.toMatchObject({
+      status: 413, code: 'ERR_BLOB_TOO_LARGE'
+    })
+  })
+
+  it('returns blob bytes as number[]', async () => {
+    const { client } = clientWith(() => new Response(new Uint8Array([9, 8, 7]), { status: 200 }))
+    expect(await client.blob(DEVICE, 1, 1)).toEqual([9, 8, 7])
+  })
+
+  it('treats a missing blob as an error, not empty bytes', async () => {
+    // Silently returning [] would let a restore believe it had finished early.
+    const { client } = clientWith(() =>
+      jsonRes({ status: 'error', code: 'ERR_BLOB_NOT_FOUND', description: 'no such blob' }, 404))
+
+    await expect(client.blob(DEVICE, 1, 5)).rejects.toMatchObject({ code: 'ERR_BLOB_NOT_FOUND' })
+  })
+
+  it('defaults absent collections to empty arrays', async () => {
+    const { client } = clientWith(() => jsonRes({ status: 'success' }))
+    expect(await client.manifest()).toEqual([])
+    expect(await client.index(DEVICE, 1)).toEqual([])
+  })
+
+  it('parses a manifest', async () => {
+    const { client } = clientWith(() => jsonRes({
+      status: 'success',
+      devices: [{
+        deviceId: DEVICE, generation: 2, headSeq: 7,
+        headSha256: 'abc', totalBytes: 1024, updatedAt: '2026-08-15T00:00:00Z'
+      }]
+    }))
+
+    const [d] = await client.manifest()
+    expect(d.deviceId).toBe(DEVICE)
+    expect(d.generation).toBe(2)
+    expect(d.headSeq).toBe(7)
+  })
+
+  it('handles a non-JSON error body without masking the status', async () => {
+    const { client } = clientWith(() => new Response('<html>502</html>', { status: 502 }))
+    await expect(client.manifest()).rejects.toMatchObject({ status: 502 })
+  })
+})

--- a/__tests__/backupCodec.test.ts
+++ b/__tests__/backupCodec.test.ts
@@ -1,0 +1,122 @@
+import { PrivateKey } from '@bsv/sdk'
+import type { SyncChunk } from '@bsv/wallet-toolbox-mobile/out/src/sdk/WalletStorage.interfaces'
+import { CHUNK_ENTITIES, decodeChunk, emptyChunk, encodeChunk, isEmptyChunk } from '@/utils/backup/codec'
+import { deriveBackupWallet } from '@/utils/backup/derive'
+
+const KEY = new PrivateKey(7).toArray('be', 32)
+
+/** Every byte value, so a lossy encoding cannot slip through. */
+const ALL_BYTES = Array.from({ length: 256 }, (_, i) => i)
+
+function chunkWithBinary (): SyncChunk {
+  const base = emptyChunk('from', 'to', 'user') as unknown as Record<string, unknown>
+  base.provenTxs = [{
+    provenTxId: 1,
+    txid: 'deadbeefcafe',
+    height: 800000,
+    index: 0,
+    merklePath: ALL_BYTES,
+    rawTx: ALL_BYTES,
+    blockHash: 'abc'
+  }]
+  return base as unknown as SyncChunk
+}
+
+describe('backup chunk codec', () => {
+  it('round-trips binary fields byte-exactly', async () => {
+    const w = deriveBackupWallet(KEY)
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunkWithBinary()))
+
+    expect(decoded.provenTxs?.[0].rawTx).toEqual(ALL_BYTES)
+    expect(decoded.provenTxs?.[0].merklePath).toEqual(ALL_BYTES)
+  })
+
+  it('returns binary fields as number[], not Uint8Array', async () => {
+    // The toolbox's processSyncChunk expects number[]; handing it a typed array would
+    // fail deep inside storage rather than here.
+    const w = deriveBackupWallet(KEY)
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunkWithBinary()))
+
+    expect(Array.isArray(decoded.provenTxs?.[0].rawTx)).toBe(true)
+    expect(decoded.provenTxs?.[0].rawTx).not.toBeInstanceOf(Uint8Array)
+  })
+
+  it('packs byte arrays instead of expanding them to decimal', async () => {
+    // Without packing, binaryJsonReplacer ignores number[] — every binary field on the
+    // toolbox's tables is typed number[] — and each byte costs ~2.9 characters as decimal
+    // against ~1.37 as base64. On a realistically sized transaction the payload should
+    // therefore land near half the naive size; 0.7 leaves room for the JSON envelope and
+    // the 48-byte AES-GCM overhead without making the test meaningless.
+    const w = deriveBackupWallet(KEY)
+    const chunk = emptyChunk('a', 'b', 'c') as unknown as Record<string, unknown>
+    const rawTx = Array.from({ length: 2048 }, (_, i) => i % 256)
+    chunk.provenTxs = [{ provenTxId: 1, txid: 'ab', height: 1, index: 0, rawTx, merklePath: rawTx }]
+
+    const packed = (await encodeChunk(w, chunk as unknown as SyncChunk)).length
+    const naive = JSON.stringify(chunk).length
+
+    expect(packed).toBeLessThan(naive * 0.7)
+  })
+
+  it('preserves all twelve entity arrays', async () => {
+    // The toolbox's consumer loops forever on an undefined entity array rather than
+    // treating it as empty, so every one must survive the round trip.
+    const w = deriveBackupWallet(KEY)
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunkWithBinary())) as unknown as Record<string, unknown>
+
+    for (const name of CHUNK_ENTITIES) {
+      expect(Array.isArray(decoded[name])).toBe(true)
+    }
+  })
+
+  it('leaves short numeric arrays untouched in value', async () => {
+    const w = deriveBackupWallet(KEY)
+    const chunk = emptyChunk('a', 'b', 'c') as unknown as Record<string, unknown>
+    chunk.outputs = [{ outputId: 1, tags: [1, 2, 3], vout: 0 }]
+
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunk as unknown as SyncChunk)) as unknown as Record<string, any>
+    expect(decoded.outputs[0].tags).toEqual([1, 2, 3])
+  })
+
+  it('round-trips a long non-byte numeric array unchanged', async () => {
+    // Values above 255 must not be mistaken for bytes.
+    const w = deriveBackupWallet(KEY)
+    const big = Array.from({ length: 64 }, (_, i) => 1000 + i)
+    const chunk = emptyChunk('a', 'b', 'c') as unknown as Record<string, unknown>
+    chunk.outputs = [{ heights: big }]
+
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunk as unknown as SyncChunk)) as unknown as Record<string, any>
+    expect(decoded.outputs[0].heights).toEqual(big)
+  })
+
+  it('round-trips a byte-like id array losslessly', async () => {
+    // A long array of small integers is packed as bytes; it must come back identical.
+    const w = deriveBackupWallet(KEY)
+    const ids = Array.from({ length: 100 }, (_, i) => i % 200)
+    const chunk = emptyChunk('a', 'b', 'c') as unknown as Record<string, unknown>
+    chunk.outputs = [{ ids }]
+
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunk as unknown as SyncChunk)) as unknown as Record<string, any>
+    expect(decoded.outputs[0].ids).toEqual(ids)
+  })
+
+  it('produces ciphertext another wallet cannot read', async () => {
+    const mine = deriveBackupWallet(KEY)
+    const theirs = deriveBackupWallet(new PrivateKey(8).toArray('be', 32))
+
+    await expect(decodeChunk(theirs, await encodeChunk(mine, chunkWithBinary()))).rejects.toThrow()
+  })
+
+  it('does not leak plaintext into the ciphertext', async () => {
+    const w = deriveBackupWallet(KEY)
+    const ct = await encodeChunk(w, chunkWithBinary())
+
+    expect(Buffer.from(ct).toString('utf8')).not.toContain('deadbeefcafe')
+    expect(Buffer.from(ct).toString('utf8')).not.toContain('provenTxs')
+  })
+
+  it('recognises an empty chunk as the completion sentinel', () => {
+    expect(isEmptyChunk(emptyChunk('a', 'b', 'c'))).toBe(true)
+    expect(isEmptyChunk(chunkWithBinary())).toBe(false)
+  })
+})

--- a/__tests__/backupDerive.test.ts
+++ b/__tests__/backupDerive.test.ts
@@ -1,0 +1,94 @@
+import { PrivateKey } from '@bsv/sdk'
+import { BACKUP_KEY_ID, BACKUP_PROTOCOL } from '@/utils/backup/constants'
+import { backupPseudonym, deriveBackupKey, deriveBackupWallet } from '@/utils/backup/derive'
+
+// A deliberately trivial, well-known test key. Never funded, never used on mainnet.
+const TEST_PRIMARY = new PrivateKey(1).toArray('be', 32)
+
+describe('backup key derivation', () => {
+  it('is deterministic for a given primaryKey', () => {
+    expect(backupPseudonym(TEST_PRIMARY)).toBe(backupPseudonym(TEST_PRIMARY))
+  })
+
+  it('produces a compressed public key in hex', () => {
+    expect(backupPseudonym(TEST_PRIMARY)).toMatch(/^0[23][0-9a-f]{64}$/)
+  })
+
+  it('differs from the wallet identity key', () => {
+    // The privacy property in one assertion: the server authenticates the pseudonym and
+    // therefore never learns the identity key the rest of the app uses.
+    const identity = new PrivateKey(TEST_PRIMARY).toPublicKey().toString()
+    expect(backupPseudonym(TEST_PRIMARY)).not.toBe(identity)
+  })
+
+  it('differs for a different primaryKey', () => {
+    expect(backupPseudonym(TEST_PRIMARY)).not.toBe(backupPseudonym(new PrivateKey(2).toArray('be', 32)))
+  })
+
+  it('MATCHES THE FROZEN VECTOR', () => {
+    // Precomputed and verified identical on @bsv/sdk 2.1.9 and 2.4.0.
+    //
+    // If this fails, DO NOT update the expected value. The constant is correct; a mismatch
+    // means derive.ts disagrees with the spec — most likely the protocol tuple, the keyID,
+    // or the counterparty. Changing it here would orphan every backup already written by a
+    // shipped build, silently.
+    expect(backupPseudonym(TEST_PRIMARY))
+      .toBe('03d7a8c57df91ccdc3704f2cc546b0c19b2dcfab5d3e0a438d2a8ae6cd3d3618b5')
+  })
+
+  it('recovers the same pseudonym from a share-restored primary key', () => {
+    // Share restore yields only the m/0'/0' WIF and no rootKey. Deriving the backup key
+    // from rootKey would silently lock this cohort out of their own backups, so this test
+    // is what pins the choice of primaryKey.
+    const shares = new PrivateKey(TEST_PRIMARY).toBackupShares(2, 3)
+    const recovered = PrivateKey.fromBackupShares([shares[0], shares[2]]).toArray()
+
+    // Compare as scalars, not byte arrays: toArray() returns the minimal big-endian form,
+    // so a leading-zero key is shorter than 32 bytes. Derivation reads the scalar, so the
+    // encoding difference is immaterial — and asserting on it would be asserting on the
+    // wrong thing.
+    expect(new PrivateKey(recovered).toHex()).toBe(new PrivateKey(TEST_PRIMARY).toHex())
+    expect(backupPseudonym(recovered)).toBe(backupPseudonym(TEST_PRIMARY))
+  })
+
+  it('derives identically from padded and minimal key encodings', () => {
+    // WalletContext's share-restore path calls recoveredKey.toArray() with no padding, so
+    // the same key can reach us in either encoding. Both must land on one pseudonym.
+    const minimal = new PrivateKey(TEST_PRIMARY).toArray()
+    expect(backupPseudonym(minimal)).toBe(backupPseudonym(TEST_PRIMARY))
+  })
+
+  it('round-trips encryption with counterparty self', async () => {
+    const w = deriveBackupWallet(TEST_PRIMARY)
+    const plaintext = [1, 2, 3, 4, 5]
+
+    const { ciphertext } = await w.encrypt({
+      plaintext, protocolID: BACKUP_PROTOCOL, keyID: BACKUP_KEY_ID, counterparty: 'self',
+    })
+    const { plaintext: out } = await w.decrypt({
+      ciphertext, protocolID: BACKUP_PROTOCOL, keyID: BACKUP_KEY_ID, counterparty: 'self',
+    })
+
+    expect(out).toEqual(plaintext)
+    expect(ciphertext).not.toEqual(plaintext)
+  })
+
+  it('produces ciphertext another wallet cannot read', async () => {
+    // What makes the store zero-knowledge: nobody without this seed can derive the key,
+    // including the server holding the ciphertext.
+    const mine = deriveBackupWallet(TEST_PRIMARY)
+    const theirs = deriveBackupWallet(new PrivateKey(9).toArray('be', 32))
+
+    const { ciphertext } = await mine.encrypt({
+      plaintext: [9, 9, 9], protocolID: BACKUP_PROTOCOL, keyID: BACKUP_KEY_ID, counterparty: 'self',
+    })
+
+    await expect(theirs.decrypt({
+      ciphertext, protocolID: BACKUP_PROTOCOL, keyID: BACKUP_KEY_ID, counterparty: 'self',
+    })).rejects.toThrow()
+  })
+
+  it('exposes the private key behind the pseudonym', () => {
+    expect(deriveBackupKey(TEST_PRIMARY).toPublicKey().toString()).toBe(backupPseudonym(TEST_PRIMARY))
+  })
+})

--- a/__tests__/backupPush.test.ts
+++ b/__tests__/backupPush.test.ts
@@ -1,0 +1,238 @@
+/* eslint-disable import/first -- jest.mock must be hoisted above the imports it affects */
+// Mocked per-file rather than via moduleNameMapper: the vault suites install their own
+// AsyncStorage mock, and a global mapper makes the resolver recurse between the two.
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {}
+  return {
+    __esModule: true,
+    default: {
+      getItem: async (k: string) => store[k] ?? null,
+      setItem: async (k: string, v: string) => { store[k] = v },
+      removeItem: async (k: string) => { delete store[k] },
+      clear: async () => { for (const k of Object.keys(store)) delete store[k] }
+    }
+  }
+})
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { PrivateKey } from '@bsv/sdk'
+import type { SyncChunk } from '@bsv/wallet-toolbox-mobile/out/src/sdk/WalletStorage.interfaces'
+import { BackupHttpError, ERR_SEQ_CONFLICT } from '@/utils/backup/client'
+import { emptyChunk } from '@/utils/backup/codec'
+import { GENERATION_CHUNK_THRESHOLD } from '@/utils/backup/constants'
+import { loadCursor, saveCursor, freshCursor, zeroOffsets } from '@/utils/backup/cursor'
+import { backupPseudonym } from '@/utils/backup/derive'
+import { pushOnce } from '@/utils/backup/push'
+
+const PRIMARY = new PrivateKey(11).toArray('be', 32)
+const IDENTITY = '02' + 'ab'.repeat(32)
+const DEVICE = 'c'.repeat(32)
+const PSEUDONYM = backupPseudonym(PRIMARY)
+
+function chunkWith (counts: { provenTxs?: number, outputs?: number }, updatedAt = '2026-08-01T00:00:00.000Z'): SyncChunk {
+  const c = emptyChunk('a', 'b', IDENTITY) as unknown as Record<string, unknown[]>
+  c.provenTxs = Array.from({ length: counts.provenTxs ?? 0 }, (_, i) => ({
+    provenTxId: i, rawTx: [1, 2, 3], updated_at: updatedAt
+  }))
+  c.outputs = Array.from({ length: counts.outputs ?? 0 }, (_, i) => ({
+    outputId: i, updated_at: updatedAt
+  }))
+  return c as unknown as SyncChunk
+}
+
+function fakeStorage (chunk: SyncChunk): { getSyncChunk: jest.Mock } {
+  return { getSyncChunk: jest.fn().mockResolvedValue(chunk) }
+}
+
+function fakeClient (over: Partial<Record<'append' | 'manifest', jest.Mock>> = {}): any {
+  return {
+    append: over.append ?? jest.fn().mockResolvedValue({ seq: 1, sha256: 'newsha' }),
+    manifest: over.manifest ?? jest.fn().mockResolvedValue([]),
+    index: jest.fn().mockResolvedValue([]),
+    blob: jest.fn(),
+    pruneGeneration: jest.fn()
+  }
+}
+
+beforeEach(async () => { await AsyncStorage.clear() })
+
+describe('pushOnce', () => {
+  it('appends nothing when the chunk is empty', async () => {
+    const client = fakeClient()
+    const r = await pushOnce({
+      storage: fakeStorage(emptyChunk('a', 'b', IDENTITY)) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client, deviceId: DEVICE
+    })
+
+    expect(client.append).not.toHaveBeenCalled()
+    expect(r.pushed).toBe(0)
+    expect(r.windowClosed).toBe(true)
+  })
+
+  it('reads the chunk directly from the storage provider with bounded sizing', async () => {
+    // Never via WalletStorageManager: updateBackups/syncToWriter take the sync lock and
+    // block every storage read and write for the duration.
+    const storage = fakeStorage(chunkWith({ provenTxs: 1 }))
+    await pushOnce({
+      storage: storage as any, primaryKey: PRIMARY, identityKey: IDENTITY,
+      client: fakeClient(), deviceId: DEVICE
+    })
+
+    expect(storage.getSyncChunk).toHaveBeenCalledWith(expect.objectContaining({
+      identityKey: IDENTITY,
+      maxRoughSize: 512_000,
+      maxItems: 200
+    }))
+  })
+
+  it('never sends the real identity key as the log address', async () => {
+    const storage = fakeStorage(chunkWith({ provenTxs: 1 }))
+    await pushOnce({
+      storage: storage as any, primaryKey: PRIMARY, identityKey: IDENTITY,
+      client: fakeClient(), deviceId: DEVICE
+    })
+
+    // identityKey is needed for the LOCAL user lookup, but the log is addressed by the
+    // pseudonym, and the two must never be the same value.
+    const args = storage.getSyncChunk.mock.calls[0][0]
+    expect(args.toStorageIdentityKey).toBe(PSEUDONYM)
+    expect(args.toStorageIdentityKey).not.toBe(IDENTITY)
+  })
+
+  it('appends the encrypted chunk and advances the cursor', async () => {
+    const client = fakeClient()
+    const r = await pushOnce({
+      storage: fakeStorage(chunkWith({ provenTxs: 2, outputs: 3 })) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client, deviceId: DEVICE
+    })
+
+    expect(r.pushed).toBe(1)
+    expect(client.append).toHaveBeenCalledWith(DEVICE, 1, 1, undefined, expect.any(Array))
+
+    const cursor = await loadCursor(PSEUDONYM, DEVICE)
+    expect(cursor.seq).toBe(1)
+    expect(cursor.prevSha256).toBe('newsha')
+    expect(cursor.offsets.provenTx).toBe(2)
+    expect(cursor.offsets.output).toBe(3)
+    expect(cursor.maxUpdatedAt).toBe('2026-08-01T00:00:00.000Z')
+  })
+
+  it('does not advance the cursor when the append fails', async () => {
+    // Advancing on failure would skip records permanently — a silent hole in the restore.
+    const client = fakeClient({ append: jest.fn().mockRejectedValue(new Error('network down')) })
+
+    await expect(pushOnce({
+      storage: fakeStorage(chunkWith({ provenTxs: 1 })) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client, deviceId: DEVICE
+    })).rejects.toThrow('network down')
+
+    const cursor = await loadCursor(PSEUDONYM, DEVICE)
+    expect(cursor.seq).toBe(0)
+    expect(cursor.offsets.provenTx).toBe(0)
+  })
+
+  it('chains prevSha256 from the previous append', async () => {
+    await saveCursor(PSEUDONYM, DEVICE, {
+      ...freshCursor(), seq: 1, prevSha256: 'oldsha', chunksInGeneration: 1
+    })
+    const client = fakeClient({ append: jest.fn().mockResolvedValue({ seq: 2, sha256: 'secondsha' }) })
+
+    await pushOnce({
+      storage: fakeStorage(chunkWith({ provenTxs: 1 })) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client, deviceId: DEVICE
+    })
+
+    expect(client.append).toHaveBeenCalledWith(DEVICE, 1, 2, 'oldsha', expect.any(Array))
+    expect((await loadCursor(PSEUDONYM, DEVICE)).prevSha256).toBe('secondsha')
+  })
+
+  it('closes the window by advancing since and zeroing offsets', async () => {
+    // Mirrors EntitySyncState: when a chunk comes back empty the window is exhausted, so
+    // `since` jumps to the greatest updated_at seen and the offsets reset.
+    await saveCursor(PSEUDONYM, DEVICE, {
+      ...freshCursor(),
+      offsets: { ...zeroOffsets(), provenTx: 5 },
+      maxUpdatedAt: '2026-08-02T00:00:00.000Z',
+      seq: 3,
+      chunksInGeneration: 3
+    })
+
+    await pushOnce({
+      storage: fakeStorage(emptyChunk('a', 'b', IDENTITY)) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client: fakeClient(), deviceId: DEVICE
+    })
+
+    const cursor = await loadCursor(PSEUDONYM, DEVICE)
+    expect(cursor.since).toBe('2026-08-02T00:00:00.000Z')
+    expect(cursor.offsets.provenTx).toBe(0)
+    expect(cursor.maxUpdatedAt).toBeUndefined()
+    expect(cursor.seq).toBe(3)
+  })
+
+  it('rotates to a new generation past the threshold, at a window boundary', async () => {
+    await saveCursor(PSEUDONYM, DEVICE, {
+      ...freshCursor(),
+      since: '2026-01-01T00:00:00.000Z',
+      seq: GENERATION_CHUNK_THRESHOLD,
+      chunksInGeneration: GENERATION_CHUNK_THRESHOLD
+    })
+
+    const r = await pushOnce({
+      storage: fakeStorage(emptyChunk('a', 'b', IDENTITY)) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client: fakeClient(), deviceId: DEVICE
+    })
+
+    expect(r.rotated).toBe(true)
+
+    // A new generation is a full snapshot: no since filter, sequence restarts at one.
+    const cursor = await loadCursor(PSEUDONYM, DEVICE)
+    expect(cursor.generation).toBe(2)
+    expect(cursor.seq).toBe(0)
+    expect(cursor.since).toBeUndefined()
+    expect(cursor.chunksInGeneration).toBe(0)
+  })
+
+  it('does not rotate mid-window', async () => {
+    // Rotating with records still pending would leave a generation that is not a coherent
+    // snapshot, which a restore could not trust.
+    await saveCursor(PSEUDONYM, DEVICE, {
+      ...freshCursor(), seq: GENERATION_CHUNK_THRESHOLD, chunksInGeneration: GENERATION_CHUNK_THRESHOLD
+    })
+
+    const r = await pushOnce({
+      storage: fakeStorage(chunkWith({ provenTxs: 1 })) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client: fakeClient(), deviceId: DEVICE
+    })
+
+    expect(r.rotated).toBe(false)
+    expect((await loadCursor(PSEUDONYM, DEVICE)).generation).toBe(1)
+  })
+
+  it('starts a fresh generation after a sequence conflict', async () => {
+    // Happens when the log outlived the cursor — a reinstall, say. Guessing which records
+    // the remote already covers risks a hole, so a fresh snapshot is the safe answer.
+    const client = fakeClient({
+      append: jest.fn().mockRejectedValue(new BackupHttpError(409, ERR_SEQ_CONFLICT, 'expected seq 7')),
+      manifest: jest.fn().mockResolvedValue([
+        { deviceId: DEVICE, generation: 4, headSeq: 6, headSha256: 'x', totalBytes: 1, updatedAt: 'z' }
+      ])
+    })
+
+    const r = await pushOnce({
+      storage: fakeStorage(chunkWith({ provenTxs: 1 })) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, client, deviceId: DEVICE
+    })
+
+    expect(r.pushed).toBe(0)
+    const cursor = await loadCursor(PSEUDONYM, DEVICE)
+    expect(cursor.generation).toBe(5)
+    expect(cursor.seq).toBe(0)
+  })
+
+  it('requires either a client or a baseUrl', async () => {
+    await expect(pushOnce({
+      storage: fakeStorage(chunkWith({ provenTxs: 1 })) as any,
+      primaryKey: PRIMARY, identityKey: IDENTITY, deviceId: DEVICE
+    })).rejects.toThrow(/client or a baseUrl/)
+  })
+})

--- a/__tests__/backupRestore.test.ts
+++ b/__tests__/backupRestore.test.ts
@@ -1,0 +1,145 @@
+import { PrivateKey } from '@bsv/sdk'
+import type { SyncChunk } from '@bsv/wallet-toolbox-mobile/out/src/sdk/WalletStorage.interfaces'
+import type { LogEntry } from '@/utils/backup/client'
+import { encodeChunk, emptyChunk, isEmptyChunk } from '@/utils/backup/codec'
+import { deriveBackupWallet } from '@/utils/backup/derive'
+import { BackupChainError, RemoteSyncReader } from '@/utils/backup/RemoteSyncReader'
+
+const PRIMARY = new PrivateKey(21).toArray('be', 32)
+const DEVICE = 'd'.repeat(32)
+const SETTINGS = { storageIdentityKey: 'local-storage-key' } as any
+
+const args = {
+  identityKey: 'ik', fromStorageIdentityKey: 'a', toStorageIdentityKey: 'b',
+  maxRoughSize: 0, maxItems: 0, offsets: []
+} as any
+
+function chunkWithTx (txid: string): SyncChunk {
+  const c = emptyChunk('a', 'b', 'user') as unknown as Record<string, unknown[]>
+  c.provenTxs = [{ provenTxId: 1, txid, rawTx: [1, 2, 3] }]
+  return c as unknown as SyncChunk
+}
+
+/** A client backed by an in-memory log, standing in for the server. */
+function fakeClient (blobs: number[][], entries?: LogEntry[]): any {
+  const index: LogEntry[] = entries ?? blobs.map((b, i) => ({
+    seq: i + 1,
+    sha256: `sha${i + 1}`,
+    prevSha256: i === 0 ? undefined : `sha${i}`,
+    size: b.length,
+    createdAt: '2026-08-15T00:00:00Z'
+  }))
+  return {
+    index: jest.fn().mockResolvedValue(index),
+    blob: jest.fn(async (_d: string, _g: number, seq: number) => blobs[seq - 1]),
+    manifest: jest.fn().mockResolvedValue([]),
+    append: jest.fn(),
+    pruneGeneration: jest.fn()
+  }
+}
+
+describe('RemoteSyncReader', () => {
+  it('returns chunks in sequence order', async () => {
+    const w = deriveBackupWallet(PRIMARY)
+    const blobs = [
+      await encodeChunk(w, chunkWithTx('aaa')),
+      await encodeChunk(w, chunkWithTx('bbb'))
+    ]
+    const reader = new RemoteSyncReader(fakeClient(blobs), w, DEVICE, 1, SETTINGS)
+
+    expect((await reader.getSyncChunk(args)).provenTxs?.[0].txid).toBe('aaa')
+    expect((await reader.getSyncChunk(args)).provenTxs?.[0].txid).toBe('bbb')
+  })
+
+  it('signals completion with an all-empty chunk', async () => {
+    // The toolbox treats an empty chunk as the completion sentinel, and needs every one of
+    // the twelve arrays present rather than undefined.
+    const w = deriveBackupWallet(PRIMARY)
+    const reader = new RemoteSyncReader(fakeClient([await encodeChunk(w, chunkWithTx('aaa'))]), w, DEVICE, 1, SETTINGS)
+
+    await reader.getSyncChunk(args)
+    const done = await reader.getSyncChunk(args)
+
+    expect(isEmptyChunk(done)).toBe(true)
+    expect(Array.isArray(done.outputs)).toBe(true)
+    expect(Array.isArray(done.certificateFields)).toBe(true)
+  })
+
+  it('rejects a log with a missing sequence', async () => {
+    // A gap means the restore would be silently incomplete — the wallet would look healthy
+    // while missing outputs it needs to spend. Failing loudly is the safer outcome.
+    const w = deriveBackupWallet(PRIMARY)
+    const blobs = [await encodeChunk(w, chunkWithTx('aaa'))]
+    const broken: LogEntry[] = [
+      { seq: 2, sha256: 'sha2', prevSha256: 'sha1', size: 1, createdAt: 'z' }
+    ]
+
+    const reader = new RemoteSyncReader(fakeClient(blobs, broken), w, DEVICE, 1, SETTINGS)
+    await expect(reader.getSyncChunk(args)).rejects.toBeInstanceOf(BackupChainError)
+  })
+
+  it('rejects a forked chain', async () => {
+    const w = deriveBackupWallet(PRIMARY)
+    const blobs = [
+      await encodeChunk(w, chunkWithTx('aaa')),
+      await encodeChunk(w, chunkWithTx('bbb'))
+    ]
+    const forked: LogEntry[] = [
+      { seq: 1, sha256: 'sha1', prevSha256: undefined, size: 1, createdAt: 'z' },
+      { seq: 2, sha256: 'sha2', prevSha256: 'NOT-sha1', size: 1, createdAt: 'z' }
+    ]
+
+    const reader = new RemoteSyncReader(fakeClient(blobs, forked), w, DEVICE, 1, SETTINGS)
+    await expect(reader.getSyncChunk(args)).rejects.toThrow(/forked/)
+  })
+
+  it('cannot decrypt a log written by a different wallet', async () => {
+    const mine = deriveBackupWallet(PRIMARY)
+    const theirs = deriveBackupWallet(new PrivateKey(22).toArray('be', 32))
+    const blobs = [await encodeChunk(theirs, chunkWithTx('aaa'))]
+
+    const reader = new RemoteSyncReader(fakeClient(blobs), mine, DEVICE, 1, SETTINGS)
+    await expect(reader.getSyncChunk(args)).rejects.toThrow()
+  })
+
+  it('reads the index once, not per chunk', async () => {
+    const w = deriveBackupWallet(PRIMARY)
+    const blobs = [
+      await encodeChunk(w, chunkWithTx('aaa')),
+      await encodeChunk(w, chunkWithTx('bbb'))
+    ]
+    const client = fakeClient(blobs)
+    const reader = new RemoteSyncReader(client, w, DEVICE, 1, SETTINGS)
+
+    await reader.getSyncChunk(args)
+    await reader.getSyncChunk(args)
+    await reader.getSyncChunk(args)
+
+    expect(client.index).toHaveBeenCalledTimes(1)
+  })
+
+  it('round-trips a chunk through encode and restore byte-exactly', async () => {
+    // The property the whole feature depends on: what a restore replays is exactly what
+    // the push captured, including the binary fields that make outputs spendable.
+    const w = deriveBackupWallet(PRIMARY)
+    const original = emptyChunk('a', 'b', 'user') as unknown as Record<string, unknown[]>
+    original.outputs = [{
+      outputId: 1,
+      senderIdentityKey: '02' + 'cd'.repeat(32),
+      derivationPrefix: 'cHJlZml4',
+      derivationSuffix: 'c3VmZml4',
+      lockingScript: Array.from({ length: 64 }, (_, i) => i)
+    }]
+
+    const blobs = [await encodeChunk(w, original as unknown as SyncChunk)]
+    const reader = new RemoteSyncReader(fakeClient(blobs), w, DEVICE, 1, SETTINGS)
+    const restored = await reader.getSyncChunk(args) as any
+
+    // This metadata exists only in the database and is exactly why the seed alone cannot
+    // recover a wallet.
+    expect(restored.outputs[0].senderIdentityKey).toBe('02' + 'cd'.repeat(32))
+    expect(restored.outputs[0].derivationPrefix).toBe('cHJlZml4')
+    expect(restored.outputs[0].derivationSuffix).toBe('c3VmZml4')
+    expect(restored.outputs[0].lockingScript).toEqual(Array.from({ length: 64 }, (_, i) => i))
+  })
+})

--- a/__tests__/backupTask.test.ts
+++ b/__tests__/backupTask.test.ts
@@ -1,0 +1,129 @@
+import { TaskBackupPush } from '@/utils/monitor/TaskBackupPush'
+import { MIN_PUSH_INTERVAL_MS } from '@/utils/backup/constants'
+import type { PushResult } from '@/utils/backup/push'
+
+const monitor = {} as any
+
+const ok = (over: Partial<PushResult> = {}): PushResult => ({
+  pushed: 0, bytes: 0, windowClosed: true, rotated: false, ...over
+})
+
+function task (push: () => Promise<PushResult> = async () => ok()): TaskBackupPush {
+  return new TaskBackupPush(monitor, push)
+}
+
+beforeEach(() => { TaskBackupPush.reset() })
+
+describe('TaskBackupPush trigger', () => {
+  it('never runs while offline', () => {
+    // Pushing offline would burn the backoff on failures the app already knows about.
+    TaskBackupPush.noteConnectivity(false)
+    TaskBackupPush.noteChanged()
+    TaskBackupPush.requestNow()
+
+    expect(task().trigger(Date.now()).run).toBe(false)
+  })
+
+  it('runs immediately when connectivity returns', () => {
+    TaskBackupPush.noteConnectivity(true)
+    expect(task().trigger(Date.now()).run).toBe(true)
+  })
+
+  it('does not run when nothing has changed', () => {
+    TaskBackupPush.noteConnectivity(true)
+    TaskBackupPush.checkNow = false
+
+    expect(task().trigger(Date.now()).run).toBe(false)
+  })
+
+  it('runs when the database has changed and the interval has elapsed', () => {
+    TaskBackupPush.noteConnectivity(true)
+    TaskBackupPush.checkNow = false
+    TaskBackupPush.noteChanged()
+
+    expect(task().trigger(Date.now()).run).toBe(true)
+  })
+
+  it('respects the minimum interval between passes', () => {
+    // The monitor ticks roughly every five seconds and runs tasks back-to-back without
+    // yielding; pushing that often would compete with the UI for the JS thread.
+    TaskBackupPush.noteConnectivity(true)
+    TaskBackupPush.checkNow = false
+    TaskBackupPush.noteChanged()
+
+    const now = Date.now()
+    const t = task()
+    expect(t.trigger(now).run).toBe(true)
+
+    TaskBackupPush.noteRan(now)
+    expect(t.trigger(now + 5_000).run).toBe(false)
+    expect(t.trigger(now + MIN_PUSH_INTERVAL_MS + 1).run).toBe(true)
+  })
+
+  it('honours an explicit request even inside the interval', () => {
+    TaskBackupPush.noteConnectivity(true)
+    const now = Date.now()
+    TaskBackupPush.noteRan(now)
+    TaskBackupPush.requestNow()
+
+    expect(task().trigger(now + 1_000).run).toBe(true)
+  })
+})
+
+describe('TaskBackupPush runTask', () => {
+  it('clears the change flag once the log has caught up', async () => {
+    TaskBackupPush.noteChanged()
+    await task(async () => ok({ pushed: 0, windowClosed: true })).runTask()
+
+    expect(TaskBackupPush.hasChanges).toBe(false)
+    expect(TaskBackupPush.lastError).toBeUndefined()
+    expect(TaskBackupPush.lastSuccessAt).toBeDefined()
+  })
+
+  it('keeps going while chunks are still being pushed', async () => {
+    // A pass handles one chunk, so a successful push means there is probably more to drain.
+    TaskBackupPush.noteChanged()
+    await task(async () => ok({ pushed: 1, bytes: 100, windowClosed: false })).runTask()
+
+    expect(TaskBackupPush.hasChanges).toBe(true)
+    expect(TaskBackupPush.checkNow).toBe(true)
+  })
+
+  it('backs off exponentially on failure and records why', async () => {
+    const failing = task(async () => { throw new Error('server unreachable') })
+
+    await failing.runTask()
+    const first = TaskBackupPush.backoffMs
+    await failing.runTask()
+
+    expect(TaskBackupPush.lastError).toBe('server unreachable')
+    expect(TaskBackupPush.backoffMs).toBeGreaterThan(first)
+  })
+
+  it('caps the backoff', async () => {
+    const failing = task(async () => { throw new Error('down') })
+    for (let i = 0; i < 20; i++) await failing.runTask()
+
+    expect(TaskBackupPush.backoffMs).toBeLessThanOrEqual(TaskBackupPush.MAX_BACKOFF_MS)
+  })
+
+  it('does not throw out of runTask', async () => {
+    // The monitor runs tasks consecutively; throwing would take out the tasks after it.
+    await expect(task(async () => { throw new Error('boom') }).runTask()).resolves.toContain('failed')
+  })
+
+  it('resets the backoff after a success', async () => {
+    let fail = true
+    const t = task(async () => {
+      if (fail) throw new Error('temporary')
+      return ok()
+    })
+
+    await t.runTask()
+    expect(TaskBackupPush.backoffMs).toBeGreaterThan(TaskBackupPush.BASE_BACKOFF_MS)
+
+    fail = false
+    await t.runTask()
+    expect(TaskBackupPush.backoffMs).toBe(TaskBackupPush.BASE_BACKOFF_MS)
+  })
+})

--- a/__tests__/sdkAuthFetchBinaryBody.test.ts
+++ b/__tests__/sdkAuthFetchBinaryBody.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Guards the @bsv/sdk 2.4.0 fix to AuthFetch.normalizeBodyToNumberArray.
+ *
+ * On 2.1.9 the method tested `typeof body === 'object'` as its FIRST branch and returned
+ * Utils.toArray(JSON.stringify(body)). Arrays, Uint8Array, ArrayBuffer, Blob, FormData and
+ * URLSearchParams are all `typeof 'object'`, so every binary branch below it was dead code
+ * and a Uint8Array body was serialised as {"0":12,"1":255,...}.
+ *
+ * The encrypted wallet backup log POSTs raw ciphertext as an octet-stream body. If this
+ * regresses on a future SDK bump, every backup blob is silently corrupted on upload — the
+ * server would store well-formed JSON that no client can decrypt, and nothing would fail
+ * loudly until someone tried to restore. Hence a hard gate rather than a comment.
+ */
+import { AuthFetch, CompletedProtoWallet, PrivateKey } from '@bsv/sdk'
+
+/** normalizeBodyToNumberArray is private; reach it deliberately rather than reimplement. */
+async function normalize (body: unknown): Promise<number[]> {
+  const client = new AuthFetch(new CompletedProtoWallet(PrivateKey.fromRandom()))
+  return await (
+    client as unknown as {
+      normalizeBodyToNumberArray: (b: unknown) => Promise<number[]>
+    }
+  ).normalizeBodyToNumberArray(body)
+}
+
+describe('AuthFetch binary body handling', () => {
+  it('passes a Uint8Array through as raw bytes', async () => {
+    expect(await normalize(new Uint8Array([0, 12, 127, 128, 255]))).toEqual([0, 12, 127, 128, 255])
+  })
+
+  it('does not JSON-stringify a Uint8Array', async () => {
+    const asText = Buffer.from(await normalize(new Uint8Array([255, 254]))).toString('utf8')
+    expect(asText).not.toContain('{"0"')
+  })
+
+  it('honours byteOffset and byteLength on a subarray view', async () => {
+    // 2.1.9 did `new Uint8Array(body.buffer)`, ignoring both, so a view returned its whole
+    // backing buffer. Chunked payloads built on a shared buffer would silently corrupt.
+    const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    expect(await normalize(backing.subarray(2, 5))).toEqual([3, 4, 5])
+  })
+
+  it('passes a number[] through unchanged', async () => {
+    expect(await normalize([1, 2, 3])).toEqual([1, 2, 3])
+  })
+
+  it('round-trips arbitrary bytes without loss', async () => {
+    const all = Array.from({ length: 256 }, (_, i) => i)
+    expect(await normalize(new Uint8Array(all))).toEqual(all)
+  })
+
+  it('still encodes a plain object as JSON', async () => {
+    const text = Buffer.from(await normalize({ hello: 'world' })).toString('utf8')
+    expect(text).toBe('{"hello":"world"}')
+  })
+
+  it('still encodes a string as UTF-8', async () => {
+    expect(Buffer.from(await normalize('héllo')).toString('utf8')).toBe('héllo')
+  })
+})

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -41,7 +41,7 @@ const DEFAULT_SETTINGS: WalletSettings = {
 }
 import { showToast } from '@/components/ui/Toast'
 import type { AppChain } from './config'
-import { DEFAULT_STORAGE_URL, DEFAULT_CHAIN, ADMIN_ORIGINATOR, toWalletChain } from './config'
+import { DEFAULT_STORAGE_URL, DEFAULT_CHAIN, ADMIN_ORIGINATOR, DEFAULT_BACKUP_URL, toWalletChain } from './config'
 import { DEFAULT_AUTO_APPROVE_THRESHOLD, AUTO_APPROVE_COOLDOWN_MS, AUTO_APPROVE_STORAGE_KEY } from '@/shared/constants'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { UserContext } from './UserContext'
@@ -79,6 +79,8 @@ class QuietEventSource extends (RNEventSource as any) {
 import { getOnline, subscribeOnline } from '@/utils/net/online'
 import { processPending } from '@/utils/localpay/pending'
 import { TaskSendOffline } from '@/utils/monitor/TaskSendOffline'
+import { TaskBackupPush } from '@/utils/monitor/TaskBackupPush'
+import { pushOnce } from '@/utils/backup/push'
 import { processOfflineActions } from '@/storage/methods/processOfflineActions'
 import { wocConfigFor } from '@/utils/pay/rails/address'
 import { SWEEP_INTERVAL_MS, runSweep, shouldSweepNow, sweptTotal } from '@/utils/pay/sweeper'
@@ -917,6 +919,8 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
           monitorOptions.EventSourceClass = QuietEventSource
           monitorOptions.onTransactionStatusChanged = async (_txid: string, _newStatus: string) => {
             setTxStatusVersion(v => v + 1)
+            // The database moved, so the backup log has something to catch up on.
+            TaskBackupPush.noteChanged()
           }
           if (phoneStorage) {
             const SSE_KEY = 'sse_last_event_id'
@@ -969,6 +973,29 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
             // Rows may be sitting in offline_actions from a previous session.
             // Pessimistic: one idle drain clears it the first time we are online.
             TaskSendOffline.noteEnqueued()
+
+            // Encrypted backup log. The database is required to spend — change outputs
+            // carry a random derivation suffix and BRC-29 receipts carry sender-chosen
+            // derivation data, none of it on-chain and none of it recoverable from the
+            // seed — so without this a user with their recovery phrase still cannot
+            // restore their funds.
+            //
+            // Reads chunks straight from phoneStorage rather than through
+            // WalletStorageManager, whose sync lock would block all storage access.
+            if (DEFAULT_BACKUP_URL !== '') {
+              monitor.addTask(
+                new TaskBackupPush(monitor, async () => {
+                  return await pushOnce({
+                    storage: phoneStorage!,
+                    primaryKey,
+                    identityKey: keyDeriver.identityKey,
+                    baseUrl: DEFAULT_BACKUP_URL
+                  })
+                })
+              )
+              // Pessimistic: one idle pass clears it if there is nothing to send.
+              TaskBackupPush.noteChanged()
+            }
           }
           monitor.addDefaultTasks()
 
@@ -1601,10 +1628,14 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
     })
   }, [walletBuilt, selectedNetwork, runHeaderSync])
 
-  // Feed the drain's online gate and arm an immediate pass on reconnect.
+  // Feed the drain's and the backup push's online gates, arming an immediate pass on
+  // reconnect. Both are gated on the app's single online signal.
   useEffect(() => {
     if (!walletBuilt) return
-    return subscribeOnline(online => TaskSendOffline.noteConnectivity(online))
+    return subscribeOnline(online => {
+      TaskSendOffline.noteConnectivity(online)
+      TaskBackupPush.noteConnectivity(online)
+    })
   }, [walletBuilt])
 
   // Fetch Arcade status events when app returns to foreground

--- a/context/config.tsx
+++ b/context/config.tsx
@@ -20,5 +20,15 @@ export function toWalletChain(chain: AppChain): WalletChain {
 export const DEFAULT_WAB_URL = 'noWAB'
 export const DEFAULT_STORAGE_URL = 'local'
 export const DEFAULT_MESSAGEBOX_URL = 'https://messagebox.babbage.systems'
+/**
+ * Encrypted wallet-backup log.
+ *
+ * Deliberately separate from DEFAULT_STORAGE_URL, which stays 'local': this service is not
+ * a wallet storage provider. It stores opaque ciphertext it cannot read, addressed by a
+ * pseudonym derived from the wallet seed.
+ *
+ * Empty string disables backup entirely.
+ */
+export const DEFAULT_BACKUP_URL = ''
 export const DEFAULT_CHAIN: AppChain = 'main'
 export const ADMIN_ORIGINATOR = 'admin.com'

--- a/docs/superpowers/plans/2026-08-15-bsv-sdk-240-upgrade.md
+++ b/docs/superpowers/plans/2026-08-15-bsv-sdk-240-upgrade.md
@@ -1,0 +1,614 @@
+# @bsv/sdk 2.4.0 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move bsv-browser from `@bsv/sdk` 2.1.9 to 2.4.0, rebasing the 2168-line native-secp256k1 patch onto the new version with byte-exactness proven, so the wallet's signing behaviour is unchanged.
+
+**Architecture:** This is a dependency bump underneath a live wallet, so it is its own branch and its own verification pass. The risk is not the SDK API — the APIs this app uses are unchanged — it is the local patch, which reroutes ECDSA signing through a Nitro native module with a `@noble/secp256k1` fallback. The patch is regenerated against 2.4.0 with `patch-package`, then gated on the existing byte-parity test suite before anything else is allowed to depend on it.
+
+**Tech Stack:** TypeScript, React Native / Expo, `patch-package`, Jest, `@bsv/sdk` 2.4.0, `@noble/secp256k1`, `react-native-nitro-modules`.
+
+## Global Constraints
+
+- Target `@bsv/sdk` **2.4.0** exactly. There is no 2.1.9 compatibility path anywhere.
+- The patch must preserve **byte-exact** ECDSA output: RFC 6979 deterministic k, low-S DER. Any divergence changes signed transactions and is a hard fail.
+- `patches/@bsv+sdk+2.1.9.patch` must be **deleted**, not left alongside the new file. `patch-package` applies by exact version-matched filename, so a stale file is silently ignored and creates the illusion of coverage.
+- All 63 test files must pass. `__tests__/nobleBackend.test.ts` is the byte-parity gate and is non-negotiable.
+- Do **not** fold any backup-feature work into this branch.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `package.json` | Pins `@bsv/sdk` version | Modify |
+| `package-lock.json` | Lockfile | Regenerate |
+| `patches/@bsv+sdk+2.1.9.patch` | Old native-secp patch | **Delete** |
+| `patches/@bsv+sdk+2.4.0.patch` | Rebased native-secp patch | Create (generated) |
+| `__tests__/nobleBackend.test.ts` | Byte-parity gate for the noble backend | Verify unchanged, extend |
+| `__tests__/sdkAuthFetchBinaryBody.test.ts` | Locks in the 2.4.0 binary-body fix | Create |
+
+The patch covers 8 SDK source files in both `dist/cjs` and `dist/esm`: `ECDSA.js`,
+`NativeSecp.js` (added wholesale by the patch), `PrivateKey.js`, `PublicKey.js`,
+`Schnorr.js`, `Signature.js`, `script/templates/P2PKH.js`, `transaction/Transaction.js`.
+
+---
+
+### Task 1: Branch and capture the 2.1.9 baseline
+
+**Files:**
+- Create: `/tmp/sdk-upgrade-baseline.json` (scratch, not committed)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: a baseline signature vector file used by Task 4 to prove byte-exactness across the version change.
+
+The whole upgrade rests on "signing behaviour did not change". That claim needs a
+before-image captured while 2.1.9 is still installed.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git checkout -b chore/bsv-sdk-2.4.0
+```
+
+- [ ] **Step 2: Confirm the starting state**
+
+```bash
+node -p "require('./node_modules/@bsv/sdk/package.json').version"
+```
+
+Expected: `2.1.9`
+
+- [ ] **Step 3: Capture baseline signatures from the patched 2.1.9**
+
+Write and run this scratch script. It signs the 27 project vectors with fixed keys
+through the routed (patched) SDK calls and records the DER hex.
+
+```bash
+cat > /tmp/capture-baseline.js <<'EOF'
+const { BigNumber, ECDSA, PrivateKey } = require('@bsv/sdk')
+const vectors = require('./native-secp-poc/fixtures/vectors.json')
+const out = []
+for (let i = 0; i < 27; i++) {
+  const key = new PrivateKey(new BigNumber(i + 1).toArray('be', 32))
+  const msg = new BigNumber(require('crypto').createHash('sha256').update('v' + i).digest().toJSON().data)
+  const sig = ECDSA.sign(msg, key, true)
+  out.push({ i, pub: key.toPublicKey().toString(), der: Buffer.from(sig.toDER()).toString('hex') })
+}
+console.log(JSON.stringify({ sdk: require('@bsv/sdk/package.json').version, vectorCount: vectors.length, out }, null, 2))
+EOF
+node /tmp/capture-baseline.js > /tmp/sdk-upgrade-baseline.json
+head -12 /tmp/sdk-upgrade-baseline.json
+```
+
+Expected: JSON with `"sdk": "2.1.9"` and 27 entries each having a `der` hex string.
+
+- [ ] **Step 4: Run the full suite to confirm a green starting point**
+
+```bash
+npm test
+```
+
+Expected: all suites pass. If anything fails **before** the upgrade, stop and fix or
+document that separately — do not carry a pre-existing failure into this branch, or the
+upgrade will be blamed for it.
+
+- [ ] **Step 5: Commit the branch point**
+
+```bash
+git commit --allow-empty -m "chore(sdk): branch point for @bsv/sdk 2.4.0 upgrade"
+```
+
+---
+
+### Task 2: Bump the dependency and remove the stale patch
+
+**Files:**
+- Modify: `package.json` (the `@bsv/sdk` entry under `dependencies`)
+- Modify: `package-lock.json` (regenerated)
+- Delete: `patches/@bsv+sdk+2.1.9.patch`
+
+**Interfaces:**
+- Consumes: the branch from Task 1
+- Produces: an installed, **unpatched** `@bsv/sdk` 2.4.0 in `node_modules`, ready for Task 3 to re-apply the native-secp changes by hand.
+
+- [ ] **Step 1: Pin 2.4.0 in package.json**
+
+Change the dependency line from `"@bsv/sdk": "^2.1.9"` to:
+
+```json
+    "@bsv/sdk": "2.4.0",
+```
+
+Pin exactly, not with a caret. A wallet should not float its cryptography dependency.
+
+- [ ] **Step 2: Delete the stale patch**
+
+```bash
+git rm patches/@bsv+sdk+2.1.9.patch
+```
+
+`patch-package` matches patches to packages by the version in the filename. Leaving the
+2.1.9 file in place would mean it is silently never applied — the most dangerous possible
+outcome, because the app would run on unpatched pure-JS crypto while the repo still looks
+patched.
+
+- [ ] **Step 3: Reinstall**
+
+```bash
+rm -rf node_modules/@bsv/sdk && npm install
+```
+
+Expected: `patch-package` reports applying `@bsv/wallet-toolbox-mobile@2.4.3` only, with
+no mention of `@bsv/sdk`.
+
+- [ ] **Step 4: Verify the new version is installed and unpatched**
+
+```bash
+node -p "require('./node_modules/@bsv/sdk/package.json').version"
+ls node_modules/@bsv/sdk/dist/cjs/src/primitives/NativeSecp.js 2>&1
+```
+
+Expected: `2.4.0`, then `No such file or directory` — confirming the patch is genuinely
+absent and Task 3 has real work to do.
+
+- [ ] **Step 5: Confirm the binary-body fix is present in 2.4.0**
+
+```bash
+sed -n '/normalizeBodyToNumberArray(body)/,/^    }/p' \
+  node_modules/@bsv/sdk/dist/cjs/src/auth/clients/AuthFetch.js | head -20
+```
+
+Expected: the first branch after the null check is `Array.isArray(body)`, **not**
+`typeof body === 'object'`. This is the fix the backup client depends on.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json patches/
+git commit -m "chore(sdk): bump @bsv/sdk to 2.4.0 and drop the 2.1.9 patch"
+```
+
+---
+
+### Task 3: Rebase the native-secp patch onto 2.4.0
+
+**Files:**
+- Modify: `node_modules/@bsv/sdk/dist/{cjs,esm}/src/primitives/ECDSA.js`
+- Create: `node_modules/@bsv/sdk/dist/{cjs,esm}/src/primitives/NativeSecp.js`
+- Modify: `node_modules/@bsv/sdk/dist/{cjs,esm}/src/primitives/{PrivateKey,PublicKey,Schnorr,Signature}.js`
+- Modify: `node_modules/@bsv/sdk/dist/{cjs,esm}/src/script/templates/P2PKH.js`
+- Modify: `node_modules/@bsv/sdk/dist/{cjs,esm}/src/transaction/Transaction.js`
+- Create: `patches/@bsv+sdk+2.4.0.patch` (generated)
+
+**Interfaces:**
+- Consumes: unpatched 2.4.0 from Task 2; the old patch body from git history at
+  `HEAD~1:patches/@bsv+sdk+2.1.9.patch`
+- Produces: `patches/@bsv+sdk+2.4.0.patch`, and a `secpBackend()` / `nativeSecp()` /
+  `bnToBuf32()` / `numsToBuf()` / `warnCustomKOnce()` / `warnForceLowSOnce()` seam in
+  `NativeSecp.js` with the same exported names as before, so `__tests__/nobleBackend.test.ts`
+  keeps working unmodified.
+
+`NativeSecp.js` is added wholesale by the patch and has no upstream counterpart, so it
+copies across verbatim. The other seven files are hunks against upstream code that may
+have moved.
+
+- [ ] **Step 1: Recover the old patch for reference**
+
+```bash
+git show HEAD~1:patches/@bsv+sdk+2.1.9.patch > /tmp/old-sdk.patch
+grep -c '^diff --git' /tmp/old-sdk.patch
+```
+
+Expected: `16` (8 files × cjs + esm).
+
+- [ ] **Step 2: Copy NativeSecp.js across unchanged**
+
+This file is entirely ours; extract it from the old patch rather than retyping.
+
+```bash
+node -e "
+const fs=require('fs');
+const p=fs.readFileSync('/tmp/old-sdk.patch','utf8').split(/^diff --git /m);
+for (const h of p) {
+  const m=h.match(/^a\/node_modules\/(\S+NativeSecp\.js)/);
+  if(!m) continue;
+  const body=h.split('\n').filter(l=>l.startsWith('+')&&!l.startsWith('+++')).map(l=>l.slice(1)).join('\n');
+  fs.writeFileSync('node_modules/'+m[1], body+'\n');
+  console.log('wrote', m[1]);
+}"
+```
+
+Expected: two lines, one for `dist/cjs/...` and one for `dist/esm/...`.
+
+- [ ] **Step 3: Try the old patch and collect the rejects**
+
+```bash
+git apply --directory=. --reject /tmp/old-sdk.patch 2>&1 | tail -30
+find node_modules/@bsv/sdk -name '*.rej' | sed 's|.*sdk/||'
+```
+
+Expected: some hunks apply, some produce `.rej` files. Any file with no `.rej` is already
+done. The `.rej` list is the exact work remaining.
+
+- [ ] **Step 4: Apply each rejected hunk by hand**
+
+For every `.rej` file, open the corresponding 2.4.0 source and re-apply the change at the
+new location. The transformation in each case is the same shape: import the seam, then
+insert the native/noble route ahead of the pure-JS body, falling through on any error.
+
+The canonical example, in `dist/cjs/src/primitives/ECDSA.js` — after the existing
+message-length guard inside `sign`, before the pure-JS work:
+
+```js
+const NativeSecp_js_1 = require("./NativeSecp.js");
+// ... inside sign(msg, key, forceLowS = false, customK):
+{
+    const n = (0, NativeSecp_js_1.secpBackend)();
+    if (n != null) {
+        if (customK != null) {
+            (0, NativeSecp_js_1.warnCustomKOnce)();
+        }
+        else if (!forceLowS) {
+            (0, NativeSecp_js_1.warnForceLowSOnce)();
+        }
+        else {
+            try {
+                const der = n.ecdsaSign((0, NativeSecp_js_1.bnToBuf32)(msg), (0, NativeSecp_js_1.bnToBuf32)(key));
+                return Signature_js_1.default.fromDER(Array.from(der));
+            }
+            catch (e) { /* fall through to pure JS */ }
+        }
+    }
+}
+```
+
+The `esm` variant is identical except `require(...)` becomes a top-level
+`import { secpBackend, ... } from './NativeSecp.js'` and `Signature_js_1.default` becomes
+`Signature`. Mirror every change into both `dist/cjs` and `dist/esm` — they are separate
+files and the app can load either.
+
+Rules while doing this:
+- Never change the pure-JS fallback body. It is the reference implementation and the
+  thing byte-exactness is measured against.
+- Every native call is wrapped in `try/catch` that falls through to pure JS.
+- `customK` and `forceLowS=false` always take the pure-JS path.
+
+- [ ] **Step 5: Remove the reject files**
+
+```bash
+find node_modules/@bsv/sdk -name '*.rej' -delete
+find node_modules/@bsv/sdk -name '*.orig' -delete
+```
+
+- [ ] **Step 6: Verify every expected file is modified**
+
+```bash
+for f in primitives/ECDSA primitives/NativeSecp primitives/PrivateKey primitives/PublicKey \
+         primitives/Schnorr primitives/Signature script/templates/P2PKH transaction/Transaction; do
+  for d in cjs esm; do
+    p="node_modules/@bsv/sdk/dist/$d/src/$f.js"
+    grep -q "NativeSecp" "$p" && echo "OK   $d/$f" || echo "MISS $d/$f"
+  done
+done
+```
+
+Expected: 16 lines, all `OK`. Any `MISS` means a hunk was dropped — go back to Step 4.
+
+- [ ] **Step 7: Generate the new patch**
+
+```bash
+npx patch-package @bsv/sdk
+ls -l patches/
+grep -c '^diff --git' patches/@bsv+sdk+2.4.0.patch
+```
+
+Expected: `patches/@bsv+sdk+2.4.0.patch` exists and reports `16`.
+
+- [ ] **Step 8: Prove the patch reapplies from clean**
+
+This is the step that catches a patch generated against accidental local edits.
+
+```bash
+rm -rf node_modules/@bsv/sdk && npm install 2>&1 | grep -i "bsv/sdk"
+grep -c "NativeSecp" node_modules/@bsv/sdk/dist/cjs/src/primitives/ECDSA.js
+```
+
+Expected: patch-package reports applying `@bsv/sdk@2.4.0`, and the grep returns a non-zero
+count.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add patches/@bsv+sdk+2.4.0.patch
+git commit -m "chore(sdk): rebase native-secp256k1 patch onto @bsv/sdk 2.4.0"
+```
+
+---
+
+### Task 4: Prove byte-exactness against the 2.1.9 baseline
+
+**Files:**
+- Test: `__tests__/nobleBackend.test.ts` (existing gate, run unmodified)
+- Create: `/tmp/verify-upgrade.js` (scratch)
+
+**Interfaces:**
+- Consumes: `/tmp/sdk-upgrade-baseline.json` from Task 1; the rebased patch from Task 3
+- Produces: proof that signing output is unchanged across the version bump. Nothing may
+  depend on 2.4.0 until this passes.
+
+- [ ] **Step 1: Re-run the identical capture against 2.4.0**
+
+```bash
+node /tmp/capture-baseline.js > /tmp/sdk-upgrade-after.json
+node -p "require('/tmp/sdk-upgrade-after.json').sdk"
+```
+
+Expected: `2.4.0`
+
+- [ ] **Step 2: Diff the signature vectors**
+
+```bash
+node -e "
+const a=require('/tmp/sdk-upgrade-baseline.json').out;
+const b=require('/tmp/sdk-upgrade-after.json').out;
+let bad=0;
+for (let i=0;i<a.length;i++){
+  if(a[i].der!==b[i].der){bad++;console.log('DER MISMATCH at',i);}
+  if(a[i].pub!==b[i].pub){bad++;console.log('PUBKEY MISMATCH at',i);}
+}
+console.log(bad===0?'BYTE-EXACT: '+a.length+' vectors match':'FAILED: '+bad+' mismatches');
+process.exit(bad===0?0:1);
+"
+```
+
+Expected: `BYTE-EXACT: 27 vectors match`, exit 0.
+
+A mismatch here is a hard stop. It means the rebased patch changed signing behaviour, and
+shipping it would produce transactions that differ from what the wallet produced before.
+
+- [ ] **Step 3: Run the byte-parity gate**
+
+```bash
+npx jest __tests__/nobleBackend.test.ts -v
+```
+
+Expected: PASS. This suite forces the native probe to fail and asserts that noble's
+RFC 6979 low-S DER and public keys are byte-identical to the SDK's pure-JS path.
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+npm test 2>&1 | tail -20
+```
+
+Expected: same pass count as the Task 1 baseline, zero failures.
+
+- [ ] **Step 5: Typecheck and lint**
+
+```bash
+npx tsc --noEmit && npm run lint
+```
+
+Expected: both clean. `tsc` is what surfaces any genuine API drift between 2.1.9 and
+2.4.0 in app code.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit --allow-empty -m "test(sdk): byte-exactness verified across 2.1.9 to 2.4.0 upgrade
+
+27/27 signature vectors and public keys byte-identical.
+nobleBackend byte-parity gate green. Full suite green."
+```
+
+---
+
+### Task 5: Lock in the binary-body fix with a regression test
+
+**Files:**
+- Create: `__tests__/sdkAuthFetchBinaryBody.test.ts`
+
+**Interfaces:**
+- Consumes: `@bsv/sdk` 2.4.0
+- Produces: a guard that fails loudly if a future SDK bump reintroduces the
+  `typeof body === 'object'` ordering bug. The backup client's raw-binary upload depends
+  entirely on this behaviour.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+/**
+ * Guards the @bsv/sdk 2.4.0 fix to AuthFetch.normalizeBodyToNumberArray.
+ *
+ * On 2.1.9 the method tested `typeof body === 'object'` FIRST and returned
+ * Utils.toArray(JSON.stringify(body)). Arrays, Uint8Array, ArrayBuffer and Blob are all
+ * typeof 'object', so every binary branch below it was dead code and a Uint8Array body
+ * was serialised as {"0":12,"1":255,...}.
+ *
+ * The encrypted wallet backup log POSTs raw ciphertext as an octet-stream body. If this
+ * regresses, every backup blob is silently corrupted on upload, so this is a hard gate.
+ */
+import { AuthFetch, CompletedProtoWallet, PrivateKey } from '@bsv/sdk'
+
+// normalizeBodyToNumberArray is private; reach it deliberately rather than reimplement.
+function normalize (body: unknown): Promise<number[]> {
+  const client = new AuthFetch(new CompletedProtoWallet(PrivateKey.fromRandom()))
+  return (client as unknown as {
+    normalizeBodyToNumberArray: (b: unknown) => Promise<number[]>
+  }).normalizeBodyToNumberArray(body)
+}
+
+describe('AuthFetch binary body handling (SDK 2.4.0)', () => {
+  it('passes a Uint8Array through as raw bytes', async () => {
+    const bytes = new Uint8Array([0, 12, 127, 128, 255])
+    expect(await normalize(bytes)).toEqual([0, 12, 127, 128, 255])
+  })
+
+  it('does not JSON-stringify a Uint8Array', async () => {
+    const result = await normalize(new Uint8Array([255, 254]))
+    const asText = Buffer.from(result).toString('utf8')
+    expect(asText).not.toContain('{"0"')
+  })
+
+  it('honours byteOffset and byteLength on a subarray view', async () => {
+    // 2.1.9 did new Uint8Array(body.buffer), ignoring both — returning the whole
+    // backing buffer instead of the view, silently corrupting chunked payloads.
+    const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    expect(await normalize(backing.subarray(2, 5))).toEqual([3, 4, 5])
+  })
+
+  it('passes a number[] through unchanged', async () => {
+    expect(await normalize([1, 2, 3])).toEqual([1, 2, 3])
+  })
+
+  it('still encodes a plain object as JSON', async () => {
+    const result = await normalize({ hello: 'world' })
+    expect(Buffer.from(result).toString('utf8')).toBe('{"hello":"world"}')
+  })
+})
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx jest __tests__/sdkAuthFetchBinaryBody.test.ts -v
+```
+
+Expected: PASS on 2.4.0. (These same tests fail on 2.1.9 — that asymmetry is the point.
+If they pass before the bump, the test is not actually reaching the method and needs
+fixing.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/sdkAuthFetchBinaryBody.test.ts
+git commit -m "test(sdk): guard AuthFetch binary-body handling on 2.4.0"
+```
+
+---
+
+### Task 6: Check whether the wallet-toolbox patch can shed its batch-derivation code
+
+**Files:**
+- Read: `patches/@bsv+wallet-toolbox-mobile+2.4.3.patch`
+- Read: `node_modules/@bsv/sdk/dist/types/src/wallet/KeyDeriver.d.ts`
+
+**Interfaces:**
+- Consumes: `@bsv/sdk` 2.4.0
+- Produces: either a reduced toolbox patch, or a recorded decision to keep it as is.
+
+2.4.0's `KeyDeriver` gains an optional `derivePrivateKeys?(derivations: readonly
+PrivateKeyDerivation[]): PrivateKey[]` — upstream's version of what the local toolbox
+patch implements by hand via `batchBrc42DeriveChild`. If upstream's hook is sufficient,
+part of a 220-line patch can be retired rather than maintained.
+
+- [ ] **Step 1: Read upstream's batch hook**
+
+```bash
+sed -n '25,60p' node_modules/@bsv/sdk/dist/types/src/wallet/KeyDeriver.d.ts
+grep -rn "PrivateKeyDerivation" node_modules/@bsv/sdk/dist/types/src/wallet/*.d.ts
+```
+
+- [ ] **Step 2: Read what the local patch does**
+
+```bash
+grep -n "batchBrc42DeriveChild" -B5 -A25 patches/@bsv+wallet-toolbox-mobile+2.4.3.patch | head -60
+```
+
+- [ ] **Step 3: Decide and record**
+
+Answer in a commit message: does upstream's `derivePrivateKeys` cover the same batching,
+and does it cross to native off the JS thread the way `batchBrc42DeriveChild` does? The
+local patch exists specifically to make **one async native crossing per counterparty**. If
+upstream's hook is synchronous and JS-side, it does **not** replace the patch, and the
+patch stays.
+
+Do not change the toolbox patch in this branch either way — this task only produces the
+decision. Retiring it is its own change with its own performance verification.
+
+- [ ] **Step 4: Commit the finding**
+
+```bash
+git commit --allow-empty -m "chore(sdk): record whether KeyDeriver.derivePrivateKeys can replace batchBrc42DeriveChild
+
+<state the finding and the decision here>"
+```
+
+---
+
+### Task 7: Device smoke test and merge
+
+**Files:** none modified
+
+**Interfaces:**
+- Consumes: everything above
+- Produces: a merged `master` on 2.4.0, unblocking the backup client plan.
+
+Jest runs the noble backend, never the Nitro native path. Only a device build exercises
+the tier that actually ships.
+
+- [ ] **Step 1: Build and run on a device**
+
+```bash
+npm run ios-dev-device
+```
+
+Per project convention the corporate firewall blocks LAN Metro, so the tunnel variant is
+the working one.
+
+- [ ] **Step 2: Run the native proof harness**
+
+Launch the dev build with `EXPO_PUBLIC_SECP_PROOF=1`. It runs all 27
+`native-secp-poc/fixtures/vectors.json` vectors through the routed SDK calls, verifies via
+a call-counting proxy that the native path was genuinely taken, and micro-benches routed
+versus pure-JS.
+
+Expected: all 27 vectors pass, the proxy confirms native was used (not silently falling
+through to noble), and the timings are in line with the figures in
+`native-secp-poc/M2-SIMULATOR-RESULTS.md`.
+
+- [ ] **Step 3: Send a real transaction**
+
+On the device, send a small payment on mainnet and confirm it broadcasts and confirms.
+This is the end-to-end proof that signing still produces valid transactions — the property
+every unit test above is a proxy for.
+
+- [ ] **Step 4: Run the Android emulator pass**
+
+```bash
+npm run android
+```
+
+Project convention: always run the Android emulator, since it has previously caught races
+that iOS did not.
+
+- [ ] **Step 5: Merge**
+
+```bash
+git checkout master && git merge --no-ff chore/bsv-sdk-2.4.0
+```
+
+- [ ] **Step 6: Confirm the merged state**
+
+```bash
+node -p "require('./node_modules/@bsv/sdk/package.json').version"
+ls patches/
+```
+
+Expected: `2.4.0`, and `patches/` containing `@bsv+sdk+2.4.0.patch` and
+`@bsv+wallet-toolbox-mobile+2.4.3.patch` — with no 2.1.9 file.
+
+---
+
+## Acceptance
+
+- `@bsv/sdk` 2.4.0 installed and pinned exactly; no 2.1.9 patch file remains
+- 27/27 signature vectors and public keys byte-identical to the 2.1.9 baseline
+- `__tests__/nobleBackend.test.ts` green
+- `__tests__/sdkAuthFetchBinaryBody.test.ts` green, proving raw binary upload works
+- Full suite, `tsc --noEmit` and lint clean
+- Native proof harness green on a real device, native path confirmed taken
+- A real mainnet transaction sent and confirmed from a device build

--- a/docs/superpowers/plans/2026-08-15-wallet-backup-client.md
+++ b/docs/superpowers/plans/2026-08-15-wallet-backup-client.md
@@ -1,0 +1,974 @@
+# Wallet Backup Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Continuously push the wallet database to the backup log as encrypted delta chunks, and restore a wallet from that log given only a mnemonic or recovery shares.
+
+**Architecture:** A backup-only identity is derived from the wallet's `primaryKey`; it serves as both the AuthFetch peer identity (so the server sees a pseudonym, never the real identity key) and the encryption key (`counterparty: 'self'`, so the server cannot decrypt). Pushes run as a monitor task that reads delta `SyncChunk`s directly from the local storage provider, bypassing `WalletStorageManager` and its sync lock. Restore implements the two-method `WalletStorageSyncReader` interface and hands it to `syncFromReader`.
+
+**Tech Stack:** TypeScript, React Native / Expo, `@bsv/sdk` **2.4.0**, `@bsv/wallet-toolbox-mobile` 2.4.3, expo-sqlite, AsyncStorage, Jest.
+
+## Global Constraints
+
+- **Blocked on the `@bsv/sdk` 2.4.0 upgrade plan.** Raw binary upload is impossible on 2.1.9, and there is no fallback path in this design.
+- Derive the backup key from **`primaryKey` (`m/0'/0'`)**, never `rootKey`. Share-restored wallets only ever recover `primaryKey`; deriving from `rootKey` would lock exactly the cohort this feature most helps out of their own backups.
+- `BACKUP_PROTOCOL` and `BACKUP_KEY_ID` are **frozen constants**. Restore has only the seed, so any per-install, per-device, or random component makes the pseudonym unrecoverable and the backup permanently dead.
+- Encrypt with `counterparty: 'self'`. That single value is the entire zero-knowledge property.
+- Never call `WalletStorageManager.updateBackups` / `syncToWriter` — they take the manager's sync lock via `runAsSync` and block all storage reads and writes, against the standing no->100ms-JS-block goal.
+- Monitor tasks run back-to-back **with no yielding**. All work defers via `InteractionManager` and is rate-limited.
+- The UI must never present the backup log as a substitute for the mnemonic. It is worthless without the seed or shares, and implying otherwise would make users keep their paper backup less carefully.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `utils/backup/constants.ts` | Frozen protocol/keyID, chunk sizing, generation threshold |
+| `utils/backup/derive.ts` | `deriveBackupWallet`, `backupPseudonym` |
+| `utils/backup/deviceId.ts` | Per-install device id in AsyncStorage |
+| `utils/backup/codec.ts` | Chunk ⇄ ciphertext |
+| `utils/backup/client.ts` | `BackupClient` over `AuthFetch` |
+| `utils/backup/cursor.ts` | Push cursor persistence |
+| `utils/backup/push.ts` | One push pass, pure and testable |
+| `utils/monitor/TaskBackupPush.ts` | Monitor task wrapper |
+| `utils/backup/RemoteSyncReader.ts` | `WalletStorageSyncReader` for restore |
+| `utils/backup/restore.ts` | Restore orchestration |
+| `context/config.tsx` | `DEFAULT_BACKUP_URL` |
+| `context/WalletContext.tsx` | Task registration |
+| `app/settings.tsx` | Toggle + disclosure |
+
+---
+
+### Task 1: Frozen derivation constants and the backup identity
+
+**Files:**
+- Create: `utils/backup/constants.ts`, `utils/backup/derive.ts`
+- Test: `__tests__/backupDerive.test.ts`
+
+**Interfaces:**
+- Consumes: `@bsv/sdk` 2.4.0
+- Produces: `deriveBackupWallet(primaryKey: number[]): CompletedProtoWallet`, `backupPseudonym(primaryKey: number[]): string` (66-char compressed hex), `BACKUP_PROTOCOL: WalletProtocol`, `BACKUP_KEY_ID: string`.
+
+- [ ] **Step 1: Write the failing test**
+
+The frozen-vector test is the most important test in this plan. If derivation ever
+changes, every existing backup is orphaned with no error message.
+
+```ts
+import { PrivateKey } from '@bsv/sdk'
+import { backupPseudonym, deriveBackupWallet } from '@/utils/backup/derive'
+
+// A fixed, well-known test key. Not funded, never used on mainnet.
+const TEST_PRIMARY = new PrivateKey(1).toArray('be', 32)
+
+describe('backup key derivation', () => {
+  it('is deterministic for a given primaryKey', () => {
+    expect(backupPseudonym(TEST_PRIMARY)).toBe(backupPseudonym(TEST_PRIMARY))
+  })
+
+  it('produces a 66-char compressed pubkey hex', () => {
+    const p = backupPseudonym(TEST_PRIMARY)
+    expect(p).toMatch(/^0[23][0-9a-f]{64}$/)
+  })
+
+  it('differs from the wallet identity key', () => {
+    // The whole privacy property: the server must never see the real identity key.
+    const identity = new PrivateKey(TEST_PRIMARY).toPublicKey().toString()
+    expect(backupPseudonym(TEST_PRIMARY)).not.toBe(identity)
+  })
+
+  it('differs for a different primaryKey', () => {
+    const other = new PrivateKey(2).toArray('be', 32)
+    expect(backupPseudonym(TEST_PRIMARY)).not.toBe(backupPseudonym(other))
+  })
+
+  it('MATCHES THE FROZEN VECTOR', () => {
+    // Precomputed and verified identical on @bsv/sdk 2.1.9 and 2.4.0. NEVER change this
+    // value. A diff here means every backup already written by a shipped build has been
+    // orphaned, with no error surfaced to the user.
+    expect(backupPseudonym(TEST_PRIMARY))
+      .toBe('03d7a8c57df91ccdc3704f2cc546b0c19b2dcfab5d3e0a438d2a8ae6cd3d3618b5')
+  })
+
+  it('round-trips encryption with counterparty self', async () => {
+    const w = deriveBackupWallet(TEST_PRIMARY)
+    const plaintext = [1, 2, 3, 4, 5]
+    const { ciphertext } = await w.encrypt({
+      plaintext, protocolID: BACKUP_PROTOCOL, keyID: BACKUP_KEY_ID, counterparty: 'self',
+    })
+    const { plaintext: out } = await w.decrypt({
+      ciphertext, protocolID: BACKUP_PROTOCOL, keyID: BACKUP_KEY_ID, counterparty: 'self',
+    })
+    expect(out).toEqual(plaintext)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `npx jest __tests__/backupDerive.test.ts -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the constants**
+
+```ts
+// utils/backup/constants.ts
+import type { WalletProtocol } from '@bsv/sdk'
+
+/**
+ * FROZEN. Restore has only the user's seed, so these values must never vary by install,
+ * device, build, or randomness. Changing either constant orphans every backup ever
+ * written. Protocol names are validated at runtime: 5-400 chars, /^[a-z0-9 ]+$/, no
+ * double spaces, must not end in " protocol".
+ *
+ * NOTE: in TypeScript WalletProtocol is a TUPLE [SecurityLevel, string], not the
+ * {securityLevel, protocol} struct the Go SDK uses.
+ */
+export const BACKUP_PROTOCOL: WalletProtocol = [2, 'wallet backup log']
+export const BACKUP_KEY_ID = '1'
+
+/** Well under the server's 1 MiB cap once encrypted. */
+export const MAX_ROUGH_SIZE = 512_000
+export const MAX_ITEMS = 200
+
+/** Start a fresh full snapshot once a generation exceeds this many chunks. */
+export const GENERATION_CHUNK_THRESHOLD = 200
+
+/** Floor between push passes; the monitor loop ticks roughly every 5s. */
+export const MIN_PUSH_INTERVAL_MS = 60_000
+```
+
+- [ ] **Step 4: Implement the derivation**
+
+```ts
+// utils/backup/derive.ts
+import { CompletedProtoWallet, KeyDeriver, PrivateKey } from '@bsv/sdk'
+import { BACKUP_KEY_ID, BACKUP_PROTOCOL } from './constants'
+
+/**
+ * Derive the backup-only identity from the wallet's primary key (m/0'/0').
+ *
+ * primaryKey, NOT rootKey: a wallet restored from printed backup shares recovers only
+ * the m/0'/0' WIF and has no rootKey. Deriving from rootKey would leave exactly that
+ * cohort unable to decrypt their own backups.
+ *
+ * The returned wallet is used for BOTH the AuthFetch peer identity and blob encryption,
+ * so the backup subsystem never touches the permissioned main wallet and cannot trigger
+ * protocol-permission or spending-authorisation prompts.
+ */
+export function deriveBackupWallet (primaryKey: number[]): CompletedProtoWallet {
+  const deriver = new KeyDeriver(new PrivateKey(primaryKey))
+  return new CompletedProtoWallet(
+    deriver.derivePrivateKey(BACKUP_PROTOCOL, BACKUP_KEY_ID, 'self')
+  )
+}
+
+/** The server-visible account address. Never the wallet's real identity key. */
+export function backupPseudonym (primaryKey: number[]): string {
+  const deriver = new KeyDeriver(new PrivateKey(primaryKey))
+  return deriver
+    .derivePrivateKey(BACKUP_PROTOCOL, BACKUP_KEY_ID, 'self')
+    .toPublicKey()
+    .toString()
+}
+```
+
+- [ ] **Step 5: Run and confirm the frozen vector matches**
+
+```bash
+npx jest __tests__/backupDerive.test.ts -v
+```
+
+Expected: all green, including the frozen-vector assertion.
+
+If the frozen-vector test fails, **do not update the expected value.** The constant was
+precomputed against both 2.1.9 and 2.4.0 and is correct. A failure means the derivation in
+`derive.ts` does not match the spec — most likely the protocol tuple, the keyID, or the
+counterparty. Fix the implementation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/backup/constants.ts utils/backup/derive.ts __tests__/backupDerive.test.ts
+git commit -m "feat(backup): frozen backup identity derived from primaryKey"
+```
+
+---
+
+### Task 2: Chunk codec
+
+**Files:**
+- Create: `utils/backup/codec.ts`
+- Test: `__tests__/backupCodec.test.ts`
+
+**Interfaces:**
+- Consumes: `deriveBackupWallet`, `@bsv/wallet-toolbox-mobile` `BinaryJson`
+- Produces: `encodeChunk(wallet, chunk): Promise<number[]>`, `decodeChunk(wallet, ciphertext): Promise<SyncChunk>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import type { SyncChunk } from '@bsv/wallet-toolbox-mobile'
+import { decodeChunk, encodeChunk } from '@/utils/backup/codec'
+import { deriveBackupWallet } from '@/utils/backup/derive'
+import { PrivateKey } from '@bsv/sdk'
+
+const KEY = new PrivateKey(7).toArray('be', 32)
+
+function chunkWithBinary (): SyncChunk {
+  return {
+    fromStorageIdentityKey: 'a', toStorageIdentityKey: 'b', userIdentityKey: 'c',
+    provenTxs: [{
+      provenTxId: 1, txid: 'deadbeef', height: 800000, index: 0,
+      // number[] fields are the ones BinaryJson base64-tags. Include a full byte range.
+      merklePath: [0, 1, 127, 128, 255],
+      rawTx: [1, 2, 3, 250, 251, 252, 253, 254, 255],
+      blockHash: 'x', created_at: new Date(0), updated_at: new Date(0),
+    }],
+    provenTxReqs: [], outputBaskets: [], txLabels: [], outputTags: [],
+    transactions: [], txLabelMaps: [], commissions: [], outputs: [],
+    outputTagMaps: [], certificates: [], certificateFields: [],
+  } as unknown as SyncChunk
+}
+
+describe('backup chunk codec', () => {
+  it('round-trips binary fields byte-exactly', async () => {
+    const w = deriveBackupWallet(KEY)
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunkWithBinary()))
+    expect(decoded.provenTxs?.[0].rawTx).toEqual([1, 2, 3, 250, 251, 252, 253, 254, 255])
+    expect(decoded.provenTxs?.[0].merklePath).toEqual([0, 1, 127, 128, 255])
+  })
+
+  it('preserves empty arrays rather than dropping them', async () => {
+    // The TS sync consumer infinite-loops on an undefined entity array, so all 12 must
+    // survive the round trip as arrays.
+    const w = deriveBackupWallet(KEY)
+    const decoded = await decodeChunk(w, await encodeChunk(w, chunkWithBinary()))
+    expect(Array.isArray(decoded.outputs)).toBe(true)
+    expect(Array.isArray(decoded.certificateFields)).toBe(true)
+  })
+
+  it('produces ciphertext a different key cannot read', async () => {
+    const mine = deriveBackupWallet(KEY)
+    const theirs = deriveBackupWallet(new PrivateKey(8).toArray('be', 32))
+    const ct = await encodeChunk(mine, chunkWithBinary())
+    await expect(decodeChunk(theirs, ct)).rejects.toThrow()
+  })
+
+  it('does not leak plaintext into the ciphertext', async () => {
+    const w = deriveBackupWallet(KEY)
+    const ct = await encodeChunk(w, chunkWithBinary())
+    expect(Buffer.from(ct).toString('utf8')).not.toContain('deadbeef')
+  })
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npx jest __tests__/backupCodec.test.ts -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the codec**
+
+```ts
+// utils/backup/codec.ts
+import type { CompletedProtoWallet } from '@bsv/sdk'
+import { Utils } from '@bsv/sdk'
+import type { SyncChunk } from '@bsv/wallet-toolbox-mobile'
+import {
+  parseJsonRpc, stringifyJsonRpc,
+} from '@bsv/wallet-toolbox-mobile/out/src/storage/remoting/BinaryJson'
+import { BACKUP_KEY_ID, BACKUP_PROTOCOL } from './constants'
+
+/**
+ * Serialise with the toolbox's own binary-aware JSON so number[] fields (rawTx,
+ * inputBEEF, merklePath) are base64-tagged rather than expanded to ~4x as decimal
+ * arrays, then encrypt.
+ *
+ * counterparty 'self' is load-bearing: it makes the ciphertext undecryptable by anyone
+ * but this key, including the server that stores it.
+ */
+export async function encodeChunk (wallet: CompletedProtoWallet, chunk: SyncChunk): Promise<number[]> {
+  const json = stringifyJsonRpc(chunk, true)
+  const { ciphertext } = await wallet.encrypt({
+    plaintext: Utils.toArray(json, 'utf8'),
+    protocolID: BACKUP_PROTOCOL,
+    keyID: BACKUP_KEY_ID,
+    counterparty: 'self',
+  })
+  return ciphertext
+}
+
+export async function decodeChunk (wallet: CompletedProtoWallet, ciphertext: number[]): Promise<SyncChunk> {
+  const { plaintext } = await wallet.decrypt({
+    ciphertext,
+    protocolID: BACKUP_PROTOCOL,
+    keyID: BACKUP_KEY_ID,
+    counterparty: 'self',
+  })
+  return parseJsonRpc(Utils.toUTF8(plaintext), true) as SyncChunk
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx jest __tests__/backupCodec.test.ts -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/backup/codec.ts __tests__/backupCodec.test.ts
+git commit -m "feat(backup): binary-safe encrypted chunk codec"
+```
+
+---
+
+### Task 3: Backup HTTP client
+
+**Files:**
+- Create: `utils/backup/client.ts`, `utils/backup/deviceId.ts`
+- Modify: `context/config.tsx`
+- Test: `__tests__/backupClient.test.ts`
+
+**Interfaces:**
+- Consumes: `deriveBackupWallet`
+- Produces:
+
+```ts
+export interface LogEntry { seq: number, sha256: string, prevSha256?: string, size: number, createdAt: string }
+export interface DeviceSummary { deviceId: string, generation: number, headSeq: number, headSha256: string, totalBytes: number, updatedAt: string }
+
+export class BackupClient {
+  constructor (baseUrl: string, primaryKey: number[])
+  append (deviceId: string, generation: number, seq: number, prevSha256: string | undefined, ciphertext: number[]): Promise<{ seq: number, sha256: string }>
+  index (deviceId: string, generation: number, from?: number): Promise<LogEntry[]>
+  blob (deviceId: string, generation: number, seq: number): Promise<number[]>
+  manifest (): Promise<DeviceSummary[]>
+  pruneGeneration (deviceId: string, generation: number): Promise<void>
+}
+export function getDeviceId (): Promise<string>   // 32 lowercase hex, persisted per install
+```
+
+- [ ] **Step 1: Add the config entry**
+
+In `context/config.tsx`, alongside `DEFAULT_MESSAGEBOX_URL`:
+
+```ts
+export const DEFAULT_BACKUP_URL = 'https://backup.bsvb.tech'
+```
+
+`DEFAULT_STORAGE_URL` stays `'local'` — the backup service is deliberately not a storage
+provider.
+
+- [ ] **Step 2: Write the failing client test**
+
+```ts
+import { BackupClient } from '@/utils/backup/client'
+import { PrivateKey } from '@bsv/sdk'
+
+const KEY = new PrivateKey(9).toArray('be', 32)
+const DEVICE = 'a'.repeat(32)
+
+describe('BackupClient', () => {
+  it('posts raw octet-stream, not JSON', async () => {
+    const calls: Array<{ url: string, init: RequestInit }> = []
+    const client = new BackupClient('https://example.test', KEY, async (url, init) => {
+      calls.push({ url, init })
+      return new Response(JSON.stringify({ status: 'success', seq: 1, sha256: 'ab' }), { status: 201 })
+    })
+
+    await client.append(DEVICE, 1, 1, undefined, [1, 2, 3])
+
+    expect(calls[0].init.headers).toMatchObject({ 'Content-Type': 'application/octet-stream' })
+    expect(calls[0].init.body).toBeInstanceOf(Uint8Array)
+    expect(calls[0].url).toContain('seq=1')
+    expect(calls[0].url).toContain('generation=1')
+  })
+
+  it('never sends an identity parameter', async () => {
+    // The server derives the account from auth alone. Sending an identity would invite
+    // exactly the cross-tenant bug this design exists to avoid.
+    const calls: string[] = []
+    const client = new BackupClient('https://example.test', KEY, async (url) => {
+      calls.push(url)
+      return new Response(JSON.stringify({ status: 'success', devices: [] }), { status: 200 })
+    })
+    await client.manifest()
+    expect(calls[0]).not.toMatch(/identity|pseudonym|pubkey/i)
+  })
+
+  it('surfaces a 409 as a sequence conflict', async () => {
+    const client = new BackupClient('https://example.test', KEY, async () =>
+      new Response(JSON.stringify({ status: 'error', code: 'ERR_SEQ_CONFLICT' }), { status: 409 }))
+    await expect(client.append(DEVICE, 1, 5, undefined, [1])).rejects.toThrow(/ERR_SEQ_CONFLICT/)
+  })
+
+  it('returns blob bytes as number[]', async () => {
+    const client = new BackupClient('https://example.test', KEY, async () =>
+      new Response(new Uint8Array([9, 8, 7]), { status: 200 }))
+    expect(await client.blob(DEVICE, 1, 1)).toEqual([9, 8, 7])
+  })
+})
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `npx jest __tests__/backupClient.test.ts -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement the client and device id**
+
+`BackupClient` takes an injectable fetch (defaulting to `new AuthFetch(deriveBackupWallet(primaryKey)).fetch`) so tests need no network. `getDeviceId` reads
+`backupDeviceId` from AsyncStorage, generating 16 random bytes as 32 lowercase hex on
+first use.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx jest __tests__/backupClient.test.ts -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/backup/client.ts utils/backup/deviceId.ts context/config.tsx __tests__/backupClient.test.ts
+git commit -m "feat(backup): AuthFetch-backed backup log client"
+```
+
+---
+
+### Task 4: Push pass and cursor
+
+**Files:**
+- Create: `utils/backup/cursor.ts`, `utils/backup/push.ts`
+- Test: `__tests__/backupPush.test.ts`
+
+**Interfaces:**
+- Consumes: `BackupClient`, `encodeChunk`, `StorageExpoSQLite`
+- Produces:
+
+```ts
+export interface PushCursor {
+  since?: string          // ISO; max updated_at consumed so far
+  offsets: Array<{ name: string, offset: number }>
+  generation: number
+  seq: number
+  prevSha256?: string
+  chunksInGeneration: number
+}
+export function loadCursor (pseudonym: string, deviceId: string): Promise<PushCursor>
+export function saveCursor (pseudonym: string, deviceId: string, c: PushCursor): Promise<void>
+
+export interface PushDeps {
+  storage: StorageExpoSQLite
+  primaryKey: number[]
+  /** Supply exactly one. `baseUrl` constructs a real BackupClient; `client` injects one
+   *  (tests and the round-trip harness use a fake server through this seam). */
+  baseUrl?: string
+  client?: BackupClient
+  deviceId?: string           // defaults to getDeviceId()
+}
+
+export function pushOnce (deps: PushDeps): Promise<{ pushed: number, bytes: number, rotated: boolean }>
+```
+
+`pushOnce` resolves `client ?? new BackupClient(baseUrl!, primaryKey)` and throws if
+neither is supplied. Task 5 passes `baseUrl`; Task 7 passes `client`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('pushOnce', () => {
+  it('does nothing when every entity array is empty', async () => {
+    const append = jest.fn()
+    const result = await pushOnce(deps({ chunk: emptyChunk(), append }))
+    expect(append).not.toHaveBeenCalled()
+    expect(result.pushed).toBe(0)
+  })
+
+  it('calls getSyncChunk directly on the storage provider', async () => {
+    // Never via WalletStorageManager: updateBackups/syncToWriter take the sync lock and
+    // block all storage reads and writes for the duration.
+    const getSyncChunk = jest.fn().mockResolvedValue(chunkWithOneTx())
+    await pushOnce(deps({ getSyncChunk }))
+    expect(getSyncChunk).toHaveBeenCalledWith(expect.objectContaining({
+      maxRoughSize: 512_000, maxItems: 200,
+    }))
+  })
+
+  it('advances the cursor only after a successful append', async () => {
+    const saveCursor = jest.fn()
+    const append = jest.fn().mockRejectedValue(new Error('network down'))
+    await expect(pushOnce(deps({ chunk: chunkWithOneTx(), append, saveCursor }))).rejects.toThrow()
+    expect(saveCursor).not.toHaveBeenCalled()
+  })
+
+  it('chains prevSha256 from the previous append', async () => {
+    const append = jest.fn().mockResolvedValue({ seq: 2, sha256: 'newsha' })
+    const saveCursor = jest.fn()
+    await pushOnce(deps({
+      chunk: chunkWithOneTx(), append, saveCursor,
+      cursor: { seq: 1, generation: 1, prevSha256: 'oldsha', offsets: [], chunksInGeneration: 1 },
+    }))
+    expect(append).toHaveBeenCalledWith(expect.anything(), 1, 2, 'oldsha', expect.anything())
+    expect(saveCursor).toHaveBeenCalledWith(expect.anything(), expect.anything(),
+      expect.objectContaining({ prevSha256: 'newsha', seq: 2 }))
+  })
+
+  it('rotates to a new generation past the threshold', async () => {
+    // A fresh full snapshot (since undefined) starts generation N+1, bounding both
+    // server storage and restore time.
+    const result = await pushOnce(deps({
+      chunk: chunkWithOneTx(),
+      cursor: { seq: 200, generation: 1, offsets: [], chunksInGeneration: 200, since: '2026-01-01T00:00:00Z' },
+    }))
+    expect(result.rotated).toBe(true)
+  })
+
+  it('restarts the generation from seq 1 with no since filter', async () => {
+    const getSyncChunk = jest.fn().mockResolvedValue(chunkWithOneTx())
+    const append = jest.fn().mockResolvedValue({ seq: 1, sha256: 'x' })
+    await pushOnce(deps({
+      getSyncChunk, append,
+      cursor: { seq: 200, generation: 1, offsets: [], chunksInGeneration: 200, since: '2026-01-01T00:00:00Z' },
+    }))
+    expect(getSyncChunk).toHaveBeenCalledWith(expect.objectContaining({ since: undefined }))
+    expect(append).toHaveBeenCalledWith(expect.anything(), 2, 1, undefined, expect.anything())
+  })
+})
+```
+
+- [ ] **Step 2: Run them**
+
+Run: `npx jest __tests__/backupPush.test.ts -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement cursor and push**
+
+`pushOnce` reads the cursor, decides whether to rotate generation, calls
+`storage.getSyncChunk` directly, returns early if all 12 entity arrays are empty, encodes,
+appends, then persists the advanced cursor. On `ERR_SEQ_CONFLICT` it re-reads the server
+index and resynchronises the cursor rather than looping.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx jest __tests__/backupPush.test.ts -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/backup/cursor.ts utils/backup/push.ts __tests__/backupPush.test.ts
+git commit -m "feat(backup): delta push pass with generation rotation"
+```
+
+---
+
+### Task 5: Monitor task
+
+**Files:**
+- Create: `utils/monitor/TaskBackupPush.ts`
+- Modify: `context/WalletContext.tsx` (registration beside `TaskSendOffline`)
+- Test: `__tests__/backupTask.test.ts`
+
+**Interfaces:**
+- Consumes: `pushOnce`
+- Produces: `TaskBackupPush extends WalletMonitorTask` with static `noteConnectivity(online)`, `noteChanged()`, `requestNow()`.
+
+Follow `utils/monitor/TaskSendOffline.ts`: all state is static and process-global by
+design, because the monitor is torn down and rebuilt on network switches and wallet
+rebuilds and the push cadence must survive that.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('TaskBackupPush', () => {
+  beforeEach(() => { TaskBackupPush.reset() })
+
+  it('does not trigger while offline', () => {
+    TaskBackupPush.noteConnectivity(false)
+    TaskBackupPush.noteChanged()
+    expect(new TaskBackupPush(monitor, jest.fn()).trigger(Date.now()).run).toBe(false)
+  })
+
+  it('triggers when online and the database changed', () => {
+    TaskBackupPush.noteConnectivity(true)
+    TaskBackupPush.noteChanged()
+    expect(new TaskBackupPush(monitor, jest.fn()).trigger(Date.now()).run).toBe(true)
+  })
+
+  it('respects the minimum interval between passes', () => {
+    // The monitor loop ticks roughly every 5s with no yielding between tasks; pushing
+    // that often would burn battery and block the JS thread.
+    TaskBackupPush.noteConnectivity(true)
+    TaskBackupPush.noteChanged()
+    const task = new TaskBackupPush(monitor, jest.fn())
+    const now = Date.now()
+    expect(task.trigger(now).run).toBe(true)
+    TaskBackupPush.noteRan(now)
+    TaskBackupPush.noteChanged()
+    expect(task.trigger(now + 5_000).run).toBe(false)
+    expect(task.trigger(now + 61_000).run).toBe(true)
+  })
+
+  it('backs off after a failure', () => {
+    TaskBackupPush.noteConnectivity(true)
+    TaskBackupPush.noteFailure(Date.now())
+    expect(TaskBackupPush.backoffMs).toBeGreaterThan(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npx jest __tests__/backupTask.test.ts -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the task**
+
+Wrap the `pushOnce` call in `InteractionManager.runAfterInteractions` so encryption and
+HTTP never run inside the non-yielding monitor tick.
+
+- [ ] **Step 4: Register it in WalletContext**
+
+Beside the existing `TaskSendOffline` registration, inside the same `if (phoneStorage)`
+block, before `monitor.addDefaultTasks()`. Registration order is load-bearing.
+
+```ts
+if (phoneStorage) {
+  monitor.addTask(
+    new TaskBackupPush(monitor, async () => {
+      return await pushOnce({
+        storage: phoneStorage!,
+        primaryKey,
+        baseUrl: selectedBackupUrl,
+      })
+    })
+  )
+  TaskBackupPush.noteChanged()  // pessimistic: one idle pass clears it
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx jest __tests__/backupTask.test.ts -v && npx tsc --noEmit`
+Expected: PASS and clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/monitor/TaskBackupPush.ts context/WalletContext.tsx __tests__/backupTask.test.ts
+git commit -m "feat(backup): monitor task driving delta pushes"
+```
+
+---
+
+### Task 6: Restore reader and orchestration
+
+**Files:**
+- Create: `utils/backup/RemoteSyncReader.ts`, `utils/backup/restore.ts`
+- Test: `__tests__/backupRestore.test.ts`
+
+**Interfaces:**
+- Consumes: `BackupClient`, `decodeChunk`
+- Produces:
+
+```ts
+export class RemoteSyncReader implements WalletStorageSyncReader {
+  constructor (
+    client: BackupClient,
+    wallet: CompletedProtoWallet,
+    deviceId: string,
+    generation: number,
+    settings: TableSettings,
+  )
+  makeAvailable (): Promise<TableSettings>
+  getSyncChunk (args: RequestSyncChunkArgs): Promise<SyncChunk>
+}
+
+export interface RestoreDeps {
+  storage: StorageExpoSQLite
+  primaryKey: number[]
+  baseUrl?: string            // same one-of rule as PushDeps
+  client?: BackupClient
+  deviceId?: string           // defaults to the newest device in the manifest
+}
+
+export function restoreFromBackup (deps: RestoreDeps): Promise<{ chunks: number }>
+```
+
+`WalletStorageSyncReader` is only two methods — `makeAvailable()` and `getSyncChunk(args)` —
+and that is the entire restore contract.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('RemoteSyncReader', () => {
+  it('returns chunks in sequence order', async () => {
+    const reader = new RemoteSyncReader(fakeClient([blobA, blobB]), wallet, 'dev', 1, settings)
+    expect((await reader.getSyncChunk(args)).provenTxs?.[0].txid).toBe('a')
+    expect((await reader.getSyncChunk(args)).provenTxs?.[0].txid).toBe('b')
+  })
+
+  it('signals completion with an all-empty chunk', async () => {
+    // The toolbox treats an empty chunk as the completion sentinel.
+    const reader = new RemoteSyncReader(fakeClient([blobA]), wallet, 'dev', 1, settings)
+    await reader.getSyncChunk(args)
+    const done = await reader.getSyncChunk(args)
+    expect(done.provenTxs).toEqual([])
+    expect(done.outputs).toEqual([])
+  })
+
+  it('refuses a broken prevSha256 chain', async () => {
+    // A gap or a fork means the restore would be silently incomplete, which is worse
+    // than failing loudly.
+    const reader = new RemoteSyncReader(fakeClientWithBrokenChain(), wallet, 'dev', 1, settings)
+    await expect(reader.getSyncChunk(args)).rejects.toThrow(/chain/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npx jest __tests__/backupRestore.test.ts -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the reader**
+
+`getSyncChunk` fetches the next blob by sequence, verifies `sha256` and the `prevSha256`
+chain, decrypts, and returns the parsed chunk. When the sequence is exhausted it returns a
+chunk with all 12 arrays present and empty.
+
+- [ ] **Step 4: Implement restore orchestration**
+
+`restoreFromBackup` derives the pseudonym from the recovered `primaryKey`, fetches the
+manifest, selects the device and newest complete generation, then calls
+`WalletStorageManager.syncFromReader(identityKey, reader)`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx jest __tests__/backupRestore.test.ts -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/backup/RemoteSyncReader.ts utils/backup/restore.ts __tests__/backupRestore.test.ts
+git commit -m "feat(backup): restore via WalletStorageSyncReader"
+```
+
+---
+
+### Task 7: End-to-end round trip — the test that proves the feature
+
+**Files:**
+- Test: `__tests__/backupRoundTrip.test.ts`
+
+**Interfaces:**
+- Consumes: everything above
+
+Nothing else in this plan proves the feature works. It also covers a code path that has
+**never executed in this app**: `StorageExpoSQLite.processSyncChunk` is a pass-through
+whose comment implies it was never exercised, and zero tests cover sync anywhere in the
+repo. Treat any failure here as a real defect in the sync layer, not in the test.
+
+- [ ] **Step 1: Write the round-trip test**
+
+```ts
+describe('backup round trip', () => {
+  it('restores outputs and actions into a fresh database', async () => {
+    const primaryKey = new PrivateKey(11).toArray('be', 32)
+
+    // 1. Seed a wallet database with real transactions and outputs.
+    const source = await makeTestStorage('source.db')
+    await seedWallet(source, { transactions: 5, outputs: 12 })
+    const before = await source.listOutputs({ basket: 'default' })
+
+    // 2. Push every chunk into an in-memory fake server.
+    const server = new FakeBackupServer()
+    let guard = 0
+    while (guard++ < 100) {
+      const r = await pushOnce({ storage: source, primaryKey, client: server.client() })
+      if (r.pushed === 0) break
+    }
+    expect(server.blobCount()).toBeGreaterThan(0)
+
+    // 3. Restore into a brand-new database.
+    const target = await makeTestStorage('target.db')
+    await restoreFromBackup({ storage: target, primaryKey, client: server.client() })
+
+    // 4. The restored wallet must be able to spend: same outputs, same derivation data.
+    const after = await target.listOutputs({ basket: 'default' })
+    expect(after.outputs).toHaveLength(before.outputs.length)
+    expect(after.outputs.map(o => o.outpoint).sort())
+      .toEqual(before.outputs.map(o => o.outpoint).sort())
+  })
+
+  it('preserves BRC-29 derivation metadata exactly', async () => {
+    // This is the metadata that exists ONLY in the database and without which an output
+    // cannot be spent. It is the entire reason this feature exists.
+    const primaryKey = new PrivateKey(12).toArray('be', 32)
+    const source = await makeTestStorage('src2.db')
+    await seedBrc29Receipt(source, {
+      senderIdentityKey: '02' + 'ab'.repeat(32),
+      derivationPrefix: 'cHJlZml4',
+      derivationSuffix: 'c3VmZml4',
+    })
+
+    const server = new FakeBackupServer()
+    await drainPush(source, primaryKey, server)
+
+    const target = await makeTestStorage('tgt2.db')
+    await restoreFromBackup({ storage: target, primaryKey, client: server.client() })
+
+    const [out] = (await target.listOutputs({ basket: 'default', include: 'entire transactions' })).outputs
+    expect(out.derivationPrefix).toBe('cHJlZml4')
+    expect(out.derivationSuffix).toBe('c3VmZml4')
+    expect(out.senderIdentityKey).toBe('02' + 'ab'.repeat(32))
+  })
+
+  it('restores from a share-recovered primaryKey', async () => {
+    // Share-restored wallets have no mnemonic and no rootKey. If derivation had used
+    // rootKey, this test would fail and that cohort would be silently locked out.
+    const primaryKey = new PrivateKey(13).toArray('be', 32)
+    const source = await makeTestStorage('src3.db')
+    await seedWallet(source, { transactions: 2, outputs: 3 })
+
+    const server = new FakeBackupServer()
+    await drainPush(source, primaryKey, server)
+
+    const shares = new PrivateKey(primaryKey).toBackupShares(2, 3)
+    const recovered = PrivateKey.fromBackupShares([shares[0], shares[2]]).toArray()
+    expect(recovered).toEqual(primaryKey)
+
+    const target = await makeTestStorage('tgt3.db')
+    await restoreFromBackup({ storage: target, primaryKey: recovered, client: server.client() })
+    expect((await target.listOutputs({ basket: 'default' })).outputs).toHaveLength(3)
+  })
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npx jest __tests__/backupRoundTrip.test.ts -v`
+Expected: PASS. If `processSyncChunk` proves to be a genuine stub, fix the storage layer —
+do not weaken the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/backupRoundTrip.test.ts
+git commit -m "test(backup): end-to-end push and restore round trip"
+```
+
+---
+
+### Task 8: Settings, disclosure and restore UI
+
+**Files:**
+- Modify: `app/settings.tsx`, `app/auth/scan-shares.tsx`, `app/auth/mnemonic.tsx`
+- Modify: `context/i18n/translations.tsx`
+
+**Interfaces:**
+- Consumes: `restoreFromBackup`, `BackupClient`
+
+Backup is **on by default**; opt-in would reproduce the very problem this solves. That
+default means sending an encrypted wallet database to a BSVA-operated server without being
+asked, which requires honesty rather than silence.
+
+- [ ] **Step 1: Add the settings row**
+
+A toggle plus copy stating: what is sent, that it is encrypted with a key only their seed
+can derive, and that the operator cannot read it. Turning it off stops pushing and offers
+to delete the log.
+
+- [ ] **Step 2: Add the restore step to the recovery flows**
+
+After a successful mnemonic entry or share scan, check the manifest and offer to restore.
+If a backup exists, restoring is the default action.
+
+- [ ] **Step 3: Write the disclosure copy**
+
+Never imply the backup replaces the mnemonic. Wording along these lines:
+
+> Your wallet history is backed up, encrypted, so you can recover it on a new device.
+> **You still need your recovery phrase or printed shares** — without them the backup
+> cannot be unlocked, by us or by anyone else.
+
+The warning is the important half. If users believe the cloud backup replaces their paper
+backup they will guard the paper less carefully and end up worse off than before this
+feature existed.
+
+- [ ] **Step 4: Add translations**
+
+Add the new keys to `context/i18n/translations.tsx` for all supported languages.
+
+- [ ] **Step 5: Verify**
+
+Run: `npx tsc --noEmit && npm run lint && npm test`
+Expected: all clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app context
+git commit -m "feat(backup): settings toggle, disclosure copy and restore flow"
+```
+
+---
+
+### Task 9: Device verification
+
+**Files:** none modified
+
+- [ ] **Step 1: Run against the real server**
+
+Point `DEFAULT_BACKUP_URL` at a running instance from the server plan and build:
+
+```bash
+npm run ios-dev-device
+```
+
+- [ ] **Step 2: Confirm pushes happen**
+
+Send a payment, then check the server index. Expected: a new chunk within a minute, and no
+visible UI jank while it uploads.
+
+- [ ] **Step 3: Restore onto a second device**
+
+Install on a clean device, enter the same mnemonic, restore. Expected: transaction history
+and balance match the source device.
+
+- [ ] **Step 4: Spend from the restored wallet**
+
+This is the real acceptance test for the entire feature. Send a payment from the restored
+wallet using an output it learned about only through the backup log. If that broadcasts,
+the derivation metadata survived and the problem is solved.
+
+- [ ] **Step 5: Run the Android emulator pass**
+
+```bash
+npm run android
+```
+
+Project convention: always run the Android emulator, since it has caught races iOS did not.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit --allow-empty -m "test(backup): device verification — restore and spend confirmed"
+```
+
+---
+
+## Acceptance
+
+- Frozen derivation vector test green; pseudonym differs from the wallet identity key
+- Chunks round-trip byte-exactly, including all `number[]` binary fields
+- A different key cannot decrypt another's ciphertext
+- No request carries an identity parameter
+- Round-trip test restores outputs, actions and BRC-29 derivation metadata into a fresh DB
+- Share-recovered `primaryKey` restores successfully
+- Push never blocks the JS thread for more than 100ms
+- A payment sent from a restored wallet, on a device, broadcasts and confirms

--- a/docs/superpowers/plans/2026-08-15-wallet-backup-server-go.md
+++ b/docs/superpowers/plans/2026-08-15-wallet-backup-server-go.md
@@ -1,0 +1,1354 @@
+# Wallet Backup Blob-Log Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A Go HTTP service that stores append-only, opaque encrypted blobs for wallet backup and recovery, authenticated by BRC-103/104, structurally incapable of reading what it stores.
+
+**Architecture:** A small chi service in the house style of `go-uhrp-storage-server`. Clients authenticate with `go-bsv-middleware`; the authenticated identity key *is* the account address, and no request anywhere carries a client-supplied identity. Blobs are AES-GCM ciphertext the server never decrypts, stored in Postgres `bytea` behind a `BlobStore` interface, organised as `(pseudonym, deviceId, generation, seq)` with two generations retained and no idle expiry.
+
+**Tech Stack:** Go 1.26.3, chi v5, `github.com/bsv-blockchain/go-sdk`, `github.com/bsv-blockchain/go-bsv-middleware`, Postgres (`lib/pq`), `log/slog`, `database/sql`, testify, Docker.
+
+## Global Constraints
+
+- Module path `github.com/bsv-blockchain/go-wallet-backup-server`, Go **1.26.3**, no `toolchain` line.
+- **The account address is `ShouldGetAuthenticatedIdentity(ctx).ToDERHex()` and nothing else.** No request body, query parameter, path segment, or header may supply an identity. This is not a style preference — `go-wallet-toolbox` has a live cross-tenant auth bypass from exactly this mistake.
+- The server **must never be able to decrypt a blob**. No decrypt call, no server key in any encryption protocol, no plaintext parsing of blob bytes.
+- Auth middleware mounts at the **origin root**, never under a subtree. The TS client posts its handshake to `${origin}/.well-known/auth` on an exact-path match.
+- **Do not construct the payment middleware.** `NewPayment` without `WithRequestPriceCalculator` silently charges 100 sat/request, and its path dereferences `CompletedProtoWallet.InternalizeAction`, which returns `(nil, nil)`.
+- **No streaming is possible behind the auth middleware** — its `ResponseWriterWrapper` buffers to sign responses and implements neither `http.Flusher` nor `http.Hijacker`. Every request and response is fully buffered, so `http.MaxBytesReader` and a hard **1 MiB** blob cap are mandatory, not defensive.
+- Error envelope: `{"status":"error","code":"ERR_SCREAMING_SNAKE","description":"Human sentence."}`. Success: `{"status":"success", ...}`. Slices normalised to `[]`, never `null`.
+- `SERVER_PRIVATE_KEY` is 64-char hex from env with **no dev default**; fail fast at startup if unset.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `cmd/server/main.go` | Composition root: config, logger, wallet, store, server, graceful shutdown |
+| `internal/config/config.go` | `Config` struct + `Load()` from `os.Getenv` |
+| `internal/logger/logger.go` | `Configure(level, format) *slog.Logger` |
+| `internal/wallet/wallet.go` | Server identity from hex key |
+| `internal/server/server.go` | chi router, middleware chain, route groups |
+| `internal/server/middlewares/identity.go` | `RequireIdentityKey`, `GetIdentityKey` |
+| `internal/server/responses/responses.go` | `WriteJSON` / `WriteError` envelope |
+| `internal/server/handlers/append.go` | `POST /v1/log/{deviceId}` |
+| `internal/server/handlers/read.go` | `GET` index, blob, manifest |
+| `internal/server/handlers/prune.go` | `DELETE /v1/generation/{deviceId}/{generation}` |
+| `internal/server/handlers/health.go` | `GET /health` |
+| `internal/blobstore/blobstore.go` | `BlobStore` interface + `BlobKey` |
+| `internal/blobstore/postgres.go` | Postgres implementation |
+| `internal/store/migrations.go` | Idempotent `CREATE TABLE IF NOT EXISTS` list |
+| `test-client/` | Node + `@bsv/sdk` AuthFetch interop tests |
+
+---
+
+### Task 1: Scaffold, config, logger, health endpoint
+
+**Files:**
+- Create: `go.mod`, `cmd/server/main.go`, `internal/config/config.go`, `internal/logger/logger.go`, `internal/server/server.go`, `internal/server/responses/responses.go`, `internal/server/handlers/health.go`
+- Test: `internal/config/config_test.go`, `internal/server/handlers/health_test.go`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `config.Config{Port, ServerPrivateKey, DatabaseURL, LogLevel, LogFormat, MaxBlobBytes}`, `config.Load() (*Config, error)`, `logger.Configure(level, format string) *slog.Logger`, `responses.WriteJSON(w, status int, payload any)`, `responses.WriteError(w, status int, code, description string)`, `server.New(...) *http.Server`.
+
+- [ ] **Step 1: Write the failing config test**
+
+```go
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadRequiresServerPrivateKey(t *testing.T) {
+	t.Setenv("SERVER_PRIVATE_KEY", "")
+	_, err := Load()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SERVER_PRIVATE_KEY")
+}
+
+func TestLoadRejectsMalformedKey(t *testing.T) {
+	t.Setenv("SERVER_PRIVATE_KEY", "nothex")
+	_, err := Load()
+	require.Error(t, err)
+}
+
+func TestLoadDefaults(t *testing.T) {
+	t.Setenv("SERVER_PRIVATE_KEY", "0000000000000000000000000000000000000000000000000000000000000001")
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 8080, cfg.Port)
+	require.Equal(t, int64(1<<20), cfg.MaxBlobBytes)
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./internal/config/ -v`
+Expected: FAIL — package does not compile, `Load` undefined.
+
+- [ ] **Step 3: Implement config**
+
+```go
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+type Config struct {
+	Port             int
+	ServerPrivateKey string
+	DatabaseURL      string
+	LogLevel         string
+	LogFormat        string
+	MaxBlobBytes     int64
+}
+
+func Load() (*Config, error) {
+	key := os.Getenv("SERVER_PRIVATE_KEY")
+	if key == "" {
+		return nil, errors.New("SERVER_PRIVATE_KEY is not defined in environment variables")
+	}
+	if len(key) != 64 {
+		return nil, fmt.Errorf("SERVER_PRIVATE_KEY must be 64 hex characters, got %d", len(key))
+	}
+	for _, c := range key {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return nil, errors.New("SERVER_PRIVATE_KEY must be hexadecimal")
+		}
+	}
+	return &Config{
+		Port:             getEnvInt("PORT", 8080),
+		ServerPrivateKey: key,
+		DatabaseURL:      getEnvDefault("DATABASE_URL", "postgres://localhost:5432/wallet_backup?sslmode=disable"),
+		LogLevel:         getEnvDefault("LOG_LEVEL", "info"),
+		LogFormat:        getEnvDefault("LOG_FORMAT", "json"),
+		MaxBlobBytes:     int64(getEnvInt("MAX_BLOB_BYTES", 1<<20)),
+	}, nil
+}
+
+func getEnvDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+func getEnvInt(k string, d int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return d
+}
+```
+
+- [ ] **Step 4: Run the config test**
+
+Run: `go test ./internal/config/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Implement logger and responses**
+
+```go
+// internal/logger/logger.go
+package logger
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func Configure(level, format string) *slog.Logger {
+	var l slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		l = slog.LevelDebug
+	case "warn":
+		l = slog.LevelWarn
+	case "error":
+		l = slog.LevelError
+	default:
+		l = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: l}
+	var h slog.Handler = slog.NewJSONHandler(os.Stdout, opts)
+	if strings.ToLower(format) == "text" {
+		h = slog.NewTextHandler(os.Stdout, opts)
+	}
+	lg := slog.New(h)
+	slog.SetDefault(lg)
+	return lg
+}
+```
+
+```go
+// internal/server/responses/responses.go
+package responses
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ErrorBody struct {
+	Status      string `json:"status"`
+	Code        string `json:"code"`
+	Description string `json:"description"`
+}
+
+func WriteJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func WriteError(w http.ResponseWriter, status int, code, description string) {
+	WriteJSON(w, status, ErrorBody{Status: "error", Code: code, Description: description})
+}
+```
+
+- [ ] **Step 6: Write the health handler test**
+
+```go
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakePinger struct{ err error }
+
+func (f fakePinger) Ping() error { return f.err }
+
+func TestHealthOK(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Health(fakePinger{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"status":"ok"`)
+}
+
+func TestHealthDegraded(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Health(fakePinger{err: http.ErrServerClosed}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+```
+
+- [ ] **Step 7: Implement the health handler**
+
+```go
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/server/responses"
+)
+
+type Pinger interface{ Ping() error }
+
+func Health(p Pinger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := p.Ping(); err != nil {
+			responses.WriteJSON(w, http.StatusServiceUnavailable,
+				map[string]any{"status": "degraded", "details": map[string]any{"database": err.Error()}})
+			return
+		}
+		responses.WriteJSON(w, http.StatusOK,
+			map[string]any{"status": "ok", "details": map[string]any{"database": "ok"}})
+	})
+}
+```
+
+- [ ] **Step 8: Run the handler tests**
+
+Run: `go test ./internal/server/... -v`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add go.mod go.sum cmd internal
+git commit -m "feat: scaffold service with config, logger, responses and health"
+```
+
+---
+
+### Task 2: Server identity and BRC-103/104 auth
+
+**Files:**
+- Create: `internal/wallet/wallet.go`, `internal/server/middlewares/identity.go`
+- Modify: `internal/server/server.go`
+- Test: `internal/server/middlewares/identity_test.go`
+
+**Interfaces:**
+- Consumes: `config.Config` from Task 1
+- Produces: `wallet.NewServerIdentity(hexKey string) (sdkwallet.Interface, error)`, `middlewares.RequireIdentityKey(next http.Handler) http.Handler`, `middlewares.GetIdentityKey(ctx context.Context) *ec.PublicKey`, and a router with the auth boundary in place.
+
+- [ ] **Step 1: Add dependencies**
+
+```bash
+go get github.com/bsv-blockchain/go-sdk@v1.2.23
+go get github.com/bsv-blockchain/go-bsv-middleware@v0.13.5
+go get github.com/go-chi/chi/v5
+go get github.com/stretchr/testify
+```
+
+- [ ] **Step 2: Implement the server identity**
+
+```go
+package wallet
+
+import (
+	"fmt"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	sdkwallet "github.com/bsv-blockchain/go-sdk/wallet"
+)
+
+// NewServerIdentity builds a key-only wallet for BRC-103/104 auth. It has no storage and
+// no chain access — deliberately, since this service never transacts.
+func NewServerIdentity(hexKey string) (sdkwallet.Interface, error) {
+	priv, err := ec.PrivateKeyFromHex(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse server key: %w", err)
+	}
+	w, err := sdkwallet.NewCompletedProtoWallet(priv)
+	if err != nil {
+		return nil, fmt.Errorf("build server wallet: %w", err)
+	}
+	return w, nil
+}
+```
+
+- [ ] **Step 3: Write the identity middleware test**
+
+```go
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireIdentityKeyRejectsUnauthenticated(t *testing.T) {
+	called := false
+	h := RequireIdentityKey(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+
+	rec := httptest.NewRecorder()
+	// No auth middleware ran, so no identity is in the context.
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/manifest", nil))
+
+	require.False(t, called, "handler must not run without an authenticated identity")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Contains(t, rec.Body.String(), "ERR_AUTH_REQUIRED")
+}
+```
+
+- [ ] **Step 4: Run it**
+
+Run: `go test ./internal/server/middlewares/ -v`
+Expected: FAIL — `RequireIdentityKey` undefined.
+
+- [ ] **Step 5: Implement the identity middleware**
+
+The re-stash under a local typed key is what makes handlers unit-testable; the library's
+own context key is unexported, so without it handler tests can only ever assert 401.
+
+```go
+package middlewares
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bsv-blockchain/go-bsv-middleware/pkg/middleware"
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/server/responses"
+)
+
+type ctxKey struct{}
+
+var identityContextKey = ctxKey{}
+
+func RequireIdentityKey(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key, err := middleware.ShouldGetAuthenticatedIdentity(r.Context())
+		if err != nil || key == nil || middleware.IsUnknownIdentity(key) {
+			responses.WriteError(w, http.StatusUnauthorized, "ERR_AUTH_REQUIRED", "Authentication required.")
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), identityContextKey, key)))
+	})
+}
+
+// GetIdentityKey returns the authenticated caller's key, or nil.
+// This is the ONLY source of an account address in this service.
+func GetIdentityKey(ctx context.Context) *ec.PublicKey {
+	k, _ := ctx.Value(identityContextKey).(*ec.PublicKey)
+	return k
+}
+
+// WithIdentityKey injects an identity for tests.
+func WithIdentityKey(ctx context.Context, k *ec.PublicKey) context.Context {
+	return context.WithValue(ctx, identityContextKey, k)
+}
+```
+
+- [ ] **Step 6: Run the test**
+
+Run: `go test ./internal/server/middlewares/ -v`
+Expected: PASS
+
+- [ ] **Step 7: Wire the router**
+
+Mounting is the part that silently breaks. The auth middleware intercepts
+`POST /.well-known/auth` on an exact path compare and never calls `next`, and the TS client
+always posts the handshake to the origin root. Mounting under `/api` would 401 everything.
+
+```go
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/bsv-blockchain/go-bsv-middleware/pkg/middleware"
+	"github.com/bsv-blockchain/go-sdk/auth"
+	sdkwallet "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
+	"log/slog"
+
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/blobstore"
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/server/handlers"
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/server/middlewares"
+)
+
+type Deps struct {
+	Wallet       sdkwallet.Interface
+	Store        blobstore.BlobStore
+	Pinger       handlers.Pinger
+	Logger       *slog.Logger
+	MaxBlobBytes int64
+	Port         int
+}
+
+func New(d Deps) *http.Server {
+	r := chi.NewRouter()
+	r.Use(chimw.RequestID, chimw.Logger, chimw.Recoverer)
+	r.Use(corsMiddleware)
+	r.Use(maxBody(d.MaxBlobBytes))
+
+	r.Method(http.MethodGet, "/health", handlers.Health(d.Pinger))
+
+	// Single SessionManager instance shared by both mounts. Replace with a shared
+	// implementation before running more than one replica: sessions are in-process, so
+	// a handshake on replica A followed by a request on replica B returns
+	// 401 session-not-found.
+	sessions := auth.NewSessionManager()
+	authMW := middleware.NewAuth(d.Wallet,
+		middleware.WithAuthDisallowUnauthenticated(),
+		middleware.WithAuthSessionManager(sessions),
+		middleware.WithAuthLogger(d.Logger),
+	)
+
+	// Handled inside the middleware; the wrapped handler is never reached.
+	r.Handle("/.well-known/auth", authMW.HTTPHandler(http.NotFoundHandler()))
+
+	r.Group(func(r chi.Router) {
+		r.Use(authMW.HTTPHandler)
+		r.Use(middlewares.RequireIdentityKey)
+
+		r.Get("/v1/manifest", handlers.Manifest(d.Store))
+		r.Post("/v1/log/{deviceId}", handlers.Append(d.Store, d.MaxBlobBytes))
+		r.Get("/v1/log/{deviceId}", handlers.Index(d.Store))
+		r.Get("/v1/log/{deviceId}/{seq}", handlers.Blob(d.Store))
+		r.Delete("/v1/generation/{deviceId}/{generation}", handlers.PruneGeneration(d.Store))
+	})
+
+	return &http.Server{
+		Addr:              fmt.Sprintf(":%d", d.Port),
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+}
+
+func maxBody(n int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, n+4096) // blob cap plus envelope slack
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		// AuthFetch reads x-bsv-auth-* off the response; without this they are hidden.
+		w.Header().Set("Access-Control-Expose-Headers", "*")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal cmd go.mod go.sum
+git commit -m "feat: BRC-103/104 auth boundary with identity-only account addressing"
+```
+
+---
+
+### Task 3: Blob store, schema and migrations
+
+**Files:**
+- Create: `internal/blobstore/blobstore.go`, `internal/blobstore/postgres.go`, `internal/store/migrations.go`
+- Test: `internal/blobstore/postgres_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks
+- Produces:
+
+```go
+type BlobKey struct {
+	Pseudonym  string // 66-char compressed hex, from auth only
+	DeviceID   string
+	Generation int
+	Seq        int
+}
+
+type Entry struct {
+	Seq        int       `json:"seq"`
+	Sha256     string    `json:"sha256"`
+	PrevSha256 string    `json:"prevSha256"`
+	Size       int       `json:"size"`
+	CreatedAt  time.Time `json:"createdAt"`
+}
+
+type DeviceSummary struct {
+	DeviceID   string    `json:"deviceId"`
+	Generation int       `json:"generation"`
+	HeadSeq    int       `json:"headSeq"`
+	HeadSha256 string    `json:"headSha256"`
+	TotalBytes int64     `json:"totalBytes"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+type BlobStore interface {
+	Append(ctx context.Context, k BlobKey, prevSha256 string, data []byte) (sha string, err error)
+	Get(ctx context.Context, k BlobKey) ([]byte, error)
+	Index(ctx context.Context, pseudonym, deviceID string, generation, from, limit int) ([]Entry, error)
+	Manifest(ctx context.Context, pseudonym string) ([]DeviceSummary, error)
+	DeleteGeneration(ctx context.Context, pseudonym, deviceID string, generation int) (int64, error)
+	Ping() error
+}
+
+var (
+	ErrSeqConflict = errors.New("sequence conflict")
+	ErrNotFound    = errors.New("not found")
+)
+```
+
+- [ ] **Step 1: Write the schema**
+
+```go
+package store
+
+var Migrations = []string{
+	`CREATE TABLE IF NOT EXISTS blob_log (
+		pseudonym    TEXT        NOT NULL,
+		device_id    TEXT        NOT NULL,
+		generation   INTEGER     NOT NULL,
+		seq          INTEGER     NOT NULL,
+		sha256       TEXT        NOT NULL,
+		prev_sha256  TEXT,
+		ciphertext   BYTEA       NOT NULL,
+		created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+		PRIMARY KEY (pseudonym, device_id, generation, seq)
+	)`,
+	`CREATE INDEX IF NOT EXISTS blob_log_head
+		ON blob_log (pseudonym, device_id, generation, seq DESC)`,
+}
+
+func Migrate(db *sql.DB) error {
+	for i, m := range Migrations {
+		if _, err := db.Exec(m); err != nil {
+			return fmt.Errorf("migration %d: %w", i, err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Write the failing store test**
+
+```go
+func TestAppendEnforcesContiguousSeq(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	k := BlobKey{Pseudonym: "02aa", DeviceID: "d1", Generation: 1, Seq: 1}
+
+	_, err := s.Append(ctx, k, "", []byte("one"))
+	require.NoError(t, err)
+
+	// Re-appending the same seq must conflict, not overwrite. Overwriting would let a
+	// bug or a racing device silently destroy a backup entry.
+	_, err = s.Append(ctx, k, "", []byte("different"))
+	require.ErrorIs(t, err, ErrSeqConflict)
+
+	// Skipping a sequence number must be refused, or restore would hit a silent hole.
+	k.Seq = 3
+	_, err = s.Append(ctx, k, "", []byte("three"))
+	require.ErrorIs(t, err, ErrSeqConflict)
+}
+
+func TestAppendReturnsSha256(t *testing.T) {
+	s := newTestStore(t)
+	sha, err := s.Append(context.Background(),
+		BlobKey{Pseudonym: "02aa", DeviceID: "d1", Generation: 1, Seq: 1}, "", []byte("hello"))
+	require.NoError(t, err)
+	sum := sha256.Sum256([]byte("hello"))
+	require.Equal(t, hex.EncodeToString(sum[:]), sha)
+}
+
+func TestGetIsScopedToPseudonym(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	_, err := s.Append(ctx, BlobKey{Pseudonym: "02aa", DeviceID: "d1", Generation: 1, Seq: 1}, "", []byte("secret"))
+	require.NoError(t, err)
+
+	// A different pseudonym must not see it, even with every other field identical.
+	_, err = s.Get(ctx, BlobKey{Pseudonym: "02bb", DeviceID: "d1", Generation: 1, Seq: 1})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `go test ./internal/blobstore/ -v`
+Expected: FAIL — package does not compile.
+
+- [ ] **Step 4: Implement the Postgres store**
+
+The append is a single transaction that reads the current head and inserts only if the
+new sequence is exactly head+1.
+
+```go
+func (s *PostgresStore) Append(ctx context.Context, k BlobKey, prev string, data []byte) (string, error) {
+	sum := sha256.Sum256(data)
+	sha := hex.EncodeToString(sum[:])
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var head sql.NullInt64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT MAX(seq) FROM blob_log WHERE pseudonym=$1 AND device_id=$2 AND generation=$3`,
+		k.Pseudonym, k.DeviceID, k.Generation).Scan(&head); err != nil {
+		return "", err
+	}
+
+	expected := 1
+	if head.Valid {
+		expected = int(head.Int64) + 1
+	}
+	if k.Seq != expected {
+		return "", fmt.Errorf("%w: expected seq %d, got %d", ErrSeqConflict, expected, k.Seq)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO blob_log (pseudonym, device_id, generation, seq, sha256, prev_sha256, ciphertext)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+		k.Pseudonym, k.DeviceID, k.Generation, k.Seq, sha, nullable(prev), data); err != nil {
+		return "", err
+	}
+	return sha, tx.Commit()
+}
+```
+
+Implement `Get`, `Index`, `Manifest`, `DeleteGeneration` and `Ping` in the same file. Every
+query's `WHERE` clause must include `pseudonym=$1`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `go test ./internal/blobstore/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/blobstore internal/store
+git commit -m "feat: postgres blob store with contiguous-seq append and pseudonym scoping"
+```
+
+---
+
+### Task 4: Append handler
+
+**Files:**
+- Create: `internal/server/handlers/append.go`
+- Test: `internal/server/handlers/append_test.go`
+
+**Interfaces:**
+- Consumes: `blobstore.BlobStore`, `middlewares.GetIdentityKey`, `middlewares.WithIdentityKey`
+- Produces: `handlers.Append(store blobstore.BlobStore, maxBytes int64) http.HandlerFunc`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestAppendRejectsNonOctetStream(t *testing.T) {
+	rec, req := newAuthedRequest(t, http.MethodPost, "/v1/log/"+validDevice+"?seq=1&generation=1", []byte("x"))
+	req.Header.Set("Content-Type", "application/json")
+	route(t, fakeStore{}).ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnsupportedMediaType, rec.Code)
+}
+
+func TestAppendRejectsOversizeBlob(t *testing.T) {
+	rec, req := newAuthedRequest(t, http.MethodPost, "/v1/log/"+validDevice+"?seq=1&generation=1",
+		make([]byte, (1<<20)+1))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	route(t, fakeStore{}).ServeHTTP(rec, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	require.Contains(t, rec.Body.String(), "ERR_BLOB_TOO_LARGE")
+}
+
+func TestAppendRejectsMalformedDeviceID(t *testing.T) {
+	rec, req := newAuthedRequest(t, http.MethodPost, "/v1/log/NOT-HEX?seq=1&generation=1", []byte("x"))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	route(t, fakeStore{}).ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "ERR_INVALID_DEVICE_ID")
+}
+
+func TestAppendUsesAuthenticatedIdentityAsPseudonym(t *testing.T) {
+	// The security property of the whole service: the row key comes from auth, and a
+	// client cannot influence it. There is no identity parameter to try to spoof, so
+	// this asserts the handler reads from the context and nowhere else.
+	var captured blobstore.BlobKey
+	store := fakeStore{onAppend: func(k blobstore.BlobKey) { captured = k }}
+
+	rec, req := newAuthedRequestAs(t, testPubKeyHex, http.MethodPost,
+		"/v1/log/"+validDevice+"?seq=1&generation=1", []byte("blob"))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	route(t, store).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.Equal(t, testPubKeyHex, captured.Pseudonym)
+}
+
+func TestAppendReturnsSeqConflictAs409(t *testing.T) {
+	store := fakeStore{err: blobstore.ErrSeqConflict}
+	rec, req := newAuthedRequest(t, http.MethodPost, "/v1/log/"+validDevice+"?seq=5&generation=1", []byte("x"))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	route(t, store).ServeHTTP(rec, req)
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.Contains(t, rec.Body.String(), "ERR_SEQ_CONFLICT")
+}
+```
+
+- [ ] **Step 2: Run them**
+
+Run: `go test ./internal/server/handlers/ -run TestAppend -v`
+Expected: FAIL — `Append` undefined.
+
+- [ ] **Step 3: Implement the handler**
+
+```go
+package handlers
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/blobstore"
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/server/middlewares"
+	"github.com/bsv-blockchain/go-wallet-backup-server/internal/server/responses"
+)
+
+var deviceIDPattern = regexp.MustCompile(`^[a-f0-9]{32}$`)
+
+func Append(store blobstore.BlobStore, maxBytes int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key := middlewares.GetIdentityKey(r.Context())
+		if key == nil {
+			responses.WriteError(w, http.StatusUnauthorized, "ERR_AUTH_REQUIRED", "Authentication required.")
+			return
+		}
+
+		if r.Header.Get("Content-Type") != "application/octet-stream" {
+			responses.WriteError(w, http.StatusUnsupportedMediaType, "ERR_UNSUPPORTED_MEDIA_TYPE",
+				"Body must be application/octet-stream.")
+			return
+		}
+
+		deviceID := chi.URLParam(r, "deviceId")
+		if !deviceIDPattern.MatchString(deviceID) {
+			responses.WriteError(w, http.StatusBadRequest, "ERR_INVALID_DEVICE_ID",
+				"Device id must be 32 lowercase hex characters.")
+			return
+		}
+
+		seq, err1 := strconv.Atoi(r.URL.Query().Get("seq"))
+		generation, err2 := strconv.Atoi(r.URL.Query().Get("generation"))
+		if err1 != nil || err2 != nil || seq < 1 || generation < 1 {
+			responses.WriteError(w, http.StatusBadRequest, "ERR_INVALID_PARAMS",
+				"seq and generation must be positive integers.")
+			return
+		}
+
+		// Bounded read. No streaming is possible behind the auth middleware, so this is
+		// fully buffered by design and the cap is what keeps it safe.
+		data, err := io.ReadAll(io.LimitReader(r.Body, maxBytes+1))
+		if err != nil {
+			responses.WriteError(w, http.StatusRequestEntityTooLarge, "ERR_BLOB_TOO_LARGE",
+				"Blob exceeds the maximum size.")
+			return
+		}
+		if int64(len(data)) > maxBytes {
+			responses.WriteError(w, http.StatusRequestEntityTooLarge, "ERR_BLOB_TOO_LARGE",
+				"Blob exceeds the maximum size.")
+			return
+		}
+
+		// The account address comes from auth and only from auth.
+		k := blobstore.BlobKey{
+			Pseudonym:  key.ToDERHex(),
+			DeviceID:   deviceID,
+			Generation: generation,
+			Seq:        seq,
+		}
+
+		sha, err := store.Append(r.Context(), k, r.URL.Query().Get("prevSha256"), data)
+		switch {
+		case errors.Is(err, blobstore.ErrSeqConflict):
+			responses.WriteError(w, http.StatusConflict, "ERR_SEQ_CONFLICT", err.Error())
+		case err != nil:
+			responses.WriteError(w, http.StatusInternalServerError, "ERR_INTERNAL", "Could not store the blob.")
+		default:
+			responses.WriteJSON(w, http.StatusCreated,
+				map[string]any{"status": "success", "seq": seq, "sha256": sha})
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/server/handlers/ -run TestAppend -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/handlers
+git commit -m "feat: append handler with size cap and auth-derived addressing"
+```
+
+---
+
+### Task 5: Read handlers — manifest, index, blob
+
+**Files:**
+- Create: `internal/server/handlers/read.go`
+- Test: `internal/server/handlers/read_test.go`
+
+**Interfaces:**
+- Consumes: `blobstore.BlobStore`
+- Produces: `handlers.Manifest(store)`, `handlers.Index(store)`, `handlers.Blob(store)` — all `http.HandlerFunc`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestManifestReturnsEmptyArrayNotNull(t *testing.T) {
+	rec, req := newAuthedRequest(t, http.MethodGet, "/v1/manifest", nil)
+	route(t, fakeStore{devices: nil}).ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"devices":[]`)
+	require.NotContains(t, rec.Body.String(), "null")
+}
+
+func TestBlobReturnsRawOctetStream(t *testing.T) {
+	payload := []byte{0x00, 0xff, 0x10}
+	rec, req := newAuthedRequest(t, http.MethodGet, "/v1/log/"+validDevice+"/1?generation=1", nil)
+	route(t, fakeStore{blob: payload}).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/octet-stream", rec.Header().Get("Content-Type"))
+	require.Equal(t, payload, rec.Body.Bytes())
+}
+
+func TestBlobNotFound(t *testing.T) {
+	rec, req := newAuthedRequest(t, http.MethodGet, "/v1/log/"+validDevice+"/99?generation=1", nil)
+	route(t, fakeStore{err: blobstore.ErrNotFound}).ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "ERR_BLOB_NOT_FOUND")
+}
+```
+
+- [ ] **Step 2: Run them**
+
+Run: `go test ./internal/server/handlers/ -run 'TestManifest|TestBlob' -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the read handlers**
+
+Each reads the pseudonym from `middlewares.GetIdentityKey` and passes it to the store.
+`Blob` writes raw bytes with `Content-Type: application/octet-stream`; the others use
+`responses.WriteJSON`. Normalise nil slices to `[]T{}` before encoding.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/server/handlers/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/handlers
+git commit -m "feat: manifest, index and blob read handlers"
+```
+
+---
+
+### Task 6: Generation pruning and retention
+
+**Files:**
+- Create: `internal/server/handlers/prune.go`
+- Test: `internal/server/handlers/prune_test.go`, `internal/blobstore/retention_test.go`
+
+**Interfaces:**
+- Consumes: `blobstore.BlobStore.DeleteGeneration`
+- Produces: `handlers.PruneGeneration(store) http.HandlerFunc`
+
+Retention is **keep the current and previous generation**. Two, so a failed compaction
+never leaves a user with zero backups. There is no idle expiry: a pseudonym untouched for
+years belongs to exactly the user this service exists for.
+
+- [ ] **Step 1: Write the failing retention tests**
+
+```go
+func TestDeleteGenerationRefusesTheTwoNewest(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for gen := 1; gen <= 3; gen++ {
+		_, err := s.Append(ctx, BlobKey{Pseudonym: "02aa", DeviceID: "d1", Generation: gen, Seq: 1}, "", []byte("x"))
+		require.NoError(t, err)
+	}
+
+	// Generations 3 (current) and 2 (previous) must survive.
+	_, err := s.DeleteGeneration(ctx, "02aa", "d1", 3)
+	require.Error(t, err)
+	_, err = s.DeleteGeneration(ctx, "02aa", "d1", 2)
+	require.Error(t, err)
+
+	// Generation 1 is now redundant and may go.
+	n, err := s.DeleteGeneration(ctx, "02aa", "d1", 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+}
+
+func TestDeleteGenerationIsScopedToPseudonym(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for gen := 1; gen <= 3; gen++ {
+		_, err := s.Append(ctx, BlobKey{Pseudonym: "02aa", DeviceID: "d1", Generation: gen, Seq: 1}, "", []byte("x"))
+		require.NoError(t, err)
+	}
+	n, err := s.DeleteGeneration(ctx, "02bb", "d1", 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), n, "must not delete another pseudonym's data")
+}
+```
+
+- [ ] **Step 2: Run them**
+
+Run: `go test ./internal/blobstore/ -run TestDeleteGeneration -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the guard in DeleteGeneration**
+
+```go
+func (s *PostgresStore) DeleteGeneration(ctx context.Context, pseudonym, deviceID string, generation int) (int64, error) {
+	var newest sql.NullInt64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT MAX(generation) FROM blob_log WHERE pseudonym=$1 AND device_id=$2`,
+		pseudonym, deviceID).Scan(&newest); err != nil {
+		return 0, err
+	}
+	// Keep the current and previous generation so a failed compaction never leaves the
+	// user with nothing to restore from.
+	if newest.Valid && generation > int(newest.Int64)-2 {
+		return 0, fmt.Errorf("refusing to delete generation %d: within the two retained generations", generation)
+	}
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM blob_log WHERE pseudonym=$1 AND device_id=$2 AND generation=$3`,
+		pseudonym, deviceID, generation)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/blobstore/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Implement the handler and test it**
+
+`PruneGeneration` maps the retention error to `409 ERR_RETENTION_GUARD` and success to
+`204`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal
+git commit -m "feat: generation pruning with a two-generation retention floor"
+```
+
+---
+
+### Task 7: Cross-tenant security suite
+
+**Files:**
+- Create: `internal/server/security_test.go`
+
+**Interfaces:**
+- Consumes: the full router from Task 2 and all handlers
+- Produces: proof that identity A cannot reach identity B's data on **every** route.
+
+This exists because `go-wallet-toolbox` shipped precisely this bug. A table-driven test
+over every route is the guard.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestNoRouteLeaksAcrossIdentities(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	alice := "02" + strings.Repeat("aa", 32)
+	bob := "02" + strings.Repeat("bb", 32)
+	device := strings.Repeat("a", 32)
+
+	_, err := store.Append(ctx, blobstore.BlobKey{
+		Pseudonym: alice, DeviceID: device, Generation: 1, Seq: 1,
+	}, "", []byte("alice-secret"))
+	require.NoError(t, err)
+
+	routes := []struct {
+		name, method, path string
+	}{
+		{"manifest", http.MethodGet, "/v1/manifest"},
+		{"index", http.MethodGet, "/v1/log/" + device + "?generation=1"},
+		{"blob", http.MethodGet, "/v1/log/" + device + "/1?generation=1"},
+		{"prune", http.MethodDelete, "/v1/generation/" + device + "/1"},
+	}
+
+	for _, rt := range routes {
+		t.Run(rt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := authedAs(t, bob, rt.method, rt.path, nil)
+			routerFor(store).ServeHTTP(rec, req)
+
+			require.NotContains(t, rec.Body.String(), "alice-secret",
+				"%s leaked another identity's blob content", rt.name)
+			require.NotEqual(t, http.StatusOK, rec.Code,
+				"%s returned another identity's data", rt.name)
+		})
+	}
+}
+
+func TestAppendCannotWriteIntoAnotherIdentitysLog(t *testing.T) {
+	store := newTestStore(t)
+	alice := "02" + strings.Repeat("aa", 32)
+	bob := "02" + strings.Repeat("bb", 32)
+	device := strings.Repeat("a", 32)
+
+	rec := httptest.NewRecorder()
+	req := authedAs(t, bob, http.MethodPost, "/v1/log/"+device+"?seq=1&generation=1", []byte("bob-wrote-this"))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	routerFor(store).ServeHTTP(rec, req)
+
+	// Bob's write lands under Bob's pseudonym, never Alice's.
+	_, err := store.Get(context.Background(), blobstore.BlobKey{
+		Pseudonym: alice, DeviceID: device, Generation: 1, Seq: 1,
+	})
+	require.ErrorIs(t, err, blobstore.ErrNotFound)
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `go test ./internal/server/ -run 'TestNoRouteLeaks|TestAppendCannot' -v`
+Expected: PASS if the handlers were implemented correctly. **If any subtest fails, that is
+a real cross-tenant vulnerability — fix the handler, never the test.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/server/security_test.go
+git commit -m "test: prove no route leaks across authenticated identities"
+```
+
+---
+
+### Task 8: TypeScript interop test
+
+**Files:**
+- Create: `test-client/package.json`, `test-client/backup.test.ts`, `docker-compose.test.yml`
+
+**Interfaces:**
+- Consumes: the running server
+- Produces: proof that the real `@bsv/sdk` `AuthFetch` client can complete the handshake and round-trip a blob. Unit tests cannot prove this — they never exercise BRC-103/104 framing.
+
+`go-bsv-middleware` already ships a dockerized Node client driving the Go middleware; copy
+that harness shape.
+
+- [ ] **Step 1: Write the interop test**
+
+```ts
+import { AuthFetch, CompletedProtoWallet, PrivateKey } from '@bsv/sdk'
+import { randomBytes } from 'crypto'
+
+const BASE = process.env.SERVER_URL ?? 'http://localhost:8080'
+
+function clientFor (priv = PrivateKey.fromRandom()): { fetch: AuthFetch, key: string } {
+  const wallet = new CompletedProtoWallet(priv)
+  return { fetch: new AuthFetch(wallet), key: priv.toPublicKey().toString() }
+}
+
+describe('backup log interop', () => {
+  it('round-trips a blob as raw binary', async () => {
+    const { fetch } = clientFor()
+    const device = randomBytes(16).toString('hex')
+    const blob = randomBytes(4096)
+
+    const put = await fetch.fetch(`${BASE}/v1/log/${device}?seq=1&generation=1`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: blob,
+    })
+    expect(put.status).toBe(201)
+
+    const got = await fetch.fetch(`${BASE}/v1/log/${device}/1?generation=1`, { method: 'GET' })
+    expect(got.status).toBe(200)
+    expect(Buffer.from(await got.arrayBuffer())).toEqual(blob)
+  })
+
+  it('rejects a second write to the same sequence', async () => {
+    const { fetch } = clientFor()
+    const device = randomBytes(16).toString('hex')
+    const url = `${BASE}/v1/log/${device}?seq=1&generation=1`
+    const opts = { method: 'POST', headers: { 'Content-Type': 'application/octet-stream' } }
+
+    expect((await fetch.fetch(url, { ...opts, body: randomBytes(16) })).status).toBe(201)
+    expect((await fetch.fetch(url, { ...opts, body: randomBytes(16) })).status).toBe(409)
+  })
+
+  it('does not expose one identity\'s blob to another', async () => {
+    const alice = clientFor()
+    const bob = clientFor()
+    const device = randomBytes(16).toString('hex')
+
+    await alice.fetch.fetch(`${BASE}/v1/log/${device}?seq=1&generation=1`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: Buffer.from('alice-secret'),
+    })
+
+    // Same device id, different authenticated identity: must not resolve.
+    const res = await bob.fetch.fetch(`${BASE}/v1/log/${device}/1?generation=1`, { method: 'GET' })
+    expect(res.status).toBe(404)
+  })
+})
+```
+
+- [ ] **Step 2: Run against a live server**
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+SERVER_URL=http://localhost:8080 npm --prefix test-client test
+```
+
+Expected: all three pass. A failure in the first test most often means the auth middleware
+was mounted under a subtree rather than the origin root, so the handshake never reached it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test-client docker-compose.test.yml
+git commit -m "test: TypeScript AuthFetch interop against the live server"
+```
+
+---
+
+### Task 9: Ops — Docker, CI, graceful shutdown
+
+**Files:**
+- Create: `Dockerfile`, `.dockerignore`, `docker-compose.yml`, `.env.example`, `.github/workflows/go.yml`, `.github/workflows/docker-publish.yml`
+- Modify: `cmd/server/main.go`
+
+**Interfaces:**
+- Consumes: everything above
+- Produces: a deployable image and CI.
+
+- [ ] **Step 1: Add graceful shutdown to main**
+
+```go
+srv := server.New(deps)
+go func() {
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("server failed", "error", err)
+		os.Exit(1)
+	}
+}()
+
+stop := make(chan os.Signal, 1)
+signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+<-stop
+
+ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+defer cancel()
+if err := srv.Shutdown(ctx); err != nil {
+	logger.Error("graceful shutdown failed", "error", err)
+}
+```
+
+- [ ] **Step 2: Write the multi-stage Dockerfile**
+
+Alpine multi-stage, matching house style. Static build, non-root user, `HEALTHCHECK`
+hitting `/health`.
+
+- [ ] **Step 3: Add the CI workflow**
+
+```yaml
+name: go
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: wallet_backup_test
+        options: >-
+          --health-cmd pg_isready --health-interval 10s
+          --health-timeout 5s --health-retries 5
+        ports: ['5432:5432']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.26.3' }
+      - run: go test ./... -race -cover
+      - uses: golangci/golangci-lint-action@v6
+```
+
+Neither reference service has a Go test/lint workflow. Adding one closes a documented gap
+rather than breaking convention.
+
+- [ ] **Step 4: Write .env.example**
+
+```
+PORT=8080
+SERVER_PRIVATE_KEY=
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/wallet_backup?sslmode=disable
+LOG_LEVEL=info
+LOG_FORMAT=json
+MAX_BLOB_BYTES=1048576
+```
+
+`SERVER_PRIVATE_KEY` is deliberately blank — there is no dev default, and startup fails
+without it.
+
+- [ ] **Step 5: Verify the whole suite with race detection**
+
+```bash
+go test ./... -race -cover
+golangci-lint run
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Dockerfile .dockerignore docker-compose.yml .env.example .github
+git commit -m "chore: docker image, CI workflow and graceful shutdown"
+```
+
+---
+
+## Deferred: paid access
+
+The service ships **free**. If it later charges, the intended route is
+[go-402-pay](https://github.com/bsv-blockchain/go-402-pay) (BRC-121) rather than the
+BRC-105 middleware bundled with `go-bsv-middleware`, combined with a
+[BRC-228](https://bsv.brc.dev/payments/0228) ephemeral `senderIdentityKey`.
+
+This is additive — `pay402.PaymentMiddleware` wraps routes with a `CalculatePrice` hook —
+so nothing in this plan needs to anticipate it. Two constraints if it happens:
+
+- Payment must not re-link the pseudonym to the user's real identity. BRC-228 removes the
+  identity key from the *remittance*, but its own spec states inputs and change are signed
+  by the real wallet and that it is "not graph-private". The residual leak is chain-graph
+  correlation of the funding UTXOs.
+- The pseudonymous client wallet **cannot pay**: `CompletedProtoWallet.createAction`
+  throws `not implemented`. Only the user's real wallet can fund a transaction, so a
+  bridge between the paying identity and the authenticating pseudonym is required, and
+  that bridge is where linkage leaks.
+
+Resolve the privacy analysis before implementing.
+
+---
+
+## Acceptance
+
+- `go test ./... -race -cover` green; `golangci-lint run` clean
+- Cross-tenant suite proves no route leaks across identities
+- TypeScript `AuthFetch` interop round-trips a blob as raw binary
+- Blobs over 1 MiB rejected with `413` before allocation
+- No decrypt call, and no server key in any encryption protocol, anywhere in the tree
+- No route reads an identity from a request body, query, path, or header
+- Startup fails fast without `SERVER_PRIVATE_KEY`
+- `/health` reports database reachability

--- a/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
+++ b/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
@@ -220,8 +220,18 @@ Sync chunks are dominated by raw transaction bytes — `TableProvenTx.rawTx`,
 all typed `number[]`. Naive `JSON.stringify` renders each byte as up to four characters.
 
 Use the toolbox's own `binaryJsonReplacer` / `binaryJsonReviver` / `stringifyJsonRpc`
-(`.../storage/remoting/BinaryJson.ts`), which base64-tag binary arrays. This guarantees
-round-trip fidelity with the toolbox's types rather than inventing an encoding.
+(`.../storage/remoting/BinaryJson.ts`) for round-trip fidelity with the toolbox's types
+rather than inventing an encoding.
+
+**Correction, found during implementation:** that serialiser does **not**, on its own,
+compact these fields. `binaryJsonReplacer` base64-encodes `Uint8Array` only, and every
+binary field on the toolbox's tables is typed `number[]`, so `rawTx` and friends would go
+over the wire as decimal arrays at roughly 2.9 characters per byte. The client therefore
+runs a packing pass first, converting byte-valued arrays to `Uint8Array` so the serialiser
+can compact them and converting them back on decode. The transform is lossless in both
+directions — an array that merely looks byte-like, such as small integer ids, returns
+exactly the values it started with — and is covered by tests including a 256-value
+all-bytes case and a non-byte numeric array.
 
 Because the server stores opaque bytes and never parses payloads, the serialization
 format is a purely client-internal choice with no interop constraint.
@@ -418,10 +428,69 @@ which returns `(nil, nil)`.
 
 ### 402 is a privacy invariant, not a product preference
 
-A 402 payment would be constructed by the user's **real** wallet, re-linking the
-pseudonym to their on-chain identity in a single request — destroying the entire property
-this design exists to provide. The service must be free. Write this down where someone
-proposing monetization will read it.
+The service is free. This was re-examined in detail against
+[go-402-pay](https://github.com/bsv-blockchain/go-402-pay) (BRC-121) combined with a
+[BRC-228](https://bsv.brc.dev/payments/0228) ephemeral `senderIdentityKey`, on the
+reasoning that an unlinked payment identity would preserve the property. **It does not.**
+BRC-228 removes the least important leak.
+
+The pseudonymous `CompletedProtoWallet` cannot fund anything — `createAction` throws
+`not implemented` — so the user's real wallet must pay. What that hands the server:
+
+- **The BEEF is the leak, not the sender key.** `x-bsv-beef` carries each input's ancestry
+  back to a proof, which means one or more *complete prior transactions of the user's
+  wallet* — the bytes, not references. Delivered inside a request BRC-104 has
+  cryptographically bound to the pseudonym, it is a signed assertion that this pseudonym
+  controls these outpoints. BRC-228 does not touch this.
+- **Change chaining collapses the pseudonym.** Payment *n*'s change funds payment *n+1*,
+  so after two payments the operator can walk the wallet forward indefinitely with any
+  public indexer. Change *amounts* additionally disclose balance and balance trajectory,
+  which is close to a unique fingerprint at this user-base size.
+- **A cross-service join needs no chain analysis at all.** This app already sends the real
+  identity key in cleartext as `x-bsv-sender` to ordinary BRC-121 merchants
+  (`utils/webview/bsvPaymentHandler.ts:175-179`), and every BRC-103 peer learns it by
+  construction. One join against any service holding both the identity key and an outpoint
+  from the same wallet is sufficient — and the operator here also runs the app and the
+  ARC broadcaster the client posts to directly from the device's IP.
+- **Charging forces the server to keep records it otherwise would not.** go-402-pay
+  delegates replay protection to the wallet's `InternalizeAction`, so a paid server needs
+  a funded, storage-backed wallet and gains a permanent per-payment ledger keyed by
+  pseudonym. The free server holds one key and opaque bytes.
+
+The distinction that decides it: today's residual is **correlational and deniable** —
+it requires the operator to deliberately retain and cross-reference logs they have no
+business reason to keep, it degrades under CGNAT, VPNs and roaming, and it leaves no
+artifact that survives a breach or a subpoena. Payment replaces all of that at once with a
+**cryptographic, durable, self-documenting and legally-retained** record.
+
+If revenue becomes necessary, in order of preference: charge elsewhere in a relationship
+where the user is already identified; or, if the real motive is abuse control, enforce
+per-pseudonym quotas and rate limits, which cost a day and leak nothing. Blind-signed
+tokens are the only genuinely private paid design and are not worth building for a small
+user base, because the anonymity set would not support the claim.
+
+**Do not ship per-request 402 and describe the result as pseudonymous.** That is worse
+than either honest alternative, because users would act on a claim the architecture does
+not support.
+
+Three engineering blockers stand independently of privacy, recorded so nobody rediscovers
+them: the server's `CompletedProtoWallet` panics on a nil dereference under the payment
+middleware; `AuthFetch` hard-errors on a BRC-121 402 response, demanding an
+`x-bsv-payment-version` header go-402-pay never sends, so **no client today speaks both
+BRC-103 auth and BRC-121 payment**; and this app's own 402 client is GET/HTML-only with no
+retry, so a binary `POST` upload would be a rewrite rather than a reuse.
+
+### The honest residual, free design included
+
+The free design is **not** unlinkable. The server observes source IP, TLS fingerprint,
+request cadence, ciphertext lengths, device count, total volume, and — because one
+pseudonym spans a user's devices so restore can enumerate them — that those devices belong
+to one person.
+
+IP is the real residual and it is not small: a phone's IP is geolocatable,
+ISP-attributable, and often stable enough within a session to individuate. Any claim that
+this design achieves unlinkability against *this* operator is overselling it. What it does
+buy is that the correlation is a policy failure rather than an architectural fact.
 
 ### The pseudonym, honestly
 
@@ -579,14 +648,8 @@ so a Postgres-backed implementation is a drop-in when a second replica is needed
 ## Open questions
 
 - Repo name: `go-wallet-backup-server` is the proposal.
-- **Whether the service is free or paid is under active review.** The "402 is a privacy
-  invariant" section below reflects the original free-only decision. A paid variant using
-  [go-402-pay](https://github.com/bsv-blockchain/go-402-pay) (BRC-121) with a
-  [BRC-228](https://bsv.brc.dev/payments/0228) ephemeral `senderIdentityKey` is being
-  evaluated. The structural obstacle is that the pseudonymous `CompletedProtoWallet`
-  cannot fund transactions — `createAction` throws `not implemented` — so only the real
-  wallet can pay, and the bridge between paying identity and authenticating pseudonym is
-  where linkage can leak. Resolve before implementing the server's route table.
+- Repository: **`github.com/bsv-blockchain/go-private-backup-cache`**.
+- ~~Whether the service is free or paid~~ — **resolved: free.** See below.
 - Generation-rotation threshold — 200 chunks is a guess; needs a measurement against a
   real wallet's growth rate.
 - Should push be gated on unmetered connectivity? The app has `hooks/useOnline.ts` but no

--- a/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
+++ b/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
@@ -1,0 +1,566 @@
+# Encrypted wallet backup log
+
+**Status:** design proposal, awaiting approval
+**Date:** 2026-08-14
+**Scope:** client (bsv-browser, TypeScript) + server (new Go service)
+
+---
+
+## The problem, restated
+
+User research found that most users never back up their mnemonic, never print recovery
+shares, and never export wallet data. That framing understates the danger, because it
+assumes the mnemonic is what matters.
+
+**A mnemonic alone recovers nothing.** Spending a wallet output requires derivation
+metadata that exists only in the local SQLite database:
+
+- Change outputs are created with `const n = randomDerivation(16)` — a random derivation
+  suffix persisted only in the DB
+  (`@bsv/wallet-toolbox-mobile/out/src/storage/methods/createAction.js`).
+- Received BRC-29 outputs carry `senderIdentityKey`, `derivationPrefix` and
+  `derivationSuffix` chosen by the *sender*
+  (`.../storage/schema/tables/TableOutput.d.ts:21-23`).
+- No rescan or reconstruct-from-chain path exists anywhere in `StorageProvider`.
+
+So a user who dutifully printed recovery shares and then lost their phone still cannot
+spend their coins. The backup feature the app ships today is necessary but not
+sufficient, and that gap is silent.
+
+This design fixes the database half. It converts the recovery requirement from
+"you need **both** the mnemonic and the device" into "you need **only** the mnemonic or
+the printed shares" — which makes the existing paper backup genuinely sufficient for the
+first time.
+
+### Explicitly out of scope
+
+- **Backing up the entropy/mnemonic itself.** Decided out of scope. It cannot ride in
+  this log: the log is encrypted under a key derived from the entropy, so encrypting the
+  entropy into it is circular. A separate mechanism (platform-synced keychain, passkey
+  PRF, hardware wrap) would be a future change. See [BRC-157 entropy backup migration](2026-08-14-brc157-entropy-backup-migration.md).
+- **Forcing, gating, or nagging users to back up.** Decided out of scope. This feature is
+  automatic and requires no user consent flow beyond enabling the service.
+
+---
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Transport of DB state | Toolbox `SyncChunk` deltas | Incremental and chunked by construction |
+| Server role | Opaque append-only blob log | Not a storage provider; cannot read anything |
+| Encryption | `wallet.encrypt`, `counterparty: 'self'` | Verified: server decrypt fails |
+| Server identity of a user | The authenticated AuthFetch key, which is a derived pseudonym | No user-supplied identity field anywhere |
+| Server language/stack | Go, `go-sdk` + `go-bsv-middleware`, chi | House convention |
+| Blob persistence | Postgres `bytea` behind a `BlobStore` interface | Transactional generation swaps; S3 seam preserved |
+| Retention | Keep 2 generations, never idle-expire | Deleting an idle backup destroys exactly the user who lost their phone |
+| Deployment | Single instance, `SessionManager` seam for later | Backup traffic is tiny and latency-insensitive |
+| Payments | None, ever | See "402 is a privacy invariant" below |
+
+---
+
+## Architecture
+
+```
+┌─ bsv-browser (React Native) ───────────────────────────────────────────┐
+│                                                                        │
+│  primaryKey (m/0'/0')          ← the only secret BOTH cohorts have     │
+│      │                                                                 │
+│      └─ BRC-42/43 derive (fixed protocol + keyID)                      │
+│           └─ backupKey ──> CompletedProtoWallet                        │
+│                              ├─ identity ──> AuthFetch peer identity   │
+│                              └─ encrypt({counterparty:'self'})         │
+│                                                                        │
+│  push:    phoneStorage.getSyncChunk({since,offsets,maxRoughSize})      │
+│             → stringifyJsonRpc(chunk, binary=true)                     │
+│             → deflate → encrypt → POST (raw on SDK 2.4.0, else base64) │
+│                                                                        │
+│  restore: EncryptedRemoteSyncReader implements WalletStorageSyncReader │
+│             → WalletStorageManager.syncFromReader()                    │
+└────────────────────────────────────────────────────────────────────────┘
+                                   │ AuthFetch (BRC-103/104)
+                                   ▼
+┌─ go-wallet-backup-server ──────────────────────────────────────────────┐
+│  chi router, mounted at the ORIGIN ROOT (mandatory)                    │
+│    ├─ GET /health                              unauthenticated         │
+│    └─ middleware.NewAuth(CompletedProtoWallet).HTTPHandler             │
+│         │  (/.well-known/auth handled internally — do NOT route it)    │
+│         └─ pseudonym := ShouldGetAuthenticatedIdentity(ctx).ToDERHex() │
+│                                                                        │
+│  Postgres: blob bytes + (pseudonym, device, generation, seq) index     │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Client design
+
+### Key derivation — derive from `primaryKey`, not `rootKey`
+
+This is the single most important client detail.
+
+The mnemonic path yields both a `rootKey` and a `primaryKey`
+([utils/mnemonicWallet.ts:48-61](../../../utils/mnemonicWallet.ts)). The shares path
+yields **only** the primary key: `PrivateKey.fromBackupShares()` produces the `m/0'/0'`
+WIF, and `buildWalletFromRecoveredKey` uses it directly
+([context/WalletContext.tsx:1289](../../../context/WalletContext.tsx)).
+
+Deriving the backup key from `rootKey` would silently lock share-restored wallets out of
+their own backups — the exact cohort this feature most helps. Derive from `primaryKey`.
+
+```ts
+import { CompletedProtoWallet, KeyDeriver, PrivateKey } from '@bsv/sdk'
+import type { WalletProtocol } from '@bsv/sdk'
+
+// Versioned constants. Restore has only the seed, so these must never vary
+// per-install, per-device, or per-random. Covered by a test.
+// NOTE: in TypeScript WalletProtocol is a TUPLE [SecurityLevel, string] —
+// not the {securityLevel, protocol} struct the Go SDK uses.
+export const BACKUP_PROTOCOL: WalletProtocol = [2, 'wallet backup log']
+export const BACKUP_KEY_ID = '1'
+
+export function deriveBackupWallet(primaryKey: number[]): CompletedProtoWallet {
+  const deriver = new KeyDeriver(new PrivateKey(primaryKey))
+  const backupPriv = deriver.derivePrivateKey(BACKUP_PROTOCOL, BACKUP_KEY_ID, 'self')
+  return new CompletedProtoWallet(backupPriv)
+}
+```
+
+Protocol names are validated at runtime, not compile time: 5–400 chars, `^[a-z0-9 ]+$`,
+no double spaces, must not end in `" protocol"`.
+
+`CompletedProtoWallet` is exported from the `@bsv/sdk` root (verified at 2.1.9) and
+implements the full `WalletInterface` that `AuthFetch` requires. `ProtoWallet` alone is
+insufficient — `AuthFetch`'s constructor is typed against `WalletInterface`.
+
+Using a dedicated wallet rather than the app's main wallet has a second benefit: blob
+encryption never routes through `WalletPermissionsManager`, so it cannot trigger
+protocol-permission prompts or spending-authorization gates.
+
+### Encryption — `counterparty: 'self'` is the entire security property
+
+Verified empirically against `go-sdk`: a client encrypting with `CounterpartyTypeSelf`
+produces ciphertext the server cannot decrypt even while holding the client's public key
+(`cipher: message authentication failed`). With `CounterpartyTypeOther{serverKey}` the
+server *can* decrypt via ECDH.
+
+The blindness is a property of one enum value chosen by the client. The server's job is
+to be structurally unable to help: no identity field in any request, no decrypt path, no
+server key in the encryption protocol.
+
+BRC-2 wire layout is `IV(32) || ciphertext || tag(16)` — AES-256-GCM, 48 bytes of
+overhead, no plaintext-recoverable metadata.
+
+### Push
+
+Registered as a monitor task beside `TaskSendOffline`
+([context/WalletContext.tsx:945](../../../context/WalletContext.tsx)), where
+`phoneStorage` is already in scope.
+
+```
+1. cursor = AsyncStorage[`backupCursor-${pseudonym}-${deviceId}`]  // {since, offsets, seq, generation, prevSha256}
+2. chunk = await phoneStorage.getSyncChunk({
+     fromStorageIdentityKey, toStorageIdentityKey, identityKey,
+     since: cursor.since, offsets: cursor.offsets,
+     maxRoughSize: 512_000, maxItems: 200,
+   })
+3. if every entity array is empty → nothing to do, return
+4. body = deflate(stringifyJsonRpc(chunk, /* binary */ true))
+5. ct = await backupWallet.encrypt({ plaintext: body, protocolID, keyID, counterparty: 'self' })
+6. POST /v1/log/{deviceId}
+     SDK 2.4.0: raw octet-stream body, seq/generation/prevSha256 as query params
+     SDK 2.1.9: JSON { seq, generation, prevSha256, ciphertext: base64(ct), ciphertextLen }
+7. advance cursor from the chunk's max updated_at + returned offsets; persist
+```
+
+Call `getSyncChunk` **directly on the local provider**, not through
+`WalletStorageManager`. Reasons:
+
+- `updateBackups`/`syncToWriter` take the manager's sync lock via `runAsSync`, blocking
+  all reads *and* writes to active storage for the duration — against the standing
+  no->100ms-JS-block goal.
+- Registering a remote as a backup store hits the `_conflictingActives` trap: a fresh
+  remote user gets `activeStorage = <remote's own key>`, so `isActiveEnabled` goes false
+  and `updateBackups()` throws `WERR_NOT_ACTIVE` via `getAuth(true)`.
+- `getSyncChunk` is fully implemented on `StorageReader`
+  (`.../storage/StorageReader.js:82`), which `StorageExpoSQLite` extends. It works today.
+
+Bypassing the manager lock means a chunk can be read mid-write. This is safe: chunks are
+`since`-based and replay is idempotent, so a torn read self-corrects on the next round.
+
+Monitor tasks run back-to-back with no yielding, so deflate + encrypt + HTTP must be
+deferred via `InteractionManager` and rate-limited (precedent:
+[utils/pay/proofNudge.ts](../../../utils/pay/proofNudge.ts)).
+
+### Wire format
+
+Sync chunks are dominated by raw transaction bytes — `TableProvenTx.rawTx`,
+`TableProvenTxReq.rawTx`/`inputBEEF`, `TableTransaction.rawTx`/`inputBEEF`, `merklePath`,
+all typed `number[]`. Naive `JSON.stringify` renders each byte as up to four characters.
+
+Use the toolbox's own `binaryJsonReplacer` / `binaryJsonReviver` / `stringifyJsonRpc`
+(`.../storage/remoting/BinaryJson.ts`), which base64-tag binary arrays. This guarantees
+round-trip fidelity with the toolbox's types rather than inventing an encoding.
+
+Because the server stores opaque bytes and never parses payloads, the serialization
+format is a purely client-internal choice with no interop constraint. Compress **before**
+encrypting; ciphertext is incompressible.
+
+Chunk sizing: the protocol default `maxRoughSize` is 10,000,000 — far too large to push
+from a phone on cellular, and the server-side estimator re-marshals the accumulating
+chunk on every page (O(n²) on large syncs). Use ~512 KB with `maxItems: 200`, yielding
+ciphertext comfortably under the 1 MiB cap.
+
+### Upload body encoding depends on the SDK version — prefer 2.4.0
+
+On the **installed `@bsv/sdk@2.1.9`**, raw binary upload is impossible.
+`AuthFetch.normalizeBodyToNumberArray`
+(`dist/cjs/src/auth/clients/AuthFetch.js:724-745`) tests `typeof body === 'object'` as its
+first branch and returns `Utils.toArray(JSON.stringify(body))`. Because arrays,
+`Uint8Array`, `ArrayBuffer`, `Blob`, `FormData` and `URLSearchParams` are all
+`typeof 'object'`, every subsequent binary branch is unreachable — a `Uint8Array` body is
+serialized as `{"0":12,"1":255,…}`. On 2.1.9, uploads must carry base64 ciphertext inside
+a JSON object (~1.33× overhead).
+
+**This is fixed in 2.4.0.** The `typeof body === 'object'` branch is removed and the
+ordering corrected to `number[]` → `string` → `ArrayBuffer`/`TypedArray` → `Blob` →
+`FormData`. The 2.4.0 version also fixes a latent bug in the TypedArray branch: 2.1.9 does
+`new Uint8Array(body.buffer)`, ignoring `byteOffset`/`byteLength`, which silently corrupts
+any subarray view; 2.4.0 passes all three.
+
+On 2.4.0 the client should `POST` raw `application/octet-stream` and drop the base64
+envelope entirely. **Target 2.4.0** — see the SDK upgrade section below.
+
+Downloads are unaffected on both versions: the response path builds
+`new Response(new Uint8Array(responseBody))` (`AuthFetch.js:191-196`), so `GET` returns
+raw binary either way. If shipping against 2.1.9 first, the upload/download asymmetry is
+deliberate and should be commented in the client.
+
+### Generations and compaction
+
+An append-only delta log grows without bound: soft deletes mean nothing shrinks, and the
+first backup of an established wallet is a full snapshot spanning many chunks.
+
+The client periodically starts a new **generation**: a fresh full snapshot
+(`since: undefined`) written as generation `N+1`, after which generation `N` is deleted.
+This bounds server storage per user, bounds restore time, and gives the server a
+legitimate deletion primitive it can execute without understanding any content.
+
+Trigger heuristic: when `seq` in the current generation exceeds a threshold (e.g. 200
+chunks), or cumulative bytes exceed a multiple of the last full snapshot.
+
+### Restore
+
+`WalletStorageSyncReader` is a two-method interface, which is the whole restore contract:
+
+```ts
+class EncryptedRemoteSyncReader implements WalletStorageSyncReader {
+  async makeAvailable(): Promise<TableSettings> { /* from the manifest */ }
+  async getSyncChunk(args: RequestSyncChunkArgs): Promise<SyncChunk> {
+    const blob = await this.fetchNext()          // GET /v1/log/{device}/{seq}
+    const plain = inflate(await this.wallet.decrypt({ ciphertext: blob, ...proto }))
+    return parseJsonRpc(plain, /* binary */ true)
+  }
+}
+```
+
+Then `WalletStorageManager.syncFromReader(identityKey, reader)` performs the restore
+unmodified.
+
+Restore flow: install → enter mnemonic or scan shares → derive `primaryKey` → derive
+pseudonym → `GET /v1/manifest` → pick device → replay the newest complete generation.
+
+**Risk:** zero tests cover sync anywhere in this repo, and
+`StorageExpoSQLite.processSyncChunk` is a pass-through with a comment implying it has
+never been exercised ([storage/StorageExpoSQLite.ts:1507](../../../storage/StorageExpoSQLite.ts)).
+The primitive this design rests on has never run in this app. **Build the restore path
+test-first**, with a round-trip test that seeds a DB, pushes to a fake server, restores
+into a fresh DB, and asserts `listOutputs`/`listActions` equality.
+
+### Configuration
+
+[context/config.tsx:20-24](../../../context/config.tsx) already has the pattern
+(`DEFAULT_MESSAGEBOX_URL`). Add `DEFAULT_BACKUP_URL`. `DEFAULT_STORAGE_URL` stays
+`'local'` — the backup service is deliberately not a storage provider.
+
+### SDK upgrade to 2.4.0 — recommended prerequisite
+
+The app is on `@bsv/sdk@2.1.9`; latest is **2.4.0**. Upgrading is not merely housekeeping
+here — it directly improves this feature:
+
+- **Raw binary upload becomes possible**, removing the base64 envelope and ~1.33× of
+  bandwidth and server storage on every push (see above).
+- The `byteOffset`-ignoring TypedArray bug is fixed, which matters as soon as any code
+  passes a subarray view.
+- `KeyDeriver` gains an optional `derivePrivateKeys?(derivations)` batch hook — upstream's
+  version of what the local patch implements by hand via `batchBrc42DeriveChild`. Worth
+  checking whether the upgrade lets part of the patch be retired rather than rebased.
+- `toEntropy()` / `fromEntropy()` land, which the
+  [BRC-157 entropy backup migration](2026-08-14-brc157-entropy-backup-migration.md) spec
+  separately depends on.
+
+APIs this design uses are unchanged in 2.4.0 (verified): `WalletProtocol` is still the
+tuple `[SecurityLevel, ProtocolString5To400Bytes]`, `derivePrivateKey(protocolID, keyID,
+counterparty)` keeps its signature, and `CompletedProtoWallet` is still exported.
+
+**Cost:** `patches/@bsv+sdk+2.1.9.patch` is 2168 lines — the native secp256k1 route
+(Nitro libsecp256k1 with a `@noble/secp256k1` fallback) patched into `ECDSA.js` and
+friends. That patch must be rebased onto 2.4.0 and re-verified for byte-exactness, and
+the companion `patches/@bsv+wallet-toolbox-mobile+2.4.3.patch` reviewed alongside it.
+
+This is a three-minor jump underneath a live wallet. Per the BRC-157 spec's conclusion, it
+should be **its own branch and its own verification pass** against the existing test
+suite, not folded into this feature's commits. Sequence it first; if it slips, this
+feature can ship against 2.1.9 with base64 uploads and switch the encoding later — the
+server accepts both if the upload handler content-types are distinguished.
+
+---
+
+## Server design
+
+### Module and layout
+
+```
+module github.com/bsv-blockchain/go-wallet-backup-server
+go 1.26.3
+```
+
+Mirrors the newer house layout (`go-uhrp-storage-server`'s `internal/`, not
+`go-message-box-server`'s `pkg/`):
+
+```
+cmd/server/main.go              composition root + graceful shutdown
+internal/config/config.go       plain struct + Load() from os.Getenv
+internal/logger/logger.go       Configure(LOG_LEVEL, LOG_FORMAT) *slog.Logger
+internal/server/server.go       chi router, middleware chain, route groups
+internal/server/handlers/       one file per endpoint + _test.go
+internal/server/middlewares/    RequireIdentityKey
+internal/server/responses/      {status,code,description} envelope
+internal/blobstore/             BlobStore interface + postgres impl
+internal/store/                 database/sql metadata + migrations
+internal/wallet/                server identity + mocks/
+test-client/                    Jest + @bsv/sdk AuthFetch integration tests
+```
+
+House conventions: `SERVER_PRIVATE_KEY` as 64-char hex with no dev default, `log/slog`,
+`database/sql` with no ORM, `{"status":"success"|"error","code":"ERR_…"}` envelope,
+multi-stage alpine Dockerfile, GHCR publish workflow.
+
+Deliberate deviations, each closing a documented gap rather than breaking convention:
+add `GET /health` (pattern from `merkle-service`), add a `go test` + `golangci-lint`
+workflow (neither small service has one), set `SetMaxOpenConns`/`SetConnMaxLifetime`,
+and use versioned migrations. Take graceful shutdown from `go-message-box-server`; uhrp
+lacks it. Fail fast when `SERVER_PRIVATE_KEY` is unset — every route is authenticated, so
+a wallet-less server is useless.
+
+### Auth wiring
+
+```go
+priv, _      := ec.PrivateKeyFromHex(cfg.ServerPrivateKey)
+srvWallet, _ := sdkwallet.NewCompletedProtoWallet(priv)   // crypto-only, no storage
+
+sessions := auth.NewSessionManager()
+authMW := middleware.NewAuth(srvWallet,
+    middleware.WithAuthDisallowUnauthenticated(),
+    middleware.WithAuthSessionManager(sessions),
+    middleware.WithAuthLogger(logger),
+)
+
+r.Handle("/.well-known/auth", authMW.HTTPHandler(http.NotFoundHandler()))
+r.Group(func(r chi.Router) {
+    r.Use(authMW.HTTPHandler)
+    r.Use(middlewares.RequireIdentityKey)
+    // routes
+})
+```
+
+Handlers read the caller as
+`middleware.ShouldGetAuthenticatedIdentity(r.Context())` → `*ec.PublicKey` →
+`.ToDERHex()`. Re-stash it under a local typed context key (as uhrp does) so handlers are
+unit-testable — the library's own context key is unexported, and without the re-stash
+handler tests can only assert 401s.
+
+**Mount at the origin root.** The middleware intercepts `POST /.well-known/auth` on an
+exact path compare and never calls `next`, while the TS client always posts the handshake
+to `${new URL(url).origin}/.well-known/auth`. Mounting only under an `/api` subtree makes
+the handshake miss and every request 401.
+
+**Do not construct the payment middleware.** Omitting it engages nothing. Constructing
+`NewPayment` without `WithRequestPriceCalculator` silently charges 100 sat per request,
+and the payment path dereferences the result of `CompletedProtoWallet.InternalizeAction`,
+which returns `(nil, nil)`.
+
+### 402 is a privacy invariant, not a product preference
+
+A 402 payment would be constructed by the user's **real** wallet, re-linking the
+pseudonym to their on-chain identity in a single request — destroying the entire property
+this design exists to provide. The service must be free. Write this down where someone
+proposing monetization will read it.
+
+### The pseudonym, honestly
+
+BRC-103 is transport-level mutual auth: the server necessarily learns the public key it
+authenticated. There is no configuration that authenticates a caller without revealing
+their key.
+
+Therefore any scheme where the server computes a pseudonym *from* the user's real identity
+key is theatre — the server holds both on every request. The only construction that works
+is the one above: **the AuthFetch identity itself is a derived key**, so the real identity
+key never touches the wire. The server writes `pseudonym := identityKey.ToDERHex()` and
+there is no user-supplied identity field in any request body anywhere in the API.
+
+That last point structurally eliminates the bug found in `go-wallet-toolbox`, where sync
+routes trust `args.identityKey` from the request body without binding it to the
+authenticated peer, letting any authenticated caller read or overwrite another user's
+data. **The row key is the auth key or it does not exist.**
+
+Residual leakage, to be documented rather than hidden: the server observes source IP, TLS
+fingerprint, request cadence, ciphertext lengths, device count, and total volume. Because
+one pseudonym is shared across a user's devices so that restore can enumerate them, those
+devices are linkable to each other.
+
+Dependency worth stating: this requires the client to hold the root private key
+in-process. bsv-browser does today (`swm.providePrimaryKey(primaryKey)`). If the app ever
+moves to a remote BRC-100 substrate, it could still `encrypt`/`decrypt` but could not
+extract a derived private key, and this construction would become impossible.
+
+### Routes
+
+Base path `/v1`. Everything except `/health` and `/.well-known/auth` sits inside the auth
+group. `{deviceId}` is a client-generated opaque `[a-f0-9]{32}`. `seq` is 1-based and
+contiguous per `(pseudonym, deviceId, generation)`.
+
+| Method | Path | Success | Errors |
+|---|---|---|---|
+| `GET` | `/health` | `200 {"status":"ok"}` | `503` |
+| `GET` | `/v1/manifest` | `200` device + generation list | `401` |
+| `POST` | `/v1/log/{deviceId}` | `201 {"seq":N,"sha256":"…"}` | `400 ERR_INVALID_JSON`, `401 ERR_AUTH_REQUIRED`, `409 ERR_SEQ_CONFLICT`, `413 ERR_BLOB_TOO_LARGE`, `429 ERR_RATE_LIMITED`, `507 ERR_QUOTA_EXCEEDED` |
+| `GET` | `/v1/log/{deviceId}` | `200` index (`from`, `limit`) | `401`, `404 ERR_DEVICE_NOT_FOUND` |
+| `GET` | `/v1/log/{deviceId}/{seq}` | `200 application/octet-stream` | `401`, `404 ERR_BLOB_NOT_FOUND` |
+| `DELETE` | `/v1/generation/{deviceId}/{generation}` | `204` | `401`, `404`, `409` |
+
+`POST` accepts two encodings, distinguished by `Content-Type`, so the client can ship on
+either SDK version:
+
+- `application/octet-stream` (preferred, requires SDK 2.4.0) — raw ciphertext as the body,
+  with `seq`, `generation` and `prevSha256` as query parameters.
+- `application/json` (SDK 2.1.9 fallback):
+
+```json
+{ "seq": 42, "generation": 3, "prevSha256": "…", "ciphertext": "<base64>", "ciphertextLen": 524336 }
+```
+
+`prevSha256` chains entries so a client can detect a gap or a fork before trusting a
+restore. `ciphertextLen` is redundant-but-checked, following uhrp's declared-vs-actual
+pattern. Slices are normalized to `[]` before encoding so JSON never contains `null`.
+
+### Size limits are mandatory, not defensive
+
+There is **no streaming behind the auth middleware**: `ResponseWriterWrapper` buffers
+status and body so the response can be signed, and implements neither `http.Flusher` nor
+`http.Hijacker`. SSE, chunked upload, and WebSocket are all unavailable. Meanwhile the
+closest template (uhrp) does `io.ReadAll(r.Body)` with no `MaxBytesReader`, so an 11 GB
+upload is an 11 GB heap allocation.
+
+Enforce `http.MaxBytesReader` globally and cap ciphertext at **1 MiB** (matching the
+toolbox storage server's precedent), rejecting oversize with `413`.
+
+### Persistence
+
+Postgres, behind an interface so S3 remains a drop-in — uhrp's lack of such a seam was
+flagged as a genuine gap.
+
+```go
+type BlobStore interface {
+    Put(ctx context.Context, key BlobKey, data []byte) error
+    Get(ctx context.Context, key BlobKey) ([]byte, error)
+    DeleteGeneration(ctx context.Context, pseudonym, deviceID string, generation int) error
+}
+```
+
+```sql
+CREATE TABLE IF NOT EXISTS blob_log (
+  pseudonym    TEXT    NOT NULL,          -- 66-char compressed hex, from auth only
+  device_id    TEXT    NOT NULL,
+  generation   INTEGER NOT NULL,
+  seq          INTEGER NOT NULL,
+  sha256       BYTEA   NOT NULL,
+  prev_sha256  BYTEA,
+  ciphertext   BYTEA   NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (pseudonym, device_id, generation, seq)
+);
+CREATE INDEX IF NOT EXISTS blob_log_head
+  ON blob_log (pseudonym, device_id, generation, seq DESC);
+```
+
+Postgres gives transactional generation swaps and cheap retention queries, and keeps the
+house `database/sql` pattern. Blobs are ≤1 MiB, so `bytea` is comfortable; TOAST handles
+them without special handling.
+
+### Retention
+
+Keep the **current and previous generation** — two, so a failed compaction never leaves a
+user with zero backups. Deletion of generation `N-2` happens transactionally when
+generation `N` completes.
+
+**No idle expiry.** A pseudonym that has not been written to for years belongs to exactly
+the user this feature exists for: someone who lost their phone and has not yet replaced
+it. There is also no way to warn a pseudonym you cannot contact. Storage cost per user is
+bounded by wallet size, not by age.
+
+### Deployment
+
+Single instance to start. The default in-memory `SessionManager` is per-middleware-instance,
+and the failure mode across replicas is verified: handshake on replica A, request on
+replica B, `401 session-not-found`. No shared implementation ships with the library.
+
+Keep the five-method `auth.SessionManager` interface
+(`AddSession`/`UpdateSession`/`GetSession`/`RemoveSession`/`HasSession`) visible in config
+so a Postgres-backed implementation is a drop-in when a second replica is needed.
+
+---
+
+## Testing
+
+- **Client round-trip (highest value):** seed a DB with transactions and outputs, push to
+  a fake server, restore into a fresh DB, assert `listOutputs`/`listActions` equality.
+  This is the test that proves the feature works, and it covers a code path that has never
+  executed in this app.
+- **Key derivation is frozen:** assert that a fixed `primaryKey` produces a fixed
+  pseudonym. A change here orphans every existing backup.
+- **Shares cohort:** assert a wallet restored from backup shares derives the same
+  pseudonym and decrypts blobs written by the mnemonic-restored wallet.
+- **Server cross-tenant:** identity A cannot read or write identity B's blobs on any
+  route. Assert on every route, not just one.
+- **Server rejects oversize** with `413` before allocating.
+- **Interop:** `go-bsv-middleware` already ships a dockerized Node client driving the Go
+  middleware via `new AuthFetch(new CompletedProtoWallet(priv))`. Copy that harness shape
+  for `test-client/`.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Sync path has never executed in this app | Build restore test-first; treat as greenfield |
+| Derivation constants change | Freeze in a versioned constants file with a test |
+| Monitor task blocks the JS thread | `InteractionManager` + rate limit; small chunks |
+| First full snapshot is large on cellular | 512 KB chunks; resumable via `seq`; defer to unmetered where detectable |
+| Blob log forked across two devices | `prevSha256` chain + per-device logs; restore picks one device |
+| Someone adds 402 later | Documented as a privacy invariant, not a preference |
+| SDK 2.4.0 upgrade destabilises the native-secp patch | Own branch, own verification pass, existing suite as the net; feature can ship on 2.1.9 if it slips |
+
+---
+
+## Open questions
+
+- Repo name: `go-wallet-backup-server` is the proposal.
+- Does the SDK 2.4.0 upgrade land before or alongside this feature? It is sequenced first
+  above, but the design does not hard-require it.
+- Generation-rotation threshold — 200 chunks is a guess; needs a measurement against a
+  real wallet's growth rate.
+- Should push be gated on unmetered connectivity? The app has `hooks/useOnline.ts` but no
+  metered/unmetered signal today.
+- Per-pseudonym quota value for `507 ERR_QUOTA_EXCEEDED`.

--- a/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
+++ b/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
@@ -39,7 +39,29 @@ first time.
   entropy into it is circular. A separate mechanism (platform-synced keychain, passkey
   PRF, hardware wrap) would be a future change. See [BRC-157 entropy backup migration](2026-08-14-brc157-entropy-backup-migration.md).
 - **Forcing, gating, or nagging users to back up.** Decided out of scope. This feature is
-  automatic and requires no user consent flow beyond enabling the service.
+  automatic; there is no prompt, snooze, or blocking gate anywhere in it.
+
+### Enablement — on by default, with disclosure and an off switch
+
+**Assumption, stated for the record and easily overturned.** The stated goal is that
+users who back up nothing today are protected. An opt-in service reproduces exactly the
+problem it exists to solve — the people who never printed shares are the people who will
+never tick a box. So backup is **on by default**.
+
+That default means the app sends the user's encrypted wallet database to a
+BSV-Association-operated server without them asking, which deserves honesty rather than
+silence:
+
+- Disclose it at wallet creation and in settings — what is sent, that it is encrypted
+  with a key only their seed can derive, and that the operator cannot read it.
+- Provide an off switch in settings that stops pushing and offers to delete the log
+  (`DELETE /v1/generation/...`).
+- Do not present this as a substitute for the mnemonic. The log is useless without the
+  seed or shares, and the UI must not imply otherwise — that misconception would make
+  users *less* likely to keep their paper backup, actively worsening the situation.
+
+If the preference is opt-in instead, everything else in this design is unchanged; only the
+default flips and the expected coverage drops sharply.
 
 ---
 
@@ -73,7 +95,7 @@ first time.
 │                                                                        │
 │  push:    phoneStorage.getSyncChunk({since,offsets,maxRoughSize})      │
 │             → stringifyJsonRpc(chunk, binary=true)                     │
-│             → deflate → encrypt → POST (raw on SDK 2.4.0, else base64) │
+│             → encrypt → POST (raw on SDK 2.4.0, else base64)           │
 │                                                                        │
 │  restore: EncryptedRemoteSyncReader implements WalletStorageSyncReader │
 │             → WalletStorageManager.syncFromReader()                    │
@@ -165,7 +187,7 @@ Registered as a monitor task beside `TaskSendOffline`
      maxRoughSize: 512_000, maxItems: 200,
    })
 3. if every entity array is empty → nothing to do, return
-4. body = deflate(stringifyJsonRpc(chunk, /* binary */ true))
+4. body = stringifyJsonRpc(chunk, /* binary */ true)   // optional deflate — see Wire format
 5. ct = await backupWallet.encrypt({ plaintext: body, protocolID, keyID, counterparty: 'self' })
 6. POST /v1/log/{deviceId}
      SDK 2.4.0: raw octet-stream body, seq/generation/prevSha256 as query params
@@ -203,8 +225,17 @@ Use the toolbox's own `binaryJsonReplacer` / `binaryJsonReviver` / `stringifyJso
 round-trip fidelity with the toolbox's types rather than inventing an encoding.
 
 Because the server stores opaque bytes and never parses payloads, the serialization
-format is a purely client-internal choice with no interop constraint. Compress **before**
-encrypting; ciphertext is incompressible.
+format is a purely client-internal choice with no interop constraint.
+
+**Compression is optional and deferred.** If used it must happen *before* encryption,
+since ciphertext is incompressible. But no compression library is currently a dependency
+(`pako` and `fflate` are both absent), and the gain is modest: the payload is dominated by
+transaction bytes — hashes, keys and signatures — which are high-entropy and barely
+compress. Deflate would mostly reclaim the base64 expansion introduced by `BinaryJson`
+plus the JSON field names, on the order of 30%. Weigh that against a new dependency
+(`fflate` is the lighter choice, pure JS, no native code) and CPU spent on a
+non-yielding monitor task. Recommend shipping without it and revisiting if real-world
+blob sizes justify it — especially since moving to SDK 2.4.0 removes the larger overhead.
 
 Chunk sizing: the protocol default `maxRoughSize` is 10,000,000 — far too large to push
 from a phone on cellular, and the server-side estimator re-marshals the accumulating

--- a/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
+++ b/docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
@@ -77,7 +77,8 @@ default flips and the expected coverage drops sharply.
 | Blob persistence | Postgres `bytea` behind a `BlobStore` interface | Transactional generation swaps; S3 seam preserved |
 | Retention | Keep 2 generations, never idle-expire | Deleting an idle backup destroys exactly the user who lost their phone |
 | Deployment | Single instance, `SessionManager` seam for later | Backup traffic is tiny and latency-insensitive |
-| Payments | None, ever | See "402 is a privacy invariant" below |
+| Client SDK | `@bsv/sdk` 2.4.0 only, no 2.1.9 path | Raw binary upload; 2.1.9's AuthFetch cannot send it |
+| Payments | Free for v1; paid variant under review | See open questions |
 
 ---
 
@@ -95,7 +96,7 @@ default flips and the expected coverage drops sharply.
 │                                                                        │
 │  push:    phoneStorage.getSyncChunk({since,offsets,maxRoughSize})      │
 │             → stringifyJsonRpc(chunk, binary=true)                     │
-│             → encrypt → POST (raw on SDK 2.4.0, else base64)           │
+│             → encrypt → POST raw octet-stream                          │
 │                                                                        │
 │  restore: EncryptedRemoteSyncReader implements WalletStorageSyncReader │
 │             → WalletStorageManager.syncFromReader()                    │
@@ -151,7 +152,7 @@ export function deriveBackupWallet(primaryKey: number[]): CompletedProtoWallet {
 Protocol names are validated at runtime, not compile time: 5–400 chars, `^[a-z0-9 ]+$`,
 no double spaces, must not end in `" protocol"`.
 
-`CompletedProtoWallet` is exported from the `@bsv/sdk` root (verified at 2.1.9) and
+`CompletedProtoWallet` is exported from the `@bsv/sdk` root (verified at 2.1.9 and 2.4.0) and
 implements the full `WalletInterface` that `AuthFetch` requires. `ProtoWallet` alone is
 insufficient — `AuthFetch`'s constructor is typed against `WalletInterface`.
 
@@ -189,9 +190,7 @@ Registered as a monitor task beside `TaskSendOffline`
 3. if every entity array is empty → nothing to do, return
 4. body = stringifyJsonRpc(chunk, /* binary */ true)   // optional deflate — see Wire format
 5. ct = await backupWallet.encrypt({ plaintext: body, protocolID, keyID, counterparty: 'self' })
-6. POST /v1/log/{deviceId}
-     SDK 2.4.0: raw octet-stream body, seq/generation/prevSha256 as query params
-     SDK 2.1.9: JSON { seq, generation, prevSha256, ciphertext: base64(ct), ciphertextLen }
+6. POST /v1/log/{deviceId}?seq=&generation=&prevSha256=   // raw octet-stream body
 7. advance cursor from the chunk's max updated_at + returned offsets; persist
 ```
 
@@ -242,30 +241,27 @@ from a phone on cellular, and the server-side estimator re-marshals the accumula
 chunk on every page (O(n²) on large syncs). Use ~512 KB with `maxItems: 200`, yielding
 ciphertext comfortably under the 1 MiB cap.
 
-### Upload body encoding depends on the SDK version — prefer 2.4.0
+### Upload is raw binary — and that requires SDK 2.4.0
 
-On the **installed `@bsv/sdk@2.1.9`**, raw binary upload is impossible.
-`AuthFetch.normalizeBodyToNumberArray`
+Uploads `POST` raw `application/octet-stream`. There is no base64 envelope and no JSON
+body encoding. **This is only possible on `@bsv/sdk` 2.4.0**, which is therefore a hard
+prerequisite (see below), not a nice-to-have.
+
+The reason it is version-gated is worth recording, because it is not obvious and someone
+will otherwise try to backport. On `2.1.9`, `AuthFetch.normalizeBodyToNumberArray`
 (`dist/cjs/src/auth/clients/AuthFetch.js:724-745`) tests `typeof body === 'object'` as its
-first branch and returns `Utils.toArray(JSON.stringify(body))`. Because arrays,
-`Uint8Array`, `ArrayBuffer`, `Blob`, `FormData` and `URLSearchParams` are all
-`typeof 'object'`, every subsequent binary branch is unreachable — a `Uint8Array` body is
-serialized as `{"0":12,"1":255,…}`. On 2.1.9, uploads must carry base64 ciphertext inside
-a JSON object (~1.33× overhead).
+*first* branch and returns `Utils.toArray(JSON.stringify(body))`. Arrays, `Uint8Array`,
+`ArrayBuffer`, `Blob`, `FormData` and `URLSearchParams` are all `typeof 'object'`, so every
+subsequent binary branch is dead code and a `Uint8Array` body is serialized as
+`{"0":12,"1":255,…}`.
 
-**This is fixed in 2.4.0.** The `typeof body === 'object'` branch is removed and the
-ordering corrected to `number[]` → `string` → `ArrayBuffer`/`TypedArray` → `Blob` →
-`FormData`. The 2.4.0 version also fixes a latent bug in the TypedArray branch: 2.1.9 does
-`new Uint8Array(body.buffer)`, ignoring `byteOffset`/`byteLength`, which silently corrupts
-any subarray view; 2.4.0 passes all three.
+2.4.0 removes that branch and restores the intended order — `number[]` → `string` →
+`ArrayBuffer`/`TypedArray` → `Blob` → `FormData`. It also fixes a latent bug in the
+TypedArray branch: 2.1.9 does `new Uint8Array(body.buffer)`, ignoring `byteOffset` and
+`byteLength`, which silently corrupts any subarray view. 2.4.0 passes all three.
 
-On 2.4.0 the client should `POST` raw `application/octet-stream` and drop the base64
-envelope entirely. **Target 2.4.0** — see the SDK upgrade section below.
-
-Downloads are unaffected on both versions: the response path builds
-`new Response(new Uint8Array(responseBody))` (`AuthFetch.js:191-196`), so `GET` returns
-raw binary either way. If shipping against 2.1.9 first, the upload/download asymmetry is
-deliberate and should be commented in the client.
+Downloads need no special handling on either version — the response path builds
+`new Response(new Uint8Array(responseBody))` (`AuthFetch.js:191-196`).
 
 ### Generations and compaction
 
@@ -314,12 +310,12 @@ into a fresh DB, and asserts `listOutputs`/`listActions` equality.
 (`DEFAULT_MESSAGEBOX_URL`). Add `DEFAULT_BACKUP_URL`. `DEFAULT_STORAGE_URL` stays
 `'local'` — the backup service is deliberately not a storage provider.
 
-### SDK upgrade to 2.4.0 — recommended prerequisite
+### SDK upgrade to 2.4.0 — hard prerequisite
 
-The app is on `@bsv/sdk@2.1.9`; latest is **2.4.0**. Upgrading is not merely housekeeping
-here — it directly improves this feature:
+The app is on `@bsv/sdk@2.1.9`; latest is **2.4.0**. This feature targets 2.4.0 only.
+There is no 2.1.9 compatibility path, and the client should not carry one.
 
-- **Raw binary upload becomes possible**, removing the base64 envelope and ~1.33× of
+- **Raw binary upload requires it**, removing the base64 envelope and ~1.33× of
   bandwidth and server storage on every push (see above).
 - The `byteOffset`-ignoring TypedArray bug is fixed, which matters as soon as any code
   passes a subarray view.
@@ -341,9 +337,8 @@ the companion `patches/@bsv+wallet-toolbox-mobile+2.4.3.patch` reviewed alongsid
 
 This is a three-minor jump underneath a live wallet. Per the BRC-157 spec's conclusion, it
 should be **its own branch and its own verification pass** against the existing test
-suite, not folded into this feature's commits. Sequence it first; if it slips, this
-feature can ship against 2.1.9 with base64 uploads and switch the encoding later — the
-server accepts both if the upload handler content-types are distinguished.
+suite, not folded into this feature's commits. It is a blocking dependency: the backup
+client cannot ship before it lands.
 
 ---
 
@@ -470,20 +465,16 @@ contiguous per `(pseudonym, deviceId, generation)`.
 | `GET` | `/v1/log/{deviceId}/{seq}` | `200 application/octet-stream` | `401`, `404 ERR_BLOB_NOT_FOUND` |
 | `DELETE` | `/v1/generation/{deviceId}/{generation}` | `204` | `401`, `404`, `409` |
 
-`POST` accepts two encodings, distinguished by `Content-Type`, so the client can ship on
-either SDK version:
-
-- `application/octet-stream` (preferred, requires SDK 2.4.0) — raw ciphertext as the body,
-  with `seq`, `generation` and `prevSha256` as query parameters.
-- `application/json` (SDK 2.1.9 fallback):
-
-```json
-{ "seq": 42, "generation": 3, "prevSha256": "…", "ciphertext": "<base64>", "ciphertextLen": 524336 }
-```
+`POST /v1/log/{deviceId}` takes the raw ciphertext as an `application/octet-stream` body,
+with `seq`, `generation` and `prevSha256` as query parameters. Reject any other
+`Content-Type` with `415`. There is no JSON upload encoding.
 
 `prevSha256` chains entries so a client can detect a gap or a fork before trusting a
-restore. `ciphertextLen` is redundant-but-checked, following uhrp's declared-vs-actual
-pattern. Slices are normalized to `[]` before encoding so JSON never contains `null`.
+restore. The server computes and stores `sha256` of the received bytes and returns it, so
+the client can verify the round trip without a redundant declared-length field.
+
+JSON responses use the house envelope; slices are normalized to `[]` before encoding so
+JSON never contains `null`.
 
 ### Size limits are mandatory, not defensive
 
@@ -581,15 +572,21 @@ so a Postgres-backed implementation is a drop-in when a second replica is needed
 | First full snapshot is large on cellular | 512 KB chunks; resumable via `seq`; defer to unmetered where detectable |
 | Blob log forked across two devices | `prevSha256` chain + per-device logs; restore picks one device |
 | Someone adds 402 later | Documented as a privacy invariant, not a preference |
-| SDK 2.4.0 upgrade destabilises the native-secp patch | Own branch, own verification pass, existing suite as the net; feature can ship on 2.1.9 if it slips |
+| SDK 2.4.0 upgrade destabilises the native-secp patch | Own branch, own verification pass, existing suite as the net. Blocking: there is no 2.1.9 fallback path |
 
 ---
 
 ## Open questions
 
 - Repo name: `go-wallet-backup-server` is the proposal.
-- Does the SDK 2.4.0 upgrade land before or alongside this feature? It is sequenced first
-  above, but the design does not hard-require it.
+- **Whether the service is free or paid is under active review.** The "402 is a privacy
+  invariant" section below reflects the original free-only decision. A paid variant using
+  [go-402-pay](https://github.com/bsv-blockchain/go-402-pay) (BRC-121) with a
+  [BRC-228](https://bsv.brc.dev/payments/0228) ephemeral `senderIdentityKey` is being
+  evaluated. The structural obstacle is that the pseudonymous `CompletedProtoWallet`
+  cannot fund transactions — `createAction` throws `not implemented` — so only the real
+  wallet can pay, and the bridge between paying identity and authenticating pseudonym is
+  where linkage can leak. Resolve before implementing the server's route table.
 - Generation-rotation threshold — 200 chunks is a guess; needs a measurement against a
   real wallet's growth rate.
 - Should push be gated on unmetered connectivity? The app has `hooks/useOnline.ts` but no

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@bsv/btms": "^1.1.0",
         "@bsv/btms-permission-module": "^1.1.0",
         "@bsv/message-box-client": "^2.2.1",
-        "@bsv/sdk": "^2.1.9",
+        "@bsv/sdk": "2.4.0",
         "@bsv/templates": "^1.9.6",
         "@bsv/wallet-relay": "^0.2.1",
         "@bsv/wallet-toolbox-mobile": "^2.4.3",
@@ -1575,10 +1575,13 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.1.9.tgz",
-      "integrity": "sha512-pPbyDNYJJxShCBTiJc7krcZz8DGD2AetMK4CZf0uUMM3tq6M7IPHlqqbp2w4Ps8UGJgJDp8XjMkNLyjGSTe+9w==",
-      "license": "SEE LICENSE IN LICENSE.txt"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.4.0.tgz",
+      "integrity": "sha512-ltAwEzDYB/NNeP8+UaOdXXqBvMWK8gmYF3tava781DaN4W7J4d5as6hxU95H6do1E5H/GYA7cx9FNdZtwQ7+tg==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@bsv/templates": {
       "version": "1.9.6",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
       "**/?(*.)+(spec|test).[jt]s?(x)"
     ],
     "modulePathIgnorePatterns": [
-      "<rootDir>/.worktrees/"
+      "<rootDir>/.worktrees/",
+      "<rootDir>/.claude/worktrees/"
     ],
     "moduleNameMapper": {
       "^react-native-reanimated$": "<rootDir>/__tests__/__mocks__/reanimated.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@bsv/btms": "^1.1.0",
     "@bsv/btms-permission-module": "^1.1.0",
     "@bsv/message-box-client": "^2.2.1",
-    "@bsv/sdk": "^2.1.9",
+    "@bsv/sdk": "2.4.0",
     "@bsv/templates": "^1.9.6",
     "@bsv/wallet-relay": "^0.2.1",
     "@bsv/wallet-toolbox-mobile": "^2.4.3",

--- a/patches/@bsv+sdk+2.4.0.patch
+++ b/patches/@bsv+sdk+2.4.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@bsv/sdk/dist/cjs/src/primitives/ECDSA.js b/node_modules/@bsv/sdk/dist/cjs/src/primitives/ECDSA.js
-index 7ba5047..0140b3e 100644
+index 34b8cce..10bf940 100644
 --- a/node_modules/@bsv/sdk/dist/cjs/src/primitives/ECDSA.js
 +++ b/node_modules/@bsv/sdk/dist/cjs/src/primitives/ECDSA.js
 @@ -9,6 +9,7 @@ const Signature_js_1 = __importDefault(require("./Signature.js"));
@@ -10,7 +10,7 @@ index 7ba5047..0140b3e 100644
  /**
   * Truncates a BigNumber message to the length of the curve order n, in the context of the Elliptic Curve Digital Signature Algorithm (ECDSA).
   * This method is used as part of ECDSA signing and verification.
-@@ -89,6 +90,28 @@ const sign = (msg, key, forceLowS = false, customK) => {
+@@ -131,6 +132,28 @@ const sign = (msg, key, forceLowS = false, customK) => {
      if (msg.bitLength() > nBitLength) {
          throw new Error(`ECDSA message is too large: expected <= ${nBitLength} bits. Callers must hash messages before signing.`);
      }
@@ -39,19 +39,14 @@ index 7ba5047..0140b3e 100644
      msg = truncateToN(msg);
      const msgBig = bnToBigInt(msg);
      const keyBig = bnToBigInt(key);
-@@ -184,11 +207,24 @@ const verify = (msg, sig, key) => {
-         // could be throw or return false; returning false is typical for verify
-         return false;
-     }
--    // Convert inputs to BigInt
--    const hash = bnToBigInt(msg);
-     if ((key.x == null) || (key.y == null)) {
+@@ -183,6 +206,19 @@ const verify = (msg, sig, key) => {
+     if (key.x == null || key.y == null) {
          throw new Error('Invalid public key: missing coordinates.');
      }
-+    // Native route (BSV Browser patch): libsecp256k1 verify with S normalized
-+    // first — semantics equal to this implementation (accepts any s in [1, n-1]).
-+    // Any native failure (e.g. malformed sig/pubkey for strict parsers) falls
-+    // through to the pure-JS path so edge-case behavior is preserved.
++    // Native route (BSV Browser patch): libsecp256k1 verify with S normalized first —
++    // semantics equal to this implementation (accepts any s in [1, n-1]). Any native
++    // failure (e.g. a malformed sig/pubkey for strict parsers) falls through to the
++    // pure-JS path so edge-case behaviour is preserved.
 +    {
 +        const n = (0, NativeSecp_js_1.nativeSecp)();
 +        if (n != null) {
@@ -61,8 +56,6 @@ index 7ba5047..0140b3e 100644
 +            catch (e) { /* fall through to pure-JS */ }
 +        }
 +    }
-+    // Convert inputs to BigInt
-+    const hash = bnToBigInt(msg);
      const publicKey = {
          x: bnToBigInt(key.x),
          y: bnToBigInt(key.y)
@@ -268,7 +261,7 @@ index 0000000..2cedd4b
 +    }
 +}
 diff --git a/node_modules/@bsv/sdk/dist/cjs/src/primitives/PrivateKey.js b/node_modules/@bsv/sdk/dist/cjs/src/primitives/PrivateKey.js
-index 04839a7..3a68a91 100644
+index 2946cbe..859f6ad 100644
 --- a/node_modules/@bsv/sdk/dist/cjs/src/primitives/PrivateKey.js
 +++ b/node_modules/@bsv/sdk/dist/cjs/src/primitives/PrivateKey.js
 @@ -45,6 +45,8 @@ const Hash_js_1 = require("./Hash.js");
@@ -626,10 +619,10 @@ index 171fc4d..667914d 100644
              let Qprime;
              try {
 diff --git a/node_modules/@bsv/sdk/dist/cjs/src/script/templates/P2PKH.js b/node_modules/@bsv/sdk/dist/cjs/src/script/templates/P2PKH.js
-index fc37cf4..6ae6cb1 100644
+index 0aaf101..b9863d0 100644
 --- a/node_modules/@bsv/sdk/dist/cjs/src/script/templates/P2PKH.js
 +++ b/node_modules/@bsv/sdk/dist/cjs/src/script/templates/P2PKH.js
-@@ -61,7 +61,19 @@ class P2PKH {
+@@ -63,7 +63,19 @@ class P2PKH {
       * @returns {Object} - An object containing the `sign` and `estimateLength` functions.
       */
      unlock(privateKey, signOutputs = 'all', anyoneCanPay = false, sourceSatoshis, lockingScript) {
@@ -650,7 +643,7 @@ index fc37cf4..6ae6cb1 100644
                  const signatureScope = (0, SignatureUtils_js_1.computeSignatureScope)(signOutputs, anyoneCanPay);
                  const resolved = (0, SignatureUtils_js_1.resolveSourceDetails)(tx, inputIndex, sourceSatoshis, lockingScript);
 diff --git a/node_modules/@bsv/sdk/dist/cjs/src/transaction/Transaction.js b/node_modules/@bsv/sdk/dist/cjs/src/transaction/Transaction.js
-index d3e7c68..a8ac1ba 100644
+index f798e87..bc5a3dd 100644
 --- a/node_modules/@bsv/sdk/dist/cjs/src/transaction/Transaction.js
 +++ b/node_modules/@bsv/sdk/dist/cjs/src/transaction/Transaction.js
 @@ -15,6 +15,9 @@ const Beef_js_1 = require("./Beef.js");
@@ -660,10 +653,10 @@ index d3e7c68..a8ac1ba 100644
 +const Signature_js_1 = __importDefault(require("../primitives/Signature.js"));
 +const SignatureUtils_js_1 = require("../script/templates/SignatureUtils.js");
 +const NativeSecp_js_1 = require("../primitives/NativeSecp.js");
+ const ScriptVerificationBackend_js_1 = require("./ScriptVerificationBackend.js");
  /** Post-Chronicle height used when an input's source UTXO mined-height is unobtainable. */
  const POST_CHRONICLE_HEIGHT_FALLBACK = 943816;
- /**
-@@ -642,6 +645,427 @@ class Transaction {
+@@ -658,6 +661,427 @@ class Transaction {
              }
          }
          this.materializeSourceTXIDs();
@@ -1092,7 +1085,7 @@ index d3e7c68..a8ac1ba 100644
          this.activeSignatureHashCache = { hashOutputsSingle: new Map() };
          let unlockingScripts;
 diff --git a/node_modules/@bsv/sdk/dist/esm/src/primitives/ECDSA.js b/node_modules/@bsv/sdk/dist/esm/src/primitives/ECDSA.js
-index db011b6..3fbbd60 100644
+index 9e23ad4..dd88fd1 100644
 --- a/node_modules/@bsv/sdk/dist/esm/src/primitives/ECDSA.js
 +++ b/node_modules/@bsv/sdk/dist/esm/src/primitives/ECDSA.js
 @@ -3,6 +3,7 @@ import Signature from './Signature.js';
@@ -1103,7 +1096,7 @@ index db011b6..3fbbd60 100644
  /**
   * Truncates a BigNumber message to the length of the curve order n, in the context of the Elliptic Curve Digital Signature Algorithm (ECDSA).
   * This method is used as part of ECDSA signing and verification.
-@@ -83,6 +84,28 @@ export const sign = (msg, key, forceLowS = false, customK) => {
+@@ -125,6 +126,28 @@ export const sign = (msg, key, forceLowS = false, customK) => {
      if (msg.bitLength() > nBitLength) {
          throw new Error(`ECDSA message is too large: expected <= ${nBitLength} bits. Callers must hash messages before signing.`);
      }
@@ -1132,19 +1125,14 @@ index db011b6..3fbbd60 100644
      msg = truncateToN(msg);
      const msgBig = bnToBigInt(msg);
      const keyBig = bnToBigInt(key);
-@@ -177,11 +200,24 @@ export const verify = (msg, sig, key) => {
-         // could be throw or return false; returning false is typical for verify
-         return false;
-     }
--    // Convert inputs to BigInt
--    const hash = bnToBigInt(msg);
-     if ((key.x == null) || (key.y == null)) {
+@@ -176,6 +199,19 @@ export const verify = (msg, sig, key) => {
+     if (key.x == null || key.y == null) {
          throw new Error('Invalid public key: missing coordinates.');
      }
-+    // Native route (BSV Browser patch): libsecp256k1 verify with S normalized
-+    // first — semantics equal to this implementation (accepts any s in [1, n-1]).
-+    // Any native failure (e.g. malformed sig/pubkey for strict parsers) falls
-+    // through to the pure-JS path so edge-case behavior is preserved.
++    // Native route (BSV Browser patch): libsecp256k1 verify with S normalized first —
++    // semantics equal to this implementation (accepts any s in [1, n-1]). Any native
++    // failure (e.g. a malformed sig/pubkey for strict parsers) falls through to the
++    // pure-JS path so edge-case behaviour is preserved.
 +    {
 +        const n = nativeSecp();
 +        if (n != null) {
@@ -1154,8 +1142,6 @@ index db011b6..3fbbd60 100644
 +            catch (e) { /* fall through to pure-JS */ }
 +        }
 +    }
-+    // Convert inputs to BigInt
-+    const hash = bnToBigInt(msg);
      const publicKey = {
          x: bnToBigInt(key.x),
          y: bnToBigInt(key.y)
@@ -1341,7 +1327,7 @@ index 0000000..9672b48
 +    }
 +}
 diff --git a/node_modules/@bsv/sdk/dist/esm/src/primitives/PrivateKey.js b/node_modules/@bsv/sdk/dist/esm/src/primitives/PrivateKey.js
-index 50868ae..4047a5b 100644
+index 59628ce..5f7019b 100644
 --- a/node_modules/@bsv/sdk/dist/esm/src/primitives/PrivateKey.js
 +++ b/node_modules/@bsv/sdk/dist/esm/src/primitives/PrivateKey.js
 @@ -6,6 +6,8 @@ import { sha256, sha256hmac, sha512hmac } from './Hash.js';
@@ -1629,7 +1615,7 @@ index 71f5213..0df629f 100644
          // Check zG = R + eA
          const zG = this.curve.g.mul(z);
 diff --git a/node_modules/@bsv/sdk/dist/esm/src/primitives/Signature.js b/node_modules/@bsv/sdk/dist/esm/src/primitives/Signature.js
-index f56f7a5..18a548f 100644
+index da97bed..5792973 100644
 --- a/node_modules/@bsv/sdk/dist/esm/src/primitives/Signature.js
 +++ b/node_modules/@bsv/sdk/dist/esm/src/primitives/Signature.js
 @@ -5,6 +5,7 @@ import { sha256 } from './Hash.js';
@@ -1640,7 +1626,7 @@ index f56f7a5..18a548f 100644
  /**
   * Represents a digital signature.
   *
-@@ -298,6 +299,34 @@ export default class Signature {
+@@ -295,6 +296,34 @@ export default class Signature {
       * const publicKey = signature.RecoverPublicKey(0, msgHash);
       */
      RecoverPublicKey(recovery, e) {
@@ -1675,7 +1661,7 @@ index f56f7a5..18a548f 100644
          const r = this.r;
          const s = this.s;
          // A set LSB signifies that the y-coordinate is odd
-@@ -343,6 +372,22 @@ export default class Signature {
+@@ -340,6 +369,22 @@ export default class Signature {
       * const recovery = signature.CalculateRecoveryFactor(publicKey, msgHash);
       */
      CalculateRecoveryFactor(pubkey, msgHash) {
@@ -1699,10 +1685,10 @@ index f56f7a5..18a548f 100644
              let Qprime;
              try {
 diff --git a/node_modules/@bsv/sdk/dist/esm/src/script/templates/P2PKH.js b/node_modules/@bsv/sdk/dist/esm/src/script/templates/P2PKH.js
-index b21dda5..b386547 100644
+index b3f162e..e840f74 100644
 --- a/node_modules/@bsv/sdk/dist/esm/src/script/templates/P2PKH.js
 +++ b/node_modules/@bsv/sdk/dist/esm/src/script/templates/P2PKH.js
-@@ -56,7 +56,19 @@ export default class P2PKH {
+@@ -58,7 +58,19 @@ export default class P2PKH {
       * @returns {Object} - An object containing the `sign` and `estimateLength` functions.
       */
      unlock(privateKey, signOutputs = 'all', anyoneCanPay = false, sourceSatoshis, lockingScript) {
@@ -1723,7 +1709,7 @@ index b21dda5..b386547 100644
                  const signatureScope = computeSignatureScope(signOutputs, anyoneCanPay);
                  const resolved = resolveSourceDetails(tx, inputIndex, sourceSatoshis, lockingScript);
 diff --git a/node_modules/@bsv/sdk/dist/esm/src/transaction/Transaction.js b/node_modules/@bsv/sdk/dist/esm/src/transaction/Transaction.js
-index 7bf1a4c..a1ea57a 100644
+index 5ca4747..2beb7ab 100644
 --- a/node_modules/@bsv/sdk/dist/esm/src/transaction/Transaction.js
 +++ b/node_modules/@bsv/sdk/dist/esm/src/transaction/Transaction.js
 @@ -1,7 +1,10 @@
@@ -1738,7 +1724,7 @@ index 7bf1a4c..a1ea57a 100644
  import LivePolicy from './fee-models/LivePolicy.js';
  import Spend from '../script/Spend.js';
  import { defaultBroadcaster } from './broadcasters/DefaultBroadcaster.js';
-@@ -649,6 +652,427 @@ export default class Transaction {
+@@ -666,6 +669,427 @@ export default class Transaction {
              }
          }
          this.materializeSourceTXIDs();

--- a/utils/backup/RemoteSyncReader.ts
+++ b/utils/backup/RemoteSyncReader.ts
@@ -1,0 +1,92 @@
+/**
+ * Restore side of the backup log.
+ *
+ * `WalletStorageSyncReader` is a two-method interface, and that is the entire restore
+ * contract — so replaying an encrypted log into a fresh database needs no changes to the
+ * toolbox at all. `WalletStorageManager.syncFromReader` drives this exactly as it would
+ * drive a live remote storage provider.
+ */
+import type { CompletedProtoWallet } from '@bsv/sdk'
+import type {
+  RequestSyncChunkArgs,
+  SyncChunk
+} from '@bsv/wallet-toolbox-mobile/out/src/sdk/WalletStorage.interfaces'
+import type { TableSettings } from '@bsv/wallet-toolbox-mobile/out/src/storage/schema/tables'
+import type { BackupClient, LogEntry } from './client'
+import { decodeChunk, emptyChunk } from './codec'
+
+export class BackupChainError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'BackupChainError'
+  }
+}
+
+export class RemoteSyncReader {
+  private entries: LogEntry[] | null = null
+  private next = 0
+
+  constructor (
+    private readonly client: BackupClient,
+    private readonly wallet: CompletedProtoWallet,
+    private readonly deviceId: string,
+    private readonly generation: number,
+    private readonly settings: TableSettings
+  ) {}
+
+  /** Settings for the storage being restored into. */
+  async makeAvailable (): Promise<TableSettings> {
+    return this.settings
+  }
+
+  /**
+   * Return the next chunk in sequence.
+   *
+   * `args` is ignored deliberately: a live reader would honour `since` and `offsets`, but a
+   * log is an ordered recording of chunks that were already produced against those very
+   * arguments. Replaying them in order reproduces the original stream exactly, and second
+   * -guessing it would risk skipping records.
+   */
+  async getSyncChunk (_args: RequestSyncChunkArgs): Promise<SyncChunk> {
+    if (this.entries == null) {
+      this.entries = await this.client.index(this.deviceId, this.generation)
+      this.verifyChain(this.entries)
+    }
+
+    if (this.next >= this.entries.length) {
+      // All twelve arrays present and empty: the completion sentinel.
+      return emptyChunk(this.deviceId, this.settings.storageIdentityKey, '')
+    }
+
+    const entry = this.entries[this.next++]
+    const ciphertext = await this.client.blob(this.deviceId, this.generation, entry.seq)
+    return await decodeChunk(this.wallet, ciphertext)
+  }
+
+  /** Number of chunks in this generation, once the index has been read. */
+  get length (): number {
+    return this.entries?.length ?? 0
+  }
+
+  /**
+   * Reject a log with a gap or a fork before any of it is replayed.
+   *
+   * A restore that silently stops halfway is worse than one that fails: the wallet would
+   * look healthy while missing the outputs it needs to spend.
+   */
+  private verifyChain (entries: LogEntry[]): void {
+    for (let i = 0; i < entries.length; i++) {
+      const expectedSeq = i + 1
+      if (entries[i].seq !== expectedSeq) {
+        throw new BackupChainError(
+          `backup chain has a gap: expected sequence ${expectedSeq}, found ${entries[i].seq}`
+        )
+      }
+      if (i > 0 && entries[i].prevSha256 !== entries[i - 1].sha256) {
+        throw new BackupChainError(
+          `backup chain is forked at sequence ${entries[i].seq}: previous hash does not match`
+        )
+      }
+    }
+  }
+}

--- a/utils/backup/client.ts
+++ b/utils/backup/client.ts
@@ -1,0 +1,157 @@
+/**
+ * HTTP client for the encrypted backup log.
+ *
+ * Authenticates over BRC-103/104 as the backup pseudonym rather than the wallet's identity
+ * key, so the server never learns who the user is. There is deliberately no identity
+ * parameter on any request — the server derives the account from the authenticated session
+ * and nothing else, which is what makes it impossible to address someone else's log.
+ */
+import { AuthFetch } from '@bsv/sdk'
+import { deriveBackupWallet } from './derive'
+
+export interface LogEntry {
+  seq: number
+  sha256: string
+  prevSha256?: string
+  size: number
+  createdAt: string
+}
+
+export interface DeviceSummary {
+  deviceId: string
+  generation: number
+  headSeq: number
+  headSha256: string
+  totalBytes: number
+  updatedAt: string
+}
+
+/** Thrown when the server rejects a request; `code` is the ERR_* envelope code. */
+export class BackupHttpError extends Error {
+  constructor (readonly status: number, readonly code: string, description: string) {
+    super(`${code}: ${description}`)
+    this.name = 'BackupHttpError'
+  }
+}
+
+/** The server's sequence-conflict code. Callers resynchronise rather than retrying. */
+export const ERR_SEQ_CONFLICT = 'ERR_SEQ_CONFLICT'
+
+/**
+ * Transport shape.
+ *
+ * Narrower than RequestInit on purpose: AuthFetch accepts SimplifiedFetchRequestOptions,
+ * whose headers must be a plain record rather than the full HeadersInit union.
+ */
+export interface BackupRequestInit {
+  method: string
+  headers?: Record<string, string>
+  body?: Uint8Array
+}
+
+type FetchLike = (url: string, init: BackupRequestInit) => Promise<Response>
+
+export class BackupClient {
+  private readonly fetcher: FetchLike
+
+  /**
+   * @param baseUrl origin of the backup service. The auth handshake targets the origin
+   *   root, so this must not carry a path prefix.
+   * @param primaryKey the wallet's m/0'/0' key, from which the pseudonym is derived.
+   * @param fetcher injectable transport; defaults to AuthFetch under the backup identity.
+   */
+  constructor (
+    private readonly baseUrl: string,
+    primaryKey: number[],
+    fetcher?: FetchLike
+  ) {
+    if (fetcher != null) {
+      this.fetcher = fetcher
+    } else {
+      const auth = new AuthFetch(deriveBackupWallet(primaryKey))
+      this.fetcher = async (url, init) => await auth.fetch(url, init)
+    }
+  }
+
+  /**
+   * Append a chunk.
+   *
+   * The body is raw binary. This requires @bsv/sdk 2.4.0: on 2.1.9 AuthFetch tested
+   * `typeof body === 'object'` ahead of its binary branches, so a Uint8Array body was
+   * JSON-stringified into {"0":12,...}.
+   */
+  async append (
+    deviceId: string,
+    generation: number,
+    seq: number,
+    prevSha256: string | undefined,
+    ciphertext: number[]
+  ): Promise<{ seq: number, sha256: string }> {
+    const q = new URLSearchParams({
+      seq: String(seq),
+      generation: String(generation)
+    })
+    if (prevSha256 != null && prevSha256 !== '') q.set('prevSha256', prevSha256)
+
+    const res = await this.fetcher(`${this.baseUrl}/v1/log/${deviceId}?${q.toString()}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: new Uint8Array(ciphertext)
+    })
+    const body = await this.json(res)
+    return { seq: body.seq as number, sha256: body.sha256 as string }
+  }
+
+  /** List entry metadata for one generation. */
+  async index (deviceId: string, generation: number, from = 1): Promise<LogEntry[]> {
+    const q = new URLSearchParams({ generation: String(generation), from: String(from) })
+    const res = await this.fetcher(`${this.baseUrl}/v1/log/${deviceId}?${q.toString()}`, {
+      method: 'GET'
+    })
+    const body = await this.json(res)
+    return (body.entries ?? []) as LogEntry[]
+  }
+
+  /** Fetch one blob's ciphertext. Raw binary on the way back needs no special handling. */
+  async blob (deviceId: string, generation: number, seq: number): Promise<number[]> {
+    const q = new URLSearchParams({ generation: String(generation) })
+    const res = await this.fetcher(`${this.baseUrl}/v1/log/${deviceId}/${seq}?${q.toString()}`, {
+      method: 'GET'
+    })
+    if (!res.ok) await this.throwFor(res)
+    return Array.from(new Uint8Array(await res.arrayBuffer()))
+  }
+
+  /** Every device and generation belonging to this pseudonym. */
+  async manifest (): Promise<DeviceSummary[]> {
+    const res = await this.fetcher(`${this.baseUrl}/v1/manifest`, { method: 'GET' })
+    const body = await this.json(res)
+    return (body.devices ?? []) as DeviceSummary[]
+  }
+
+  /** Drop a superseded generation. The server refuses anything within its retained window. */
+  async pruneGeneration (deviceId: string, generation: number): Promise<void> {
+    const res = await this.fetcher(`${this.baseUrl}/v1/generation/${deviceId}/${generation}`, {
+      method: 'DELETE'
+    })
+    if (!res.ok) await this.throwFor(res)
+  }
+
+  private async json (res: Response): Promise<Record<string, unknown>> {
+    if (!res.ok) await this.throwFor(res)
+    return (await res.json()) as Record<string, unknown>
+  }
+
+  private async throwFor (res: Response): Promise<never> {
+    let code = 'ERR_UNKNOWN'
+    let description = res.statusText
+    try {
+      const body = (await res.json()) as { code?: string, description?: string }
+      code = body.code ?? code
+      description = body.description ?? description
+    } catch {
+      // Non-JSON error body; the status alone has to carry the meaning.
+    }
+    throw new BackupHttpError(res.status, code, description)
+  }
+}

--- a/utils/backup/codec.ts
+++ b/utils/backup/codec.ts
@@ -1,0 +1,152 @@
+/**
+ * Encrypted chunk codec.
+ *
+ * Sync chunks are dominated by raw transaction bytes — TableProvenTx.rawTx,
+ * TableProvenTxReq.rawTx/inputBEEF, TableTransaction.rawTx/inputBEEF, merklePath — all
+ * typed `number[]`. A naive JSON.stringify renders each byte as up to four characters.
+ *
+ * The toolbox's own binary-aware serialiser is used, but on its own it does NOT help here:
+ * `binaryJsonReplacer` base64-encodes `Uint8Array` only, and the toolbox's own tables use
+ * `number[]`, so those fields would pass straight through as decimal arrays. Hence the
+ * packing pass below, which converts byte-valued arrays to `Uint8Array` first so the
+ * serialiser can compact them, and converts them back on the way in.
+ *
+ * The server stores opaque bytes and never parses a payload, so this format is a purely
+ * client-internal choice with no interop constraint.
+ */
+import type { CompletedProtoWallet } from '@bsv/sdk'
+import { Utils } from '@bsv/sdk'
+import type { SyncChunk } from '@bsv/wallet-toolbox-mobile/out/src/sdk/WalletStorage.interfaces'
+import {
+  parseJsonRpc,
+  stringifyJsonRpc
+} from '@bsv/wallet-toolbox-mobile/out/src/storage/remoting/BinaryJson'
+import { BACKUP_KEY_ID, BACKUP_PROTOCOL } from './constants'
+
+/**
+ * Minimum length before a numeric array is worth packing as bytes.
+ *
+ * Below this the base64 envelope costs more than it saves, and short numeric arrays are
+ * usually ids rather than payloads.
+ */
+const PACK_MIN_LENGTH = 32
+
+/**
+ * Repack byte-valued numeric arrays as Uint8Array so the binary serialiser can base64 them.
+ *
+ * `binaryJsonReplacer` only base64-encodes `Uint8Array`, but every binary field on the
+ * toolbox's tables — rawTx, inputBEEF, merklePath — is typed `number[]`, so without this
+ * they serialise as decimal arrays at roughly four characters per byte. Packing first turns
+ * that into base64 at about 1.37, which is a threefold saving on a payload that is mostly
+ * transaction bytes and is pushed repeatedly over mobile data.
+ *
+ * The transform is lossless in both directions because `unpackBytes` converts every
+ * Uint8Array back to `number[]`. An array that merely looked byte-like — small integer ids,
+ * say — round-trips to exactly the values it started with.
+ */
+function packBytes (value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const isByteArray =
+      value.length >= PACK_MIN_LENGTH &&
+      value.every(v => typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 255)
+    if (isByteArray) return new Uint8Array(value as number[])
+    return value.map(packBytes)
+  }
+  if (value != null && typeof value === 'object' && !(value instanceof Date)) {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = packBytes(v)
+    return out
+  }
+  return value
+}
+
+/** Inverse of packBytes: every Uint8Array becomes the `number[]` the toolbox expects. */
+function unpackBytes (value: unknown): unknown {
+  if (value instanceof Uint8Array) return Array.from(value)
+  if (Array.isArray(value)) return value.map(unpackBytes)
+  if (value != null && typeof value === 'object' && !(value instanceof Date)) {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = unpackBytes(v)
+    return out
+  }
+  return value
+}
+
+/**
+ * Serialise and encrypt a sync chunk.
+ *
+ * `counterparty: 'self'` is the entire zero-knowledge property. With 'self' the symmetric
+ * key comes from the wallet's own key material and nobody else can derive it; naming the
+ * server as counterparty instead would let the server decrypt via ECDH. One enum value
+ * decides it.
+ */
+export async function encodeChunk (
+  wallet: CompletedProtoWallet,
+  chunk: SyncChunk
+): Promise<number[]> {
+  const json = stringifyJsonRpc(packBytes(chunk), true)
+  const { ciphertext } = await wallet.encrypt({
+    plaintext: Utils.toArray(json, 'utf8'),
+    protocolID: BACKUP_PROTOCOL,
+    keyID: BACKUP_KEY_ID,
+    counterparty: 'self'
+  })
+  return ciphertext
+}
+
+/** Decrypt and parse a sync chunk. Throws if the ciphertext was not written by this key. */
+export async function decodeChunk (
+  wallet: CompletedProtoWallet,
+  ciphertext: number[]
+): Promise<SyncChunk> {
+  const { plaintext } = await wallet.decrypt({
+    ciphertext,
+    protocolID: BACKUP_PROTOCOL,
+    keyID: BACKUP_KEY_ID,
+    counterparty: 'self'
+  })
+  return unpackBytes(parseJsonRpc(Utils.toUTF8(plaintext), true)) as SyncChunk
+}
+
+/** The twelve entity arrays a SyncChunk carries, in the protocol's dependency order. */
+export const CHUNK_ENTITIES = [
+  'provenTxs',
+  'provenTxReqs',
+  'outputBaskets',
+  'txLabels',
+  'outputTags',
+  'transactions',
+  'txLabelMaps',
+  'commissions',
+  'outputs',
+  'outputTagMaps',
+  'certificates',
+  'certificateFields'
+] as const
+
+/**
+ * True when a chunk carries no records at all.
+ *
+ * The toolbox treats an all-empty chunk as the completion sentinel, so this doubles as
+ * "nothing left to push" and "restore is finished".
+ */
+export function isEmptyChunk (chunk: SyncChunk): boolean {
+  const c = chunk as unknown as Record<string, unknown[] | undefined>
+  return CHUNK_ENTITIES.every(name => (c[name]?.length ?? 0) === 0)
+}
+
+/**
+ * An all-empty chunk with every entity array present.
+ *
+ * All twelve must exist as arrays: the toolbox's consumer loops forever on an `undefined`
+ * entity array rather than treating it as empty.
+ */
+export function emptyChunk (from: string, to: string, userIdentityKey: string): SyncChunk {
+  const chunk: Record<string, unknown> = {
+    fromStorageIdentityKey: from,
+    toStorageIdentityKey: to,
+    userIdentityKey
+  }
+  for (const name of CHUNK_ENTITIES) chunk[name] = []
+  return chunk as unknown as SyncChunk
+}

--- a/utils/backup/constants.ts
+++ b/utils/backup/constants.ts
@@ -1,0 +1,60 @@
+/**
+ * Constants for the encrypted wallet backup log.
+ *
+ * @see docs/superpowers/specs/2026-08-14-encrypted-wallet-backup-log-design.md
+ */
+import type { WalletProtocol } from '@bsv/sdk'
+
+/**
+ * FROZEN. Do not change either value, ever.
+ *
+ * Restore has nothing but the user's seed to work from, so these must not vary by install,
+ * device, build, or randomness. Changing them orphans every backup ever written, with no
+ * error surfaced to anyone — the pseudonym simply becomes a different account holding no
+ * data.
+ *
+ * NOTE: in TypeScript `WalletProtocol` is a TUPLE `[SecurityLevel, string]`, not the
+ * `{securityLevel, protocol}` struct the Go SDK uses.
+ *
+ * Protocol names are validated at runtime: 5-400 chars, /^[a-z0-9 ]+$/, no double spaces,
+ * and must not end in " protocol".
+ */
+export const BACKUP_PROTOCOL: WalletProtocol = [2, 'wallet backup log']
+export const BACKUP_KEY_ID = '1'
+
+/**
+ * Delta chunk sizing.
+ *
+ * The protocol default `maxRoughSize` is 10,000,000, which is far too large to push from a
+ * phone on cellular — and the toolbox's own size estimator re-marshals the accumulating
+ * chunk on every page, so large values are quadratic. 512 KB of JSON comfortably encrypts
+ * to under the server's 1 MiB cap.
+ */
+export const MAX_ROUGH_SIZE = 512_000
+export const MAX_ITEMS = 200
+
+/**
+ * Start a fresh full snapshot once a generation exceeds this many chunks.
+ *
+ * An append-only delta log grows without bound, because soft deletes mean nothing ever
+ * shrinks. Rotating bounds both server storage per user and restore time. The number is a
+ * starting estimate and wants measuring against a real wallet's growth.
+ */
+export const GENERATION_CHUNK_THRESHOLD = 200
+
+/**
+ * Floor between push passes.
+ *
+ * The monitor loop ticks roughly every five seconds and runs its tasks back-to-back with no
+ * yielding, so pushing on every tick would burn battery and compete with the UI for the JS
+ * thread.
+ */
+export const MIN_PUSH_INTERVAL_MS = 60_000
+
+/** Server blob cap. Chunks are sized to stay well under it. */
+export const MAX_BLOB_BYTES = 1 << 20
+
+/** AsyncStorage keys. */
+export const DEVICE_ID_KEY = 'backupDeviceId'
+export const cursorKey = (pseudonym: string, deviceId: string): string =>
+  `backupCursor-${pseudonym}-${deviceId}`

--- a/utils/backup/cursor.ts
+++ b/utils/backup/cursor.ts
@@ -1,0 +1,124 @@
+/**
+ * Push cursor.
+ *
+ * The toolbox normally keeps sync state on the *writer* — `EntitySyncState` is loaded from
+ * whatever storage is receiving the data. Our writer is an opaque blob log that holds no
+ * state at all, so the client keeps the equivalent bookkeeping here.
+ *
+ * The semantics mirror `EntitySyncState` exactly, because a divergence would either skip
+ * records (a silent hole in a restore) or resend them forever:
+ *
+ *  · `offsets` are per-entity counts of items already consumed *within the current `since`
+ *    window*, and grow as chunks are taken.
+ *  · When a chunk comes back completely empty the window is exhausted: `since` advances to
+ *    the greatest `updated_at` seen, and every offset resets to zero.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { cursorKey } from './constants'
+
+/** The twelve entity names used by `offsets`, singular and camelCase, as the toolbox emits them. */
+export const ENTITY_NAMES = [
+  'provenTx',
+  'outputBasket',
+  'outputTag',
+  'txLabel',
+  'transaction',
+  'output',
+  'txLabelMap',
+  'outputTagMap',
+  'certificate',
+  'certificateField',
+  'commission',
+  'provenTxReq'
+] as const
+
+export type EntityName = (typeof ENTITY_NAMES)[number]
+
+/** Maps an offset entity name to its plural array on a SyncChunk. */
+export const ENTITY_TO_CHUNK_ARRAY: Record<EntityName, string> = {
+  provenTx: 'provenTxs',
+  outputBasket: 'outputBaskets',
+  outputTag: 'outputTags',
+  txLabel: 'txLabels',
+  transaction: 'transactions',
+  output: 'outputs',
+  txLabelMap: 'txLabelMaps',
+  outputTagMap: 'outputTagMaps',
+  certificate: 'certificates',
+  certificateField: 'certificateFields',
+  commission: 'commissions',
+  provenTxReq: 'provenTxReqs'
+}
+
+export interface PushCursor {
+  /** ISO timestamp; only records updated at or after this are considered. */
+  since?: string
+  /** Per-entity consumed counts within the current `since` window. */
+  offsets: Record<EntityName, number>
+  /** Greatest `updated_at` seen in this window; becomes `since` when the window closes. */
+  maxUpdatedAt?: string
+  /** Current generation. Generations are full snapshots; older ones get pruned. */
+  generation: number
+  /** Sequence of the last chunk appended in this generation. */
+  seq: number
+  /** sha256 of the last appended chunk, chaining the log so gaps are detectable. */
+  prevSha256?: string
+  /** Chunks appended in this generation, used to decide when to rotate. */
+  chunksInGeneration: number
+}
+
+export function freshCursor (generation = 1): PushCursor {
+  return {
+    since: undefined,
+    offsets: zeroOffsets(),
+    maxUpdatedAt: undefined,
+    generation,
+    seq: 0,
+    prevSha256: undefined,
+    chunksInGeneration: 0
+  }
+}
+
+export function zeroOffsets (): Record<EntityName, number> {
+  const out = {} as Record<EntityName, number>
+  for (const name of ENTITY_NAMES) out[name] = 0
+  return out
+}
+
+/** Offsets in the array-of-pairs shape `RequestSyncChunkArgs` expects. */
+// eslint-disable-next-line @typescript-eslint/array-type -- matches the SDK's own signature
+export function offsetsToArgs (offsets: Record<EntityName, number>): Array<{ name: string, offset: number }> {
+  return ENTITY_NAMES.map(name => ({ name, offset: offsets[name] ?? 0 }))
+}
+
+export async function loadCursor (pseudonym: string, deviceId: string): Promise<PushCursor> {
+  const raw = await AsyncStorage.getItem(cursorKey(pseudonym, deviceId))
+  if (raw == null) return freshCursor()
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<PushCursor>
+    return {
+      since: parsed.since,
+      // Merge over a zeroed base so a cursor written by an older build, before a new
+      // entity existed, does not produce an undefined offset.
+      offsets: { ...zeroOffsets(), ...(parsed.offsets ?? {}) },
+      maxUpdatedAt: parsed.maxUpdatedAt,
+      generation: parsed.generation ?? 1,
+      seq: parsed.seq ?? 0,
+      prevSha256: parsed.prevSha256,
+      chunksInGeneration: parsed.chunksInGeneration ?? 0
+    }
+  } catch {
+    // A corrupt cursor must not wedge backups forever. Starting a fresh generation costs
+    // one full snapshot and is always safe.
+    return freshCursor()
+  }
+}
+
+export async function saveCursor (pseudonym: string, deviceId: string, c: PushCursor): Promise<void> {
+  await AsyncStorage.setItem(cursorKey(pseudonym, deviceId), JSON.stringify(c))
+}
+
+export async function clearCursor (pseudonym: string, deviceId: string): Promise<void> {
+  await AsyncStorage.removeItem(cursorKey(pseudonym, deviceId))
+}

--- a/utils/backup/derive.ts
+++ b/utils/backup/derive.ts
@@ -1,0 +1,41 @@
+/**
+ * Backup identity derivation.
+ *
+ * One derived key serves two purposes: it is the AuthFetch peer identity, so the server
+ * only ever sees a pseudonym rather than the wallet's real identity key; and it is the
+ * encryption key, used with counterparty 'self' so the server cannot decrypt what it
+ * stores. Both properties are chosen by the client — the server is merely unable to help.
+ */
+import { CompletedProtoWallet, KeyDeriver, PrivateKey } from '@bsv/sdk'
+import { BACKUP_KEY_ID, BACKUP_PROTOCOL } from './constants'
+
+/**
+ * Derive the backup-only wallet from the wallet's primary key (m/0'/0').
+ *
+ * primaryKey, NOT rootKey. A wallet restored from printed backup shares recovers only the
+ * m/0'/0' WIF and has no rootKey at all, so deriving from rootKey would leave exactly that
+ * cohort unable to decrypt their own backups — the cohort this feature most helps.
+ *
+ * Using a dedicated wallet rather than the app's main one also keeps blob encryption clear
+ * of WalletPermissionsManager, so it can never raise a protocol-permission prompt or a
+ * spending-authorisation gate.
+ */
+export function deriveBackupWallet (primaryKey: number[]): CompletedProtoWallet {
+  return new CompletedProtoWallet(deriveBackupKey(primaryKey))
+}
+
+/** The private key behind the backup identity. */
+export function deriveBackupKey (primaryKey: number[]): PrivateKey {
+  const deriver = new KeyDeriver(new PrivateKey(primaryKey))
+  return deriver.derivePrivateKey(BACKUP_PROTOCOL, BACKUP_KEY_ID, 'self')
+}
+
+/**
+ * The server-visible account address: a compressed public key in DER hex.
+ *
+ * This is never the wallet's identity key, and the server has no other way to address an
+ * account — there is no identity field anywhere in the API.
+ */
+export function backupPseudonym (primaryKey: number[]): string {
+  return deriveBackupKey(primaryKey).toPublicKey().toString()
+}

--- a/utils/backup/deviceId.ts
+++ b/utils/backup/deviceId.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-install device identifier for the backup log.
+ *
+ * Opaque and locally generated — it is not a hardware id and carries no device
+ * information. It exists so that two devices restoring the same wallet keep separate,
+ * independently sequenced logs rather than fighting over one sequence.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Random, Utils } from '@bsv/sdk'
+import { DEVICE_ID_KEY } from './constants'
+
+let cached: string | null = null
+
+/** 32 lowercase hex characters, matching the server's device-id pattern. */
+export async function getDeviceId (): Promise<string> {
+  if (cached != null) return cached
+
+  const existing = await AsyncStorage.getItem(DEVICE_ID_KEY)
+  if (existing != null && /^[a-f0-9]{32}$/.test(existing)) {
+    cached = existing
+    return existing
+  }
+
+  const fresh = Utils.toHex(Random(16))
+  await AsyncStorage.setItem(DEVICE_ID_KEY, fresh)
+  cached = fresh
+  return fresh
+}
+
+/** Test seam. */
+export function resetDeviceIdCache (): void {
+  cached = null
+}

--- a/utils/backup/push.ts
+++ b/utils/backup/push.ts
@@ -1,0 +1,201 @@
+/**
+ * One backup push pass.
+ *
+ * Reads a delta `SyncChunk` straight from the local storage provider, encrypts it, and
+ * appends it to the remote log.
+ *
+ * It deliberately does NOT go through `WalletStorageManager`. `updateBackups` and
+ * `syncToWriter` take the manager's sync lock via `runAsSync`, which blocks every read and
+ * write against active storage for the duration — unacceptable against the project's
+ * standing "chrome never JS-blocked" goal. Registering a remote as a backup store also hits
+ * the `_conflictingActives` trap, where a fresh remote user reports itself as the active
+ * storage and `updateBackups()` then throws `WERR_NOT_ACTIVE`.
+ *
+ * Reading without the lock means a chunk can be taken mid-write. That is safe here: chunks
+ * are `since`-based and replay is idempotent, so a torn read corrects itself on the next
+ * pass.
+ */
+import type { StorageExpoSQLite } from '@/storage'
+import type { SyncChunk } from '@bsv/wallet-toolbox-mobile/out/src/sdk/WalletStorage.interfaces'
+import { BackupClient, BackupHttpError, ERR_SEQ_CONFLICT } from './client'
+import { encodeChunk, isEmptyChunk } from './codec'
+import { GENERATION_CHUNK_THRESHOLD, MAX_ITEMS, MAX_ROUGH_SIZE } from './constants'
+import {
+  ENTITY_NAMES,
+  ENTITY_TO_CHUNK_ARRAY,
+  freshCursor,
+  loadCursor,
+  offsetsToArgs,
+  saveCursor,
+  zeroOffsets,
+  type PushCursor
+} from './cursor'
+import { backupPseudonym, deriveBackupWallet } from './derive'
+import { getDeviceId } from './deviceId'
+
+export interface PushDeps {
+  storage: StorageExpoSQLite
+  /** The wallet's m/0'/0' key. The backup identity and encryption key derive from it. */
+  primaryKey: number[]
+  /** The wallet's real identity key — used only for the LOCAL user lookup, never sent. */
+  identityKey: string
+  /** Supply exactly one of these. */
+  baseUrl?: string
+  client?: BackupClient
+  deviceId?: string
+}
+
+export interface PushResult {
+  /** Chunks appended this pass (0 or 1). */
+  pushed: number
+  /** Ciphertext bytes appended. */
+  bytes: number
+  /** True when the `since` window closed and the cursor advanced. */
+  windowClosed: boolean
+  /** True when a new generation was started. */
+  rotated: boolean
+}
+
+/**
+ * Take at most one chunk and append it.
+ *
+ * One chunk per pass rather than draining in a loop: the monitor runs tasks back-to-back
+ * without yielding, so a long pass would stall the JS thread. Successive passes drain the
+ * backlog.
+ */
+export async function pushOnce (deps: PushDeps): Promise<PushResult> {
+  const client = resolveClient(deps)
+  const pseudonym = backupPseudonym(deps.primaryKey)
+  const deviceId = deps.deviceId ?? (await getDeviceId())
+
+  let cursor = await loadCursor(pseudonym, deviceId)
+
+  const chunk = await deps.storage.getSyncChunk({
+    identityKey: deps.identityKey,
+    fromStorageIdentityKey: deps.identityKey,
+    toStorageIdentityKey: pseudonym,
+    since: cursor.since != null ? new Date(cursor.since) : undefined,
+    maxRoughSize: MAX_ROUGH_SIZE,
+    maxItems: MAX_ITEMS,
+    offsets: offsetsToArgs(cursor.offsets)
+  })
+
+  if (isEmptyChunk(chunk)) {
+    // Window exhausted. Advance `since` past everything seen and reset the offsets, exactly
+    // as EntitySyncState does when its merge reports done.
+    const advanced: PushCursor = {
+      ...cursor,
+      since: cursor.maxUpdatedAt ?? cursor.since,
+      maxUpdatedAt: undefined,
+      offsets: zeroOffsets()
+    }
+
+    const rotated = shouldRotate(advanced)
+    const next = rotated ? rotate(advanced) : advanced
+    await saveCursor(pseudonym, deviceId, next)
+    return { pushed: 0, bytes: 0, windowClosed: true, rotated }
+  }
+
+  const wallet = deriveBackupWallet(deps.primaryKey)
+  const ciphertext = await encodeChunk(wallet, chunk)
+
+  const seq = cursor.seq + 1
+  let sha: string
+  try {
+    const r = await client.append(deviceId, cursor.generation, seq, cursor.prevSha256, ciphertext)
+    sha = r.sha256
+  } catch (e) {
+    if (e instanceof BackupHttpError && e.code === ERR_SEQ_CONFLICT) {
+      // The server and the cursor disagree about the head. Resynchronise from the server's
+      // view rather than retrying into the same wall — this happens after a reinstall that
+      // kept the log but lost the cursor, or if two devices shared a device id.
+      cursor = await resyncFromServer(client, pseudonym, deviceId, cursor)
+      await saveCursor(pseudonym, deviceId, cursor)
+      return { pushed: 0, bytes: 0, windowClosed: false, rotated: false }
+    }
+    // Anything else: leave the cursor untouched so the same chunk is retried next pass.
+    throw e
+  }
+
+  // Only advance after the append succeeded, so a failure never skips records.
+  await saveCursor(pseudonym, deviceId, {
+    ...cursor,
+    offsets: advanceOffsets(cursor, chunk),
+    maxUpdatedAt: maxUpdatedAt(cursor.maxUpdatedAt, chunk),
+    seq,
+    prevSha256: sha,
+    chunksInGeneration: cursor.chunksInGeneration + 1
+  })
+
+  return { pushed: 1, bytes: ciphertext.length, windowClosed: false, rotated: false }
+}
+
+function resolveClient (deps: PushDeps): BackupClient {
+  if (deps.client != null) return deps.client
+  if (deps.baseUrl == null || deps.baseUrl === '') {
+    throw new Error('pushOnce requires either a client or a baseUrl')
+  }
+  return new BackupClient(deps.baseUrl, deps.primaryKey)
+}
+
+/** Per-entity consumed counts grow by what this chunk carried. */
+function advanceOffsets (cursor: PushCursor, chunk: SyncChunk): PushCursor['offsets'] {
+  const c = chunk as unknown as Record<string, unknown[] | undefined>
+  const next = { ...cursor.offsets }
+  for (const name of ENTITY_NAMES) {
+    next[name] = (next[name] ?? 0) + (c[ENTITY_TO_CHUNK_ARRAY[name]]?.length ?? 0)
+  }
+  return next
+}
+
+/** Greatest `updated_at` across everything in this chunk. */
+function maxUpdatedAt (current: string | undefined, chunk: SyncChunk): string | undefined {
+  const c = chunk as unknown as Record<string, Array<Record<string, unknown>> | undefined> // eslint-disable-line @typescript-eslint/array-type
+  let max = current
+
+  for (const name of ENTITY_NAMES) {
+    for (const item of c[ENTITY_TO_CHUNK_ARRAY[name]] ?? []) {
+      const raw = item.updated_at
+      if (raw == null) continue
+      const iso = raw instanceof Date ? raw.toISOString() : String(raw)
+      if (max == null || iso > max) max = iso
+    }
+  }
+  return max
+}
+
+/**
+ * Rotate only at a window boundary.
+ *
+ * A generation is meant to be a coherent snapshot, so starting one mid-window would leave a
+ * partially written generation that a restore could not trust.
+ */
+function shouldRotate (cursor: PushCursor): boolean {
+  return cursor.chunksInGeneration >= GENERATION_CHUNK_THRESHOLD
+}
+
+/** Begin a new generation: a full snapshot, from sequence one, with no `since` filter. */
+function rotate (cursor: PushCursor): PushCursor {
+  return freshCursor(cursor.generation + 1)
+}
+
+/**
+ * Rebuild the cursor from the server's head after a sequence conflict.
+ *
+ * The server is authoritative about what it holds. Rather than guess which records the
+ * remote log already covers, start a fresh generation — one extra full snapshot is cheap
+ * next to a restore with a hole in it.
+ */
+async function resyncFromServer (
+  client: BackupClient,
+  _pseudonym: string,
+  deviceId: string,
+  cursor: PushCursor
+): Promise<PushCursor> {
+  const devices = await client.manifest()
+  const newest = devices
+    .filter(d => d.deviceId === deviceId)
+    .reduce<number>((max, d) => Math.max(max, d.generation), cursor.generation)
+
+  return freshCursor(newest + 1)
+}

--- a/utils/backup/restore.ts
+++ b/utils/backup/restore.ts
@@ -1,0 +1,126 @@
+/**
+ * Restore orchestration.
+ *
+ * Given nothing but a recovered seed (or the primary key from printed shares), rebuild the
+ * wallet database from the encrypted log.
+ */
+import type { StorageExpoSQLite } from '@/storage'
+import { BackupClient, type DeviceSummary } from './client'
+import { deriveBackupWallet } from './derive'
+import { RemoteSyncReader } from './RemoteSyncReader'
+
+export interface RestoreDeps {
+  /** A fresh, migrated storage provider to replay into. */
+  storage: StorageExpoSQLite
+  /** The wallet's m/0'/0' key, from the mnemonic or from recovery shares. */
+  primaryKey: number[]
+  /** The wallet's real identity key, for the local user record. */
+  identityKey: string
+  /** Supply exactly one. */
+  baseUrl?: string
+  client?: BackupClient
+  /** Defaults to the most recently updated device in the manifest. */
+  deviceId?: string
+  /** Defaults to the newest generation for that device. */
+  generation?: number
+}
+
+export interface RestoreResult {
+  chunks: number
+  deviceId: string
+  generation: number
+}
+
+/** What the user can choose between when more than one device has a backup. */
+export async function listBackups (deps: {
+  primaryKey: number[]
+  baseUrl?: string
+  client?: BackupClient
+}): Promise<DeviceSummary[]> {
+  return await resolveClient(deps).manifest()
+}
+
+/**
+ * Replay the newest complete generation into `storage`.
+ *
+ * Picks the newest generation rather than the oldest because a generation is a full
+ * snapshot: the newest one alone is sufficient, and it is the shortest replay.
+ */
+export async function restoreFromBackup (deps: RestoreDeps): Promise<RestoreResult> {
+  const client = resolveClient(deps)
+  const wallet = deriveBackupWallet(deps.primaryKey)
+
+  const devices = await client.manifest()
+  if (devices.length === 0) {
+    throw new Error('No backup found for this wallet')
+  }
+
+  const chosen = pickTarget(devices, deps.deviceId, deps.generation)
+
+  const settings = await deps.storage.makeAvailable()
+  const reader = new RemoteSyncReader(client, wallet, chosen.deviceId, chosen.generation, settings)
+
+  let chunks = 0
+  for (;;) {
+    const chunk = await reader.getSyncChunk({
+      identityKey: deps.identityKey,
+      fromStorageIdentityKey: chosen.deviceId,
+      toStorageIdentityKey: settings.storageIdentityKey,
+      maxRoughSize: 0,
+      maxItems: 0,
+      offsets: []
+    })
+
+    const result = await deps.storage.processSyncChunk({
+      identityKey: deps.identityKey,
+      fromStorageIdentityKey: chosen.deviceId,
+      toStorageIdentityKey: settings.storageIdentityKey,
+      maxRoughSize: 0,
+      maxItems: 0,
+      offsets: []
+    }, chunk)
+
+    if (result.done) break
+    chunks++
+
+    // The reader is finite; this guards against a processSyncChunk that never reports done.
+    if (chunks > reader.length) break
+  }
+
+  return { chunks, deviceId: chosen.deviceId, generation: chosen.generation }
+}
+
+function pickTarget (
+  devices: DeviceSummary[],
+  deviceId?: string,
+  generation?: number
+): { deviceId: string, generation: number } {
+  const candidates = deviceId != null ? devices.filter(d => d.deviceId === deviceId) : devices
+  if (candidates.length === 0) {
+    throw new Error(`No backup found for device ${String(deviceId)}`)
+  }
+
+  if (generation != null) {
+    const exact = candidates.find(d => d.generation === generation)
+    if (exact == null) throw new Error(`No backup found for generation ${generation}`)
+    return { deviceId: exact.deviceId, generation: exact.generation }
+  }
+
+  // Most recently written device, then its newest generation.
+  const newest = candidates.reduce((best, d) =>
+    d.updatedAt > best.updatedAt ? d : best
+  )
+  const newestGeneration = candidates
+    .filter(d => d.deviceId === newest.deviceId)
+    .reduce((best, d) => (d.generation > best.generation ? d : best))
+
+  return { deviceId: newestGeneration.deviceId, generation: newestGeneration.generation }
+}
+
+function resolveClient (deps: { primaryKey: number[], baseUrl?: string, client?: BackupClient }): BackupClient {
+  if (deps.client != null) return deps.client
+  if (deps.baseUrl == null || deps.baseUrl === '') {
+    throw new Error('restore requires either a client or a baseUrl')
+  }
+  return new BackupClient(deps.baseUrl, deps.primaryKey)
+}

--- a/utils/monitor/TaskBackupPush.ts
+++ b/utils/monitor/TaskBackupPush.ts
@@ -1,0 +1,126 @@
+/**
+ * Pushes wallet-database deltas to the encrypted backup log.
+ *
+ * Triggering mirrors TaskSendOffline: gated on the app's single online signal, with an
+ * immediate pass when something changes and exponential backoff after failures.
+ *
+ * All state is static and process-global BY DESIGN. The monitor is torn down and rebuilt on
+ * network switches and wallet rebuilds, and backup progress — particularly the backoff after
+ * a failing server — must survive that. A per-instance version would reset its backoff every
+ * rebuild and hammer a service that is down.
+ *
+ * The work itself is deliberately small. Monitor tasks run back-to-back with no yielding, so
+ * a pass takes at most one chunk and the interval floor keeps it off the JS thread the rest
+ * of the time.
+ */
+import { WalletMonitorTask } from '@bsv/wallet-toolbox-mobile/out/src/monitor/tasks/WalletMonitorTask'
+import type { Monitor } from '@bsv/wallet-toolbox-mobile'
+import { MIN_PUSH_INTERVAL_MS } from '../backup/constants'
+import type { PushResult } from '../backup/push'
+
+export class TaskBackupPush extends WalletMonitorTask {
+  static taskName = 'BackupPush'
+
+  static readonly BASE_BACKOFF_MS = 30_000
+  static readonly MAX_BACKOFF_MS = 900_000
+
+  /** Last observation from the app's online listener. Gates the trigger entirely. */
+  static onlineNow = false
+  /** The database may hold un-pushed changes. Set pessimistically; a clean pass clears it. */
+  static hasChanges = false
+  /** An immediate pass has been requested. Consumed at the top of runTask. */
+  static checkNow = false
+  /** Earliest time the next pass may run. */
+  static nextDueAt = 0
+  static backoffMs = TaskBackupPush.BASE_BACKOFF_MS
+  /** Last error, kept so settings can show why backups are not progressing. */
+  static lastError: string | undefined
+  /** Time of the last successful pass, for the backup-health display. */
+  static lastSuccessAt: number | undefined
+
+  static noteConnectivity (online: boolean): void {
+    TaskBackupPush.onlineNow = online
+    if (online) {
+      TaskBackupPush.checkNow = true
+      TaskBackupPush.backoffMs = TaskBackupPush.BASE_BACKOFF_MS
+      TaskBackupPush.nextDueAt = 0
+    }
+  }
+
+  /** New wallet activity. Cheap to over-call: one idle pass clears the flag. */
+  static noteChanged (): void {
+    TaskBackupPush.hasChanges = true
+  }
+
+  /** User asked for an immediate backup. */
+  static requestNow (): void {
+    TaskBackupPush.checkNow = true
+    TaskBackupPush.backoffMs = TaskBackupPush.BASE_BACKOFF_MS
+    TaskBackupPush.nextDueAt = 0
+  }
+
+  static noteRan (at: number): void {
+    TaskBackupPush.nextDueAt = at + MIN_PUSH_INTERVAL_MS
+  }
+
+  static noteFailure (at: number): void {
+    TaskBackupPush.nextDueAt = at + TaskBackupPush.backoffMs
+    TaskBackupPush.backoffMs = Math.min(
+      TaskBackupPush.backoffMs * 2,
+      TaskBackupPush.MAX_BACKOFF_MS
+    )
+  }
+
+  /** Test seam; also used when the user signs out. */
+  static reset (): void {
+    TaskBackupPush.onlineNow = false
+    TaskBackupPush.hasChanges = false
+    TaskBackupPush.checkNow = false
+    TaskBackupPush.nextDueAt = 0
+    TaskBackupPush.backoffMs = TaskBackupPush.BASE_BACKOFF_MS
+    TaskBackupPush.lastError = undefined
+    TaskBackupPush.lastSuccessAt = undefined
+  }
+
+  constructor (
+    monitor: Monitor,
+    private readonly push: () => Promise<PushResult>
+  ) {
+    super(monitor, TaskBackupPush.taskName)
+  }
+
+  trigger (nowMsecsSinceEpoch: number): { run: boolean } {
+    if (!TaskBackupPush.onlineNow) return { run: false }
+    if (TaskBackupPush.checkNow) return { run: true }
+    if (!TaskBackupPush.hasChanges) return { run: false }
+    return { run: nowMsecsSinceEpoch >= TaskBackupPush.nextDueAt }
+  }
+
+  async runTask (): Promise<string> {
+    TaskBackupPush.checkNow = false
+    const startedAt = Date.now()
+
+    try {
+      const r = await this.push()
+      TaskBackupPush.noteRan(startedAt)
+      TaskBackupPush.backoffMs = TaskBackupPush.BASE_BACKOFF_MS
+      TaskBackupPush.lastError = undefined
+      TaskBackupPush.lastSuccessAt = startedAt
+
+      // A window that closed with nothing to send means the log has caught up. Anything
+      // else means there is more to drain, so keep the flag set for the next pass.
+      if (r.windowClosed && r.pushed === 0) {
+        TaskBackupPush.hasChanges = false
+      } else {
+        TaskBackupPush.checkNow = true
+      }
+
+      return r.pushed > 0 ? `backup: pushed 1 chunk, ${r.bytes} bytes` : ''
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      TaskBackupPush.lastError = message
+      TaskBackupPush.noteFailure(startedAt)
+      return `backup: push failed, retrying after ${TaskBackupPush.backoffMs}ms: ${message}`
+    }
+  }
+}


### PR DESCRIPTION
## Why

User research found that most users never back up their mnemonic, never print recovery shares, and never export wallet data. Investigating that turned up something worse than the reported problem:

**A mnemonic alone recovers nothing.** Spending an output requires derivation metadata that exists *only* in the local SQLite database:

- Change outputs are created with `const n = randomDerivation(16)` — a random derivation suffix persisted only in the DB
- Received BRC-29 outputs carry `senderIdentityKey`, `derivationPrefix` and `derivationSuffix` chosen by the **sender**
- No rescan or reconstruct-from-chain path exists anywhere in `StorageProvider`

So a user who dutifully printed recovery shares and then lost their phone still cannot spend their coins. The backup feature we ship today is necessary but not sufficient, and that gap is silent.

This closes it: the wallet database is pushed to an encrypted log as delta chunks, so recovery goes from "you need **both** the phrase and the device" to "you need **only** the phrase or the printed shares" — which makes the paper backup we already ship genuinely sufficient for the first time.

Server side lives in [bsv-blockchain/go-private-backup-cache](https://github.com/bsv-blockchain/go-private-backup-cache).

## What changed

**`@bsv/sdk` 2.4.0 upgrade** (blocking prerequisite, own commit)

Raw binary upload is impossible on 2.1.9: `AuthFetch.normalizeBodyToNumberArray` tested `typeof body === 'object'` ahead of its binary branches, so a `Uint8Array` body was JSON-stringified into `{"0":12,...}`. 2.4.0 fixes the branch ordering and a latent `byteOffset` bug that corrupts subarray views. The 2168-line native-secp patch was rebased and a regression test added.

**Backup client** — 9 modules under `utils/backup/`, plus `TaskBackupPush`.

One derived key does two jobs: it is the AuthFetch peer identity, so the server sees a pseudonym rather than our identity key, and it is the encryption key under `counterparty: 'self'`, so the server cannot read what it stores.

## Reviewer notes

**Inert by default.** `DEFAULT_BACKUP_URL` is `''`, so no task registers and nothing is sent until an operator sets an endpoint. `DEFAULT_STORAGE_URL` stays `'local'` — this service is deliberately not a wallet storage provider.

**Derivation is from `primaryKey` (m/0'/0'), not `rootKey`.** A wallet restored from printed shares has no `rootKey`; deriving from it would silently lock exactly that cohort out of their own backups. A frozen test vector pins the result — if it ever fails, the code is wrong, not the constant, because changing it would orphan every backup already written.

**Push bypasses `WalletStorageManager` on purpose.** `updateBackups`/`syncToWriter` take the sync lock via `runAsSync`, blocking all storage reads and writes — against our standing "chrome never JS-blocked" goal. Registering a remote as a backup store also hits the `_conflictingActives` trap (`WERR_NOT_ACTIVE`). Cursor bookkeeping mirrors `EntitySyncState` exactly, since a divergence would either skip records or resend them forever.

**Two findings worth a look:**

1. `binaryJsonReplacer` base64-encodes `Uint8Array` **only**, while every binary field on the toolbox's tables is typed `number[]` — so the toolbox serialiser alone would have shipped raw transaction bytes as decimal arrays at ~2.9 chars each. A packing pass fixes it, verified lossless including for arrays that merely look byte-like.
2. `patches/@bsv+sdk+2.4.0.patch` was generated by diffing the published tarball, because `patch-package`'s own temp install re-runs this project's `postinstall` and fails. It reapplies cleanly from a wiped `node_modules` — worth knowing before the next bump.

**Paid access was evaluated and rejected on privacy grounds**, recorded in the spec. BRC-228 removes the least important leak: the BEEF of a funded payment carries complete prior transactions of the user's wallet, inside a request BRC-104 has already bound to the pseudonym.

## Testing

- **837 tests / 70 suites green**, tsc and lint clean (was 769 before; +68)
- **SDK upgrade proven byte-exact**: 27 signature vectors and 4 key-derivation checks captured on 2.1.9 *before* the bump, reproducing identically on 2.4.0
- **End-to-end against a live server, 14/14**: a wallet pushed encrypted deltas, then a wallet holding only 2-of-3 reconstructed recovery shares derived the same pseudonym, read the log back, and recovered the BRC-29 `senderIdentityKey` / `derivationPrefix` / `derivationSuffix` / `lockingScript` byte-exactly — while an unrelated wallet got 404 on the same coordinates

Also adds `.claude/worktrees/` to jest's `modulePathIgnorePatterns`: a stale worktree there was scanned by the haste map, so `npm test` reported 8 suites failing on duplicate-module errors while every project test passed. The existing entry only covered `.worktrees/`.

## Not included

Entropy/mnemonic backup and any forcing or nagging of users — both explicitly out of scope by decision. The log is useless without the seed or shares, and the eventual UI must never let it read as a substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)