### PR TITLE
feat(vault): compress the R1-K1 script template (959,632 bytes -> 51)

### DIFF
--- a/__tests__/vault/fixtures/r1k1-mainnet-lockingScript.hex.md
+++ b/__tests__/vault/fixtures/r1k1-mainnet-lockingScript.hex.md
@@ -1,0 +1,54 @@
+# R1-K1 mainnet locking-script fixture
+
+Provenance for a real, mined mainnet R1-K1 vault output, used to prove the
+pinned template (`services/vault/templateCodec.ts`, `services/vault/r1k1.ts`)
+still reproduces byte-identical output — not merely a plausible one.
+
+- txid: `6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697`
+- vout: `0`
+- source: project owner's device database (public on-chain data; no secrets)
+
+## What is committed here
+
+Not the 959,632-byte script itself. Storing 1.9 MB of hex in git to test a
+compressor whose entire purpose is avoiding 1.9 MB would be self-defeating.
+Instead, this fixture commits the 40 bytes that vary between vault outputs
+(the R1 commitment and the k1PublicKeyHash actually mined on-chain for this
+output) plus SHA-256 digests of the full script and of its scriptCode. Both
+are recorded below and, as the actual source of truth the tests import,
+in `r1k1MainnetFixture.ts`.
+
+| field | value |
+| --- | --- |
+| length | 959632 |
+| commitment (offsets 17..36) | `93d0d2a2a0e1f6411498d53c4fd9db0e543171b1` |
+| k1PublicKeyHash (offsets 959609..959628) | `4c63d12b6237ddd07db2e8a08c984d7667b487d0` |
+| SHA-256 of the full locking script | `f5f78dcf291c5a115a609c1040117e2d09fd7e1cdc2d4911c633b338545f3db8` |
+| scriptCode = lockingScript.subarray(60), length 959572 | |
+| SHA-256 of scriptCode | `aeb8d8544f5bc218543de986cd974e7e387e3f455cb53a7c7460b466c2db6de9` |
+
+The preimage behind the commitment (the r1PublicKey/salt pair that hash160's
+to `93d0d2a2a0e1f6411498d53c4fd9db0e543171b1`) is not held anywhere and is not
+needed: the fixture proves the template reproduces this exact, already-mined
+commitment/k1PublicKeyHash pair byte-for-byte, not that this key material can
+be re-derived.
+
+## How the fixture is used
+
+`r1k1MainnetFixture.ts` exports the constants above plus
+`buildMainnetFixtureScript()`, which rebuilds the full 959,632-byte script
+from the CURRENT `@bsv/templates` `R1K1Wallet` using the commitment and
+k1PublicKeyHash above — via `R1K1Wallet().lock(commitment, k1PublicKeyHash)`
+directly, not `buildVaultLockingScript`, since this fixture holds the
+commitment itself rather than the r1PublicKey/salt preimage
+`buildVaultLockingScript` would hash to derive it.
+
+`__tests__/vault/r1k1MainnetFixture.test.ts` asserts the rebuilt script's
+SHA-256 equals the digest recorded above, and that the digest is stable
+across two independent builds.
+
+If `@bsv/templates` ever changes the R1K1 locking-script layout, the rebuilt
+bytes will differ from what is actually mined and this digest comparison
+fails — loudly, in CI — instead of the compressed-fixture round trip silently
+reconstructing the wrong bytes for a real, already-mined mainnet vault
+output.

--- a/__tests__/vault/fixtures/r1k1MainnetFixture.ts
+++ b/__tests__/vault/fixtures/r1k1MainnetFixture.ts
@@ -1,0 +1,80 @@
+/**
+ * Real, mined mainnet R1-K1 vault locking script — used to prove the pinned
+ * template still reproduces byte-identical output against an ACTUAL on-chain
+ * script, not just a freshly-built one. See r1k1-mainnet-lockingScript.hex.md
+ * for full provenance.
+ *
+ * We do not commit the 959,632-byte script itself (1.9 MB of hex in git to
+ * test a compressor whose whole point is avoiding 1.9 MB would be
+ * self-defeating). Instead we commit the 40 bytes that vary between vault
+ * outputs — the R1 commitment and k1PublicKeyHash actually mined for this
+ * output — plus SHA-256 digests of the full script and of its scriptCode.
+ * `buildMainnetFixtureScript` rebuilds the full script from the CURRENT
+ * `@bsv/templates` R1K1Wallet using those 40 bytes; the accompanying test
+ * (`__tests__/vault/r1k1MainnetFixture.test.ts`) asserts the rebuilt script's
+ * digest still equals `MAINNET_LOCKING_SCRIPT_SHA256`. If `@bsv/templates`
+ * ever changes the R1K1 layout, that assertion fails loudly instead of the
+ * compressed-fixture round trip silently reconstructing the wrong bytes for
+ * a real, already-mined output.
+ *
+ * SECURITY: nothing secret here. txid/vout/commitment/k1PublicKeyHash are all
+ * public on-chain data; the r1PublicKey/salt preimage behind the commitment
+ * is not held anywhere and is not needed by this fixture.
+ */
+import { R1K1Wallet } from '@bsv/templates'
+
+export const MAINNET_FIXTURE_TXID = '6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697'
+export const MAINNET_FIXTURE_VOUT = 0
+
+export const MAINNET_LOCKING_SCRIPT_LENGTH = 959632
+export const MAINNET_LOCKING_SCRIPT_SHA256 = 'f5f78dcf291c5a115a609c1040117e2d09fd7e1cdc2d4911c633b338545f3db8'
+
+/** scriptCode = lockingScript.subarray(60); see services/vault/templateCodec.ts Task 3. */
+export const MAINNET_SCRIPT_CODE_LENGTH = 959572
+export const MAINNET_SCRIPT_CODE_SHA256 = 'aeb8d8544f5bc218543de986cd974e7e387e3f455cb53a7c7460b466c2db6de9'
+
+/** R1 commitment (hash160(r1PublicKey ‖ salt)) actually mined at offsets
+ * 17..36 of the real output. The r1PublicKey/salt preimage behind this
+ * commitment is not held anywhere — this fixture proves the template
+ * reproduces this exact, already-mined commitment byte-for-byte, not that
+ * the commitment can be re-derived from scratch. */
+export const MAINNET_COMMITMENT_HEX = '93d0d2a2a0e1f6411498d53c4fd9db0e543171b1'
+
+/** k1PublicKeyHash actually mined at offsets 959609..959628 of the real output. */
+export const MAINNET_K1_PUBLIC_KEY_HASH_HEX = '4c63d12b6237ddd07db2e8a08c984d7667b487d0'
+
+let cachedScript: number[] | undefined
+
+/**
+ * Rebuild the real mainnet locking script from the CURRENT R1K1Wallet
+ * template, using the real commitment/k1PublicKeyHash mined on-chain (above).
+ *
+ * Built via the underlying template directly — `R1K1Wallet().lock(commitment,
+ * k1PublicKeyHash)` — rather than `buildVaultLockingScript`, because this
+ * fixture holds the commitment itself, not the r1PublicKey/salt preimage
+ * `buildVaultLockingScript` would hash160 to derive it.
+ *
+ * Memoized: building the ~960 KB script is not free, and both this fixture's
+ * own test and later tasks' round-trip tests call this. Returns a fresh copy
+ * each call so callers are free to mutate their result (as e.g.
+ * templateCodec.test.ts's byte-flip tests do) without corrupting the cache
+ * for the next caller.
+ */
+export async function buildMainnetFixtureScript(): Promise<number[]> {
+  if (!cachedScript) {
+    const commitment = hexToBytes(MAINNET_COMMITMENT_HEX)
+    const k1PublicKeyHash = hexToBytes(MAINNET_K1_PUBLIC_KEY_HASH_HEX)
+    const script = await new R1K1Wallet().lock(commitment, k1PublicKeyHash)
+    cachedScript = script.toBinary()
+  }
+  return cachedScript.slice()
+}
+
+/** Local, dependency-free hex decoder (avoids pulling in @bsv/sdk's Utils
+ * just for this one call, and keeps this fixture's only import the template
+ * it is fixturing). */
+function hexToBytes(hex: string): number[] {
+  const out: number[] = []
+  for (let i = 0; i < hex.length; i += 2) out.push(parseInt(hex.slice(i, i + 2), 16))
+  return out
+}

--- a/__tests__/vault/fixtures/r1k1MainnetFixture.ts
+++ b/__tests__/vault/fixtures/r1k1MainnetFixture.ts
@@ -43,29 +43,48 @@ export const MAINNET_COMMITMENT_HEX = '93d0d2a2a0e1f6411498d53c4fd9db0e543171b1'
 /** k1PublicKeyHash actually mined at offsets 959609..959628 of the real output. */
 export const MAINNET_K1_PUBLIC_KEY_HASH_HEX = '4c63d12b6237ddd07db2e8a08c984d7667b487d0'
 
-let cachedScript: number[] | undefined
-
 /**
- * Rebuild the real mainnet locking script from the CURRENT R1K1Wallet
- * template, using the real commitment/k1PublicKeyHash mined on-chain (above).
+ * Build the real mainnet locking script from the CURRENT R1K1Wallet template,
+ * using the real commitment/k1PublicKeyHash mined on-chain (above). ALWAYS
+ * invokes `R1K1Wallet().lock()` — no memoization.
  *
  * Built via the underlying template directly — `R1K1Wallet().lock(commitment,
  * k1PublicKeyHash)` — rather than `buildVaultLockingScript`, because this
  * fixture holds the commitment itself, not the r1PublicKey/salt preimage
  * `buildVaultLockingScript` would hash160 to derive it.
  *
- * Memoized: building the ~960 KB script is not free, and both this fixture's
- * own test and later tasks' round-trip tests call this. Returns a fresh copy
- * each call so callers are free to mutate their result (as e.g.
+ * Exists so a genuine determinism check can force two independent builds
+ * instead of reading a memo twice (see `buildMainnetFixtureScript` below,
+ * and r1k1MainnetFixture.test.ts's "stable across two independent builds"
+ * test, which calls this — not the memoized wrapper — precisely so that a
+ * regression in `@bsv/templates` determinism has somewhere to show up).
+ * Ordinary callers should use `buildMainnetFixtureScript` instead.
+ */
+export async function rebuildMainnetFixtureScriptUncached(): Promise<number[]> {
+  const commitment = hexToBytes(MAINNET_COMMITMENT_HEX)
+  const k1PublicKeyHash = hexToBytes(MAINNET_K1_PUBLIC_KEY_HASH_HEX)
+  const script = await new R1K1Wallet().lock(commitment, k1PublicKeyHash)
+  return script.toBinary()
+}
+
+let cachedScript: number[] | undefined
+
+/**
+ * Memoized wrapper around `rebuildMainnetFixtureScriptUncached`: building the
+ * ~960 KB script is not free, and both this fixture's own test and later
+ * tasks' round-trip tests call this repeatedly. Returns a fresh copy each
+ * call so callers are free to mutate their result (as e.g.
  * templateCodec.test.ts's byte-flip tests do) without corrupting the cache
  * for the next caller.
+ *
+ * Because this memoizes after the first call, it must NOT be used to test
+ * that the underlying build is deterministic — a second call here proves
+ * only that `.slice()` copies correctly. Use
+ * `rebuildMainnetFixtureScriptUncached` for that.
  */
 export async function buildMainnetFixtureScript(): Promise<number[]> {
   if (!cachedScript) {
-    const commitment = hexToBytes(MAINNET_COMMITMENT_HEX)
-    const k1PublicKeyHash = hexToBytes(MAINNET_K1_PUBLIC_KEY_HASH_HEX)
-    const script = await new R1K1Wallet().lock(commitment, k1PublicKeyHash)
-    cachedScript = script.toBinary()
+    cachedScript = await rebuildMainnetFixtureScriptUncached()
   }
   return cachedScript.slice()
 }

--- a/__tests__/vault/r1k1.test.ts
+++ b/__tests__/vault/r1k1.test.ts
@@ -94,6 +94,36 @@ describe('r1k1 script module', () => {
     expect(script.toBinary().length).toBe(R1K1_R1_UNLOCK_LEN)
   })
 
+  it('estimateLength pins R1K1_R1_UNLOCK_LEN without ever invoking signDigest', async () => {
+    // Closes a real gap: templateCodec.ts and this test file each hardcode
+    // the 60-byte scriptCode offset independently of @bsv/templates' own
+    // `lockingBytes.subarray(60)` inside unlockR1 (see R1K1Wallet.js) — a
+    // typo between our two copies would be caught by cross-checking them
+    // against each other, but a genuine upstream change to THAT offset, with
+    // the locking script's bytes otherwise unchanged, would not: it would
+    // silently produce a wrong scriptCode, hence a wrong preimage, hence a
+    // wrong signature digest, for a real already-mined output — and nothing
+    // above would notice. estimateLength builds that same preimage (so it
+    // depends on the same offset) without ever calling signDigest, so a stub
+    // signer pins its length against R1K1_R1_UNLOCK_LEN; an offset drift
+    // changes the scriptCode length, which changes the preimage length,
+    // which changes this number — so it fails loudly here instead of
+    // surfacing as an unspendable output.
+    const s = await scenario()
+    const u = new R1K1Wallet().unlockR1({
+      publicKey: s.r1PublicKey,
+      salt: s.salt,
+      sourceSatoshis: 500_000,
+      lockingScript: s.lockingScript,
+      signDigest: async () => []
+    })
+
+    const length = await u.estimateLength(s.spend, 0)
+
+    expect(length).toBe(R1K1_R1_UNLOCK_LEN)
+    expect(R1K1_R1_UNLOCK_LEN).toBe(959_871)
+  })
+
   it('accepts a high-S R1 signature without normalisation', async () => {
     const s = await scenario()
     const N = p256.Point.Fn.ORDER

--- a/__tests__/vault/r1k1MainnetFixture.test.ts
+++ b/__tests__/vault/r1k1MainnetFixture.test.ts
@@ -1,0 +1,46 @@
+import { Hash, Utils } from '@bsv/sdk'
+import {
+  MAINNET_LOCKING_SCRIPT_LENGTH,
+  MAINNET_LOCKING_SCRIPT_SHA256,
+  MAINNET_SCRIPT_CODE_LENGTH,
+  MAINNET_SCRIPT_CODE_SHA256,
+  buildMainnetFixtureScript
+} from './fixtures/r1k1MainnetFixture'
+
+describe('vault template codec: real mainnet fixture', () => {
+  // Rebuilding the ~960 KB script is not free — build it once for the whole
+  // suite rather than per test (the "stability across two builds" test below
+  // calls the helper again deliberately, but that is its whole point).
+  let scriptBytes: number[]
+
+  beforeAll(async () => {
+    scriptBytes = await buildMainnetFixtureScript()
+  })
+
+  it('rebuilds a script of the recorded mainnet length', () => {
+    expect(scriptBytes.length).toBe(MAINNET_LOCKING_SCRIPT_LENGTH)
+  })
+
+  it('rebuilds the mined mainnet script byte-for-byte: SHA-256 matches the recorded digest', () => {
+    // This is the assertion that matters: a script built from the pinned
+    // template, using only the commitment and k1PublicKeyHash actually mined
+    // on mainnet (txid 6c947ae3..., vout 0), hashes to the exact digest
+    // recorded from that real, already-mined output. If @bsv/templates ever
+    // changes the R1K1 layout, this is what catches it.
+    expect(Utils.toHex(Hash.sha256(scriptBytes))).toBe(MAINNET_LOCKING_SCRIPT_SHA256)
+  })
+
+  it('the recorded digest is stable across two independent builds', async () => {
+    const rebuilt = await buildMainnetFixtureScript()
+    expect(rebuilt).toEqual(scriptBytes)
+    expect(Utils.toHex(Hash.sha256(rebuilt))).toBe(MAINNET_LOCKING_SCRIPT_SHA256)
+  })
+
+  it('scriptCode (lockingScript.subarray(60)) hashes to the recorded digest', () => {
+    // Cross-validates the region-0x02 pinned constants (Task 3) against this
+    // same real mainnet output, not just against a freshly-built script.
+    const scriptCode = scriptBytes.slice(60)
+    expect(scriptCode.length).toBe(MAINNET_SCRIPT_CODE_LENGTH)
+    expect(Utils.toHex(Hash.sha256(scriptCode))).toBe(MAINNET_SCRIPT_CODE_SHA256)
+  })
+})

--- a/__tests__/vault/r1k1MainnetFixture.test.ts
+++ b/__tests__/vault/r1k1MainnetFixture.test.ts
@@ -4,13 +4,16 @@ import {
   MAINNET_LOCKING_SCRIPT_SHA256,
   MAINNET_SCRIPT_CODE_LENGTH,
   MAINNET_SCRIPT_CODE_SHA256,
-  buildMainnetFixtureScript
+  buildMainnetFixtureScript,
+  rebuildMainnetFixtureScriptUncached
 } from './fixtures/r1k1MainnetFixture'
 
 describe('vault template codec: real mainnet fixture', () => {
   // Rebuilding the ~960 KB script is not free — build it once for the whole
-  // suite rather than per test (the "stability across two builds" test below
-  // calls the helper again deliberately, but that is its whole point).
+  // suite via the memoized helper rather than per test. The "stable across
+  // two independent builds" test below deliberately bypasses that memo (see
+  // its own comment) so it is a genuine second build, not a second read of
+  // the same cached result.
   let scriptBytes: number[]
 
   beforeAll(async () => {
@@ -31,9 +34,17 @@ describe('vault template codec: real mainnet fixture', () => {
   })
 
   it('the recorded digest is stable across two independent builds', async () => {
-    const rebuilt = await buildMainnetFixtureScript()
-    expect(rebuilt).toEqual(scriptBytes)
-    expect(Utils.toHex(Hash.sha256(rebuilt))).toBe(MAINNET_LOCKING_SCRIPT_SHA256)
+    // Uses rebuildMainnetFixtureScriptUncached, NOT buildMainnetFixtureScript
+    // — the latter is memoized, so a second call would just return a copy of
+    // the same cached array and this test would be unable to fail no matter
+    // what R1K1Wallet().lock() did. Calling the unmemoized builder twice
+    // forces two real, independent invocations of R1K1Wallet().lock(), so a
+    // genuine nondeterminism in the template would show up as a mismatch here.
+    const first = await rebuildMainnetFixtureScriptUncached()
+    const second = await rebuildMainnetFixtureScriptUncached()
+    expect(second).toEqual(first)
+    expect(Utils.toHex(Hash.sha256(first))).toBe(MAINNET_LOCKING_SCRIPT_SHA256)
+    expect(Utils.toHex(Hash.sha256(second))).toBe(MAINNET_LOCKING_SCRIPT_SHA256)
   })
 
   it('scriptCode (lockingScript.subarray(60)) hashes to the recorded digest', () => {

--- a/__tests__/vault/templateCodec.test.ts
+++ b/__tests__/vault/templateCodec.test.ts
@@ -165,6 +165,52 @@ describe('vault template codec: compress + expand', () => {
     expect(isCompressed(compressed)).toBe(false)
   })
 
+  it('leaves a same-length near-miss script unchanged — rejected by the byte-compare, not the length check', async () => {
+    // scriptBytes is a real 959632-byte vault script, so this exits
+    // matchesTemplate's LENGTH check the same way a real script does; only
+    // the subsequent byte-by-byte compare against the cached reference can
+    // reject it. Both existing "leaves non-matching bytes unchanged" tests
+    // above use a 25-byte P2PKH script, which exits at the length check and
+    // never exercises this branch.
+    const nearMiss = scriptBytes.slice()
+    // Flip byte 0 (constant, well outside both variable runs) to a value
+    // guaranteed to differ from the original AND to never collide with
+    // TEMPLATE_MARKER (0xff) — a marker-led array takes a different branch
+    // entirely (see the marker-leading test below).
+    nearMiss[0] = nearMiss[0] === 0x00 ? 0x01 : 0x00
+
+    const compressed = await compressScript(nearMiss)
+
+    expect(compressed).toEqual(nearMiss)
+    expect(compressed.length).toBe(scriptBytes.length)
+    expect(compressed[0]).not.toBe(TEMPLATE_MARKER)
+    expect(isCompressed(compressed)).toBe(false)
+  })
+
+  it('compressScript throws rather than silently passing through bytes that already begin with the compressed-script marker', async () => {
+    // A 47-byte, marker-led, well-formed-looking header (version 1, region
+    // 0x01, originalLength 959632 — the real R1K1_LOCK_LEN) whose 40-byte
+    // payload is not a real commitment/k1PublicKeyHash pair at all. Before
+    // the Fix 1 guard, compressForRegion's pass-through returned this
+    // verbatim (it matches no known template, since it's only 47 bytes
+    // long): isCompressed() would then report true, and a caller following
+    // this module's own documented isCompressed(b) ? expandScript(b) : b
+    // pattern would inflate it into a fabricated 959632-byte vault script
+    // whose commitment and k1PublicKeyHash are both 0xaa x20 — violating
+    // expand(compress(x)) === x for this constructible x.
+    const markerLeading = [TEMPLATE_MARKER, 0x01, 0x01, 0x00, 0x0e, 0xa4, 0x90, ...Array(40).fill(0xaa)]
+    expect(markerLeading.length).toBe(47)
+    expect(isCompressed(markerLeading)).toBe(true)
+
+    let caught: unknown
+    try {
+      await compressScript(markerLeading)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
+
   it('expandScript throws template-unknown for an unrecognised version', async () => {
     const bogus = [TEMPLATE_MARKER, 250, 0x01, 0, 0, 0, 0]
 
@@ -195,6 +241,41 @@ describe('vault template codec: compress + expand', () => {
     let caught: unknown
     try {
       await expandScript(truncated)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
+
+  it('expandScript reports template-unknown, not template-invalid, for short bytes that never begin with the marker', async () => {
+    // The marker check runs BEFORE the length check: a short array that was
+    // never meant to be a compressed header (it doesn't even start with
+    // 0xff) must be diagnosed as "unrecognised", not misreported as a
+    // truncated header of a real one. Covers both a non-empty short array
+    // and the empty-array edge case (no byte 0 to even inspect).
+    for (const short of [[], [0x01, 0x02, 0x03]]) {
+      let caught: unknown
+      try {
+        await expandScript(short)
+      } catch (e) {
+        caught = e
+      }
+      expect(caught).toMatchObject({ code: 'template-unknown' })
+    }
+  })
+
+  it('expandScript throws template-invalid when the payload length disagrees with the version it names', async () => {
+    // Header fields (version/region/originalLength) are left intact and
+    // correctly name a known version; only the payload itself is one byte
+    // short. This is the guard that stands between a corrupt blob and
+    // `undefined` landing in the reconstructed bytes at a variable-run
+    // offset (result[r.offset + i] = payload[payloadOffset + i]).
+    const compressed = await compressScript(scriptBytes)
+    const shortPayload = compressed.slice(0, compressed.length - 1)
+
+    let caught: unknown
+    try {
+      await expandScript(shortPayload)
     } catch (e) {
       caught = e
     }
@@ -351,5 +432,63 @@ describe('vault template codec: same-length constant-byte drift is caught', () =
       caught = e
     }
     expect(caught).toMatchObject({ code: 'template-unknown' })
+  })
+})
+
+describe('vault template codec: coincidental sample agreement cannot narrow a real variable run', () => {
+  // Regression test for a subtle false-positive distinct from the drift test
+  // above: DIFF_SAMPLE_COUNT (4) throwaway samples are diffed to FIND the
+  // variable runs, so a genuinely-variable byte that happens to draw the
+  // SAME value on every sample — a real, if individually unlikely,
+  // per-process coincidence, not an actual template change — would make
+  // findVariableRuns split a real run and report it one byte narrower than
+  // it truly is. Without a backstop, that narrower run changes constantHash
+  // and makes describeVaultTemplate throw 'template-unknown' — a false
+  // diagnosis of an @bsv/templates upgrade when nothing changed, and (since
+  // only the success path is memoized) a ~114ms re-pay on every subsequent
+  // call until the coincidence stops recurring.
+  //
+  // describeVaultTemplate masks (unions) the sample-derived runs against
+  // PINNED_VARIABLE_RUNS_V1 precisely so a coincidental agreement can only
+  // ever widen a run, never split one. This mocks buildVaultLockingScript to
+  // force one byte inside the real commitment run (offsets 17..36) to the
+  // SAME value on every sample, reproducing that coincidence deterministically
+  // rather than waiting on real (im)probability.
+  //
+  // Runs inside jest.isolateModulesAsync for the same reason as the drift
+  // test above: an isolated module instance with its own `cachedDescriptors`.
+  it('describeVaultTemplate does not throw, and keeps the full pinned run geometry, when one byte inside a real variable run agrees on every sample', async () => {
+    let freshDescribe: (() => Promise<TemplateVersion[]>) | undefined
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('@/services/vault/r1k1', () => {
+        const actual = jest.requireActual('@/services/vault/r1k1')
+        return {
+          ...actual,
+          buildVaultLockingScript: async (a: { r1PublicKey: string; salt: string; k1PublicKeyHash: number[] }) => {
+            const script = await actual.buildVaultLockingScript(a)
+            const bytes: number[] = script.toBinary()
+            // Offset 25 sits inside the real 17..36 commitment run (a
+            // genuine hash160 output, ordinarily different on every sample).
+            // Forcing it to a fixed value on every sample simulates the rare
+            // coincidence without needing astronomical luck.
+            bytes[25] = 0x00
+            return { toBinary: () => bytes }
+          }
+        }
+      })
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- isolated module registry needs a fresh require, not the file's top-level import
+      const mod = require('@/services/vault/templateCodec')
+      freshDescribe = mod.describeVaultTemplate
+    })
+
+    const descriptors = await freshDescribe!()
+    const region1 = descriptors.find((d) => d.region === 0x01)
+    expect(region1).toBeDefined()
+    // The full 20-byte commitment run, NOT split around offset 25.
+    expect(region1!.variableRuns).toEqual([
+      { offset: 17, length: 20 },
+      { offset: 959609, length: 20 }
+    ])
   })
 })

--- a/__tests__/vault/templateCodec.test.ts
+++ b/__tests__/vault/templateCodec.test.ts
@@ -1,9 +1,15 @@
 import { Hash, P2PKH, PrivateKey, Utils } from '@bsv/sdk'
 import { p256 } from '@noble/curves/nist.js'
-import { buildMainnetFixtureScript } from './fixtures/r1k1MainnetFixture'
+import {
+  buildMainnetFixtureScript,
+  MAINNET_K1_PUBLIC_KEY_HASH_HEX,
+  MAINNET_SCRIPT_CODE_LENGTH,
+  MAINNET_SCRIPT_CODE_SHA256
+} from './fixtures/r1k1MainnetFixture'
 import { R1K1_LOCK_LEN, buildVaultLockingScript } from '@/services/vault/r1k1'
 import {
   compressScript,
+  compressScriptCode,
   describeVaultTemplate,
   expandScript,
   isCompressed,
@@ -207,6 +213,97 @@ describe('vault template codec: compress + expand', () => {
       caught = e
     }
     expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
+})
+
+describe('vault template codec: region 0x02 (preimage scriptCode)', () => {
+  // Building the ~960 KB locking script (and diffing it inside
+  // describeVaultTemplate) is not free — build once for this whole block.
+  let scriptCodeDescriptor: TemplateVersion
+  let scriptBytes: number[]
+  let scriptCodeBytes: number[]
+
+  beforeAll(async () => {
+    const descriptors = await describeVaultTemplate()
+    const found = descriptors.find((d) => d.region === 0x02)
+    if (!found) throw new Error('describeVaultTemplate did not return a region 0x02 descriptor')
+    scriptCodeDescriptor = found
+
+    scriptBytes = (await buildVaultLockingScript(fixture())).toBinary()
+    scriptCodeBytes = scriptBytes.slice(60)
+  })
+
+  it("derives scriptCode by dropping the locking script's first 60 bytes — R1K1Wallet.unlockR1 builds the preimage as lockingBytes.subarray(60)", () => {
+    // This is the test that fails and names the reason if @bsv/templates ever
+    // changes that relationship: it re-derives 959572 straight from a
+    // freshly built script (via the library's own 60-byte cut) rather than
+    // trusting a hardcoded number, and separately confirms the codec's own
+    // region-0x02 descriptor was derived the same way.
+    expect(scriptCodeBytes.length).toBe(959572)
+    expect(scriptCodeBytes.length).toBe(R1K1_LOCK_LEN - 60)
+    expect(scriptCodeDescriptor.totalLength).toBe(R1K1_LOCK_LEN - 60)
+    expect(matchesTemplate(scriptCodeBytes, scriptCodeDescriptor)).toBe(true)
+  })
+
+  it('the 0x02 variable run is k1PublicKeyHash only (20 bytes), not the 40-byte 0x01 payload', () => {
+    // The R1 commitment run (offset 17, length 20 in the locking script) sits
+    // entirely below the 60-byte cut, so it drops out of the scriptCode
+    // altogether; only k1PublicKeyHash (originally at offset 959609) shifts
+    // into view, at 959609 - 60 = 959549.
+    expect(scriptCodeDescriptor.variableRuns).toEqual([{ offset: 959549, length: 20 }])
+  })
+
+  it('scriptCode constantHash matches the pinned reference recorded for version 1 region 0x02', () => {
+    // Pinned literal, independently re-declared here (not imported) so a
+    // one-sided edit to the implementation's pinned value can't silently
+    // pass — mirrors the region-0x01 constantHash test above.
+    expect(scriptCodeDescriptor.constantHash).toBe(
+      'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
+    )
+  })
+
+  it('round-trips a freshly built scriptCode byte-for-byte', async () => {
+    const compressed = await compressScriptCode(scriptCodeBytes)
+    const expanded = await expandScript(compressed)
+    expect(expanded).toEqual(scriptCodeBytes)
+  })
+
+  it('round-trips the REAL mined mainnet scriptCode byte-for-byte, and its compressed payload is k1PublicKeyHash ONLY', async () => {
+    // The fixture holds the actual k1PublicKeyHash mined on-chain for txid
+    // 6c947ae3..., vout 0 — this proves compress+expand reproduces a real,
+    // already-mined scriptCode exactly, not just a freshly-built one.
+    const mainnetScript = await buildMainnetFixtureScript()
+    const mainnetScriptCode = mainnetScript.slice(60)
+    expect(mainnetScriptCode.length).toBe(MAINNET_SCRIPT_CODE_LENGTH)
+    expect(Utils.toHex(Hash.sha256(mainnetScriptCode))).toBe(MAINNET_SCRIPT_CODE_SHA256)
+
+    const compressed = await compressScriptCode(mainnetScriptCode)
+    const expanded = await expandScript(compressed)
+    expect(expanded).toEqual(mainnetScriptCode)
+
+    // Region 0x02's payload is 20 bytes (k1PublicKeyHash), not 40: the R1
+    // commitment cannot survive the 60-byte cut, so it is not — and cannot
+    // be — part of this payload. The commitment stays recoverable elsewhere:
+    // the unlocking script pushes publicKey and salt verbatim, and
+    // commitment = hash160(publicKey ‖ salt).
+    const payload = compressed.slice(7) // HEADER_LENGTH: marker(1)+version(1)+region(1)+originalLength(4)
+    expect(payload.length).toBe(20)
+    expect(Utils.toHex(payload)).toBe(MAINNET_K1_PUBLIC_KEY_HASH_HEX)
+  })
+
+  it('produces a 27-byte compressed scriptCode starting with the 0xff marker (7-byte header + 20-byte payload)', async () => {
+    const compressed = await compressScriptCode(scriptCodeBytes)
+    expect(compressed[0]).toBe(TEMPLATE_MARKER)
+    expect(compressed.length).toBe(27)
+    expect(isCompressed(compressed)).toBe(true)
+  })
+
+  it('leaves non-matching bytes unchanged and does not allocate a header', async () => {
+    const wrongLength = scriptCodeBytes.slice(0, 1000)
+    const compressed = await compressScriptCode(wrongLength)
+    expect(compressed).toEqual(wrongLength)
+    expect(compressed[0]).not.toBe(TEMPLATE_MARKER)
+    expect(isCompressed(compressed)).toBe(false)
   })
 })
 

--- a/__tests__/vault/templateCodec.test.ts
+++ b/__tests__/vault/templateCodec.test.ts
@@ -51,6 +51,22 @@ describe('vault template codec: descriptor + exact recognition', () => {
     expect(descriptor.constantHash).toMatch(/^[0-9a-f]{64}$/)
   })
 
+  it('constantHash matches the pinned reference recorded for version 1', () => {
+    // Pinned literal, computed once from the CURRENT @bsv/templates
+    // R1K1Wallet output — mirrors PINNED_CONSTANT_HASH_V1 in
+    // templateCodec.ts (kept as a separately-recorded literal here, not an
+    // import, so this test can't be made to pass by silently changing the
+    // implementation's pinned value). totalLength/variableRuns alone cannot
+    // catch an @bsv/templates upgrade that keeps 959,632 bytes but alters a
+    // constant byte in between — this is the assertion that closes that
+    // gap. describeVaultTemplate() itself would already have thrown
+    // 'template-unknown' by the time this runs if the live template ever
+    // disagreed with this value (see the next describe block for that
+    // throwing behaviour); this test additionally pins the exact expected
+    // value so a change shows up here too, by name.
+    expect(descriptor.constantHash).toBe('41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b')
+  })
+
   it('rejects a script with one byte flipped outside a variable run', () => {
     const mutated = scriptBytes.slice()
     mutated[0] ^= 0xff // well outside both runs, and XOR-0xff always flips
@@ -191,5 +207,52 @@ describe('vault template codec: compress + expand', () => {
       caught = e
     }
     expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
+})
+
+describe('vault template codec: same-length constant-byte drift is caught', () => {
+  // The failure mode this guards against: an @bsv/templates upgrade that
+  // keeps R1K1_LOCK_LEN (959632) bytes but alters one of the FIXED bytes in
+  // between. totalLength and originalLength checks can't see this — only
+  // comparing the live template's constantHash against a pinned reference
+  // can. This is exercised end-to-end (a real describeVaultTemplate() call,
+  // not a duplicated/extracted comparison helper), against a mocked
+  // buildVaultLockingScript that flips one constant byte the SAME way on
+  // every sample it builds — so the diffing logic still treats it as
+  // constant, not variable, and only its value has drifted.
+  //
+  // Runs inside jest.isolateModulesAsync so the mocked drift gets its own,
+  // separate `templateCodec` module instance (own `cachedDescriptors`,
+  // untouched by whatever the other describe blocks in this file already
+  // cached) rather than contaminating the real one the rest of this suite
+  // relies on.
+  it('describeVaultTemplate throws template-unknown when a constant byte drifts at the same length', async () => {
+    let freshDescribe: (() => Promise<unknown>) | undefined
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('@/services/vault/r1k1', () => {
+        const actual = jest.requireActual('@/services/vault/r1k1')
+        return {
+          ...actual,
+          buildVaultLockingScript: async (a: { r1PublicKey: string; salt: string; k1PublicKeyHash: number[] }) => {
+            const script = await actual.buildVaultLockingScript(a)
+            const bytes: number[] = script.toBinary()
+            bytes[0] ^= 0xff // outside both variable runs; same on every sample, so it reads as "constant" — just the wrong constant
+            return { toBinary: () => bytes }
+          }
+        }
+      })
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- isolated module registry needs a fresh require, not the file's top-level import
+      const mod = require('@/services/vault/templateCodec')
+      freshDescribe = mod.describeVaultTemplate
+    })
+
+    let caught: unknown
+    try {
+      await freshDescribe!()
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-unknown' })
   })
 })

--- a/__tests__/vault/templateCodec.test.ts
+++ b/__tests__/vault/templateCodec.test.ts
@@ -1,7 +1,16 @@
 import { Hash, P2PKH, PrivateKey, Utils } from '@bsv/sdk'
 import { p256 } from '@noble/curves/nist.js'
+import { buildMainnetFixtureScript } from './fixtures/r1k1MainnetFixture'
 import { R1K1_LOCK_LEN, buildVaultLockingScript } from '@/services/vault/r1k1'
-import { describeVaultTemplate, matchesTemplate, TemplateVersion } from '@/services/vault/templateCodec'
+import {
+  compressScript,
+  describeVaultTemplate,
+  expandScript,
+  isCompressed,
+  matchesTemplate,
+  TEMPLATE_MARKER,
+  TemplateVersion
+} from '@/services/vault/templateCodec'
 
 function fixture() {
   const r1PublicKey = Utils.toHex(Array.from(p256.getPublicKey(p256.utils.randomSecretKey(), true)))
@@ -82,6 +91,102 @@ describe('vault template codec: descriptor + exact recognition', () => {
     let caught: unknown
     try {
       matchesTemplate(scriptBytes, neverCached)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
+})
+
+describe('vault template codec: compress + expand', () => {
+  // Another ~960 KB build, but only once for this whole describe block (not
+  // per test) — same pattern as the descriptor/recognition suite above.
+  let scriptBytes: number[]
+
+  beforeAll(async () => {
+    scriptBytes = (await buildVaultLockingScript(fixture())).toBinary()
+  })
+
+  it('round-trips a freshly built locking script byte-for-byte', async () => {
+    const compressed = await compressScript(scriptBytes)
+    const expanded = await expandScript(compressed)
+    expect(expanded).toEqual(scriptBytes)
+  })
+
+  it('round-trips the REAL mined mainnet locking script byte-for-byte', async () => {
+    // The fixture holds the actual commitment/k1PublicKeyHash mined on-chain
+    // for txid 6c947ae3..., vout 0 — this proves compress+expand reproduces a
+    // real, already-mined output exactly, not just a freshly-built one.
+    const mainnetScript = await buildMainnetFixtureScript()
+    const compressed = await compressScript(mainnetScript)
+    const expanded = await expandScript(compressed)
+    expect(expanded).toEqual(mainnetScript)
+  })
+
+  it('produces a 47-byte compressed script starting with the 0xff marker', async () => {
+    const compressed = await compressScript(scriptBytes)
+    expect(compressed[0]).toBe(TEMPLATE_MARKER)
+    expect(compressed[0]).toBe(0xff)
+    expect(compressed.length).toBe(47) // 7-byte header + 40-byte payload (commitment 20 + k1PublicKeyHash 20)
+    expect(isCompressed(compressed)).toBe(true)
+  })
+
+  it('leaves a non-matching script unchanged and does not allocate a header', async () => {
+    const pkh = Hash.hash160(PrivateKey.fromRandom().toPublicKey().encode(true) as number[])
+    const p2pkh = new P2PKH().lock(pkh).toBinary()
+
+    const compressed = await compressScript(p2pkh)
+
+    expect(compressed).toEqual(p2pkh)
+    expect(compressed.length).toBe(25)
+    expect(compressed[0]).not.toBe(TEMPLATE_MARKER)
+    expect(isCompressed(compressed)).toBe(false)
+  })
+
+  it('expandScript throws template-unknown for an unrecognised version', async () => {
+    const bogus = [TEMPLATE_MARKER, 250, 0x01, 0, 0, 0, 0]
+
+    let caught: unknown
+    try {
+      await expandScript(bogus)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-unknown' })
+  })
+
+  it('expandScript throws template-unknown for an unrecognised region', async () => {
+    const bogus = [TEMPLATE_MARKER, 1, 0x7f, 0, 0, 0, 0]
+
+    let caught: unknown
+    try {
+      await expandScript(bogus)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-unknown' })
+  })
+
+  it('expandScript throws rather than returning short bytes for a truncated header', async () => {
+    const truncated = [TEMPLATE_MARKER, 1, 0x01, 0, 0] // 5 bytes; a full header needs 7
+
+    let caught: unknown
+    try {
+      await expandScript(truncated)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
+
+  it('expandScript throws template-invalid when originalLength disagrees with the version it names', async () => {
+    const compressed = await compressScript(scriptBytes)
+    const tampered = compressed.slice()
+    tampered[3] ^= 0xff // corrupt the originalLength field's most-significant byte
+
+    let caught: unknown
+    try {
+      await expandScript(tampered)
     } catch (e) {
       caught = e
     }

--- a/__tests__/vault/templateCodec.test.ts
+++ b/__tests__/vault/templateCodec.test.ts
@@ -14,9 +14,15 @@ import {
   expandScript,
   isCompressed,
   matchesTemplate,
+  releaseTemplateCache,
   TEMPLATE_MARKER,
   TemplateVersion
 } from '@/services/vault/templateCodec'
+
+/** 11-byte v2 header: marker(1) + version(1) + region(1) + originalLength(4) +
+ * checksum(4). Kept as a local literal (not imported) so tests can't be made
+ * to pass by silently changing the implementation's HEADER_LENGTH. */
+const HEADER_LENGTH = 11
 
 function fixture() {
   const r1PublicKey = Utils.toHex(Array.from(p256.getPublicKey(p256.utils.randomSecretKey(), true)))
@@ -41,13 +47,16 @@ describe('vault template codec: descriptor + exact recognition', () => {
     expect(matchesTemplate(scriptBytes, descriptor)).toBe(true)
   })
 
-  it('derives totalLength 959632 and the two pinned variable runs, from the library', () => {
+  it('reads totalLength 959632 and the two pinned variable runs from the vendored template', () => {
     // These are the plan's pinned, verbatim constants (Global Constraints:
     // R1K1_LOCK_LEN = 959632; commitment at offsets 17..36; k1PublicKeyHash
-    // at offsets 959609..959628). describeVaultTemplate derives them by
-    // diffing built scripts rather than reading them from here — this
-    // assertion is what would fail if @bsv/templates ever changed the
-    // layout, instead of the change silently being adopted.
+    // at offsets 959609..959628). describeVaultTemplate no longer diffs live
+    // @bsv/templates builds to find these — it reads the vendored asset
+    // (services/vault/vaultTemplateArtifact.ts) and the PINNED_VARIABLE_RUNS
+    // literal directly. This assertion is what the separate "installed
+    // library still matches the vendored template" test below exists to keep
+    // honest: THAT test is what would fail if @bsv/templates ever changed the
+    // layout, since this one no longer consults the library at all.
     expect(descriptor.totalLength).toBe(959632)
     expect(descriptor.totalLength).toBe(R1K1_LOCK_LEN)
     expect(descriptor.variableRuns).toEqual([
@@ -57,19 +66,12 @@ describe('vault template codec: descriptor + exact recognition', () => {
     expect(descriptor.constantHash).toMatch(/^[0-9a-f]{64}$/)
   })
 
-  it('constantHash matches the pinned reference recorded for version 1', () => {
-    // Pinned literal, computed once from the CURRENT @bsv/templates
-    // R1K1Wallet output — mirrors PINNED_CONSTANT_HASH_V1 in
+  it('constantHash matches the pinned reference for the vendored template', () => {
+    // Pinned literal, computed once from a genuine @bsv/templates sample
+    // before the template was vendored — mirrors PINNED_CONSTANT_HASH in
     // templateCodec.ts (kept as a separately-recorded literal here, not an
     // import, so this test can't be made to pass by silently changing the
-    // implementation's pinned value). totalLength/variableRuns alone cannot
-    // catch an @bsv/templates upgrade that keeps 959,632 bytes but alters a
-    // constant byte in between — this is the assertion that closes that
-    // gap. describeVaultTemplate() itself would already have thrown
-    // 'template-unknown' by the time this runs if the live template ever
-    // disagreed with this value (see the next describe block for that
-    // throwing behaviour); this test additionally pins the exact expected
-    // value so a change shows up here too, by name.
+    // implementation's pinned value).
     expect(descriptor.constantHash).toBe('41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b')
   })
 
@@ -96,7 +98,6 @@ describe('vault template codec: descriptor + exact recognition', () => {
   it('does not match a 25-byte P2PKH script', () => {
     const pkh = Hash.hash160(PrivateKey.fromRandom().toPublicKey().encode(true) as number[])
     const p2pkh = new P2PKH().lock(pkh).toBinary()
-
     expect(p2pkh.length).toBe(25)
     expect(matchesTemplate(p2pkh, descriptor)).toBe(false)
   })
@@ -106,8 +107,8 @@ describe('vault template codec: descriptor + exact recognition', () => {
     // serialisable", so nothing stops a caller from persisting one and
     // rehydrating it in a later process that never awaited
     // describeVaultTemplate() for that exact version/region. A version
-    // number this process has no cached reference bytes for reproduces that
-    // cold-call condition without needing to reset module state.
+    // number this codec has never supported reproduces that cold-call
+    // condition without needing to reset module state.
     const neverCached: TemplateVersion = { ...descriptor, version: 999 }
 
     let caught: unknown
@@ -117,6 +118,43 @@ describe('vault template codec: descriptor + exact recognition', () => {
       caught = e
     }
     expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
+})
+
+describe('vault template codec: the vendored template still matches the installed library', () => {
+  // The one test decision 2 requires: the vendored asset is now the SOLE
+  // source of the reference template at runtime (describeVaultTemplate no
+  // longer builds or diffs anything via @bsv/templates), so nothing else in
+  // this file would notice if the currently-installed @bsv/templates drifted
+  // from what was vendored. This test builds a script with whatever
+  // @bsv/templates is installed RIGHT NOW, masks the same two variable runs
+  // by hand (not via any codec helper — this must stay independent of the
+  // implementation it's cross-checking), and hashes the result. A future
+  // @bsv/templates upgrade that changes the template fails THIS test, loudly,
+  // in CI — it can no longer make an already-stored compressed record
+  // unreadable, because reconstruction never consults the installed library.
+  it('a freshly built locking script, masked, hashes to the pinned constant', async () => {
+    const scriptBytes = (await buildVaultLockingScript(fixture())).toBinary()
+    expect(scriptBytes.length).toBe(959632)
+
+    const masked = scriptBytes.slice()
+    for (let i = 17; i < 17 + 20; i++) masked[i] = 0
+    for (let i = 959609; i < 959609 + 20; i++) masked[i] = 0
+
+    expect(Utils.toHex(Hash.sha256(masked))).toBe('41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b')
+  })
+
+  it('the same masked bytes, sliced 60 bytes in for the preimage scriptCode, hash to the pinned scriptCode constant', async () => {
+    const scriptBytes = (await buildVaultLockingScript(fixture())).toBinary()
+    const masked = scriptBytes.slice()
+    for (let i = 17; i < 17 + 20; i++) masked[i] = 0
+    for (let i = 959609; i < 959609 + 20; i++) masked[i] = 0
+
+    const scriptCode = masked.slice(60)
+    expect(scriptCode.length).toBe(959572)
+    expect(Utils.toHex(Hash.sha256(scriptCode))).toBe(
+      'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
+    )
   })
 })
 
@@ -145,11 +183,10 @@ describe('vault template codec: compress + expand', () => {
     expect(expanded).toEqual(mainnetScript)
   })
 
-  it('produces a 47-byte compressed script starting with the 0xff marker', async () => {
+  it('produces a 51-byte compressed script starting with the 0xff marker', async () => {
     const compressed = await compressScript(scriptBytes)
     expect(compressed[0]).toBe(TEMPLATE_MARKER)
-    expect(compressed[0]).toBe(0xff)
-    expect(compressed.length).toBe(47) // 7-byte header + 40-byte payload (commitment 20 + k1PublicKeyHash 20)
+    expect(compressed.length).toBe(51) // 11-byte v2 header + 40-byte payload (commitment 20 + k1PublicKeyHash 20)
     expect(isCompressed(compressed)).toBe(true)
   })
 
@@ -188,18 +225,32 @@ describe('vault template codec: compress + expand', () => {
   })
 
   it('compressScript throws rather than silently passing through bytes that already begin with the compressed-script marker', async () => {
-    // A 47-byte, marker-led, well-formed-looking header (version 1, region
-    // 0x01, originalLength 959632 — the real R1K1_LOCK_LEN) whose 40-byte
-    // payload is not a real commitment/k1PublicKeyHash pair at all. Before
-    // the Fix 1 guard, compressForRegion's pass-through returned this
-    // verbatim (it matches no known template, since it's only 47 bytes
-    // long): isCompressed() would then report true, and a caller following
-    // this module's own documented isCompressed(b) ? expandScript(b) : b
-    // pattern would inflate it into a fabricated 959632-byte vault script
-    // whose commitment and k1PublicKeyHash are both 0xaa x20 — violating
+    // A 51-byte, marker-led, well-formed-looking v2 header (version 2, region
+    // 0x01, originalLength 959632 — the real R1K1_LOCK_LEN, plus 4 arbitrary
+    // checksum bytes) whose 40-byte payload is not a real commitment/
+    // k1PublicKeyHash pair at all. Before the Fix 1 guard, compressForRegion's
+    // pass-through returned this verbatim (it matches no known template,
+    // since it's only 51 bytes long): isCompressed() would then report true,
+    // and a caller following this module's own documented
+    // isCompressed(b) ? expandScript(b) : b pattern would inflate it into a
+    // fabricated 959632-byte vault script whose commitment and
+    // k1PublicKeyHash are both 0xaa x20 — violating
     // expand(compress(x)) === x for this constructible x.
-    const markerLeading = [TEMPLATE_MARKER, 0x01, 0x01, 0x00, 0x0e, 0xa4, 0x90, ...Array(40).fill(0xaa)]
-    expect(markerLeading.length).toBe(47)
+    const markerLeading = [
+      TEMPLATE_MARKER,
+      0x02,
+      0x01,
+      0x00,
+      0x0e,
+      0xa4,
+      0x90, // originalLength = 959632, big-endian
+      0xde,
+      0xad,
+      0xbe,
+      0xef, // arbitrary checksum bytes
+      ...Array(40).fill(0xaa)
+    ]
+    expect(markerLeading.length).toBe(51)
     expect(isCompressed(markerLeading)).toBe(true)
 
     let caught: unknown
@@ -212,7 +263,8 @@ describe('vault template codec: compress + expand', () => {
   })
 
   it('expandScript throws template-unknown for an unrecognised version', async () => {
-    const bogus = [TEMPLATE_MARKER, 250, 0x01, 0, 0, 0, 0]
+    const bogus = [TEMPLATE_MARKER, 250, 0x01, 0, 0, 0, 0, 0, 0, 0, 0]
+    expect(bogus.length).toBe(HEADER_LENGTH)
 
     let caught: unknown
     try {
@@ -224,7 +276,12 @@ describe('vault template codec: compress + expand', () => {
   })
 
   it('expandScript throws template-unknown for an unrecognised region', async () => {
-    const bogus = [TEMPLATE_MARKER, 1, 0x7f, 0, 0, 0, 0]
+    // version 2 (this codec's only supported version) paired with a region
+    // byte no descriptor uses — isolates "unrecognised region" from
+    // "unrecognised version" (a bogus version alone would already explain
+    // the throw without this test proving anything about region handling).
+    const bogus = [TEMPLATE_MARKER, 2, 0x7f, 0, 0, 0, 0, 0, 0, 0, 0]
+    expect(bogus.length).toBe(HEADER_LENGTH)
 
     let caught: unknown
     try {
@@ -236,7 +293,7 @@ describe('vault template codec: compress + expand', () => {
   })
 
   it('expandScript throws rather than returning short bytes for a truncated header', async () => {
-    const truncated = [TEMPLATE_MARKER, 1, 0x01, 0, 0] // 5 bytes; a full header needs 7
+    const truncated = [TEMPLATE_MARKER, 2, 0x01, 0, 0, 0, 0, 0] // 8 bytes; a full v2 header needs 11
 
     let caught: unknown
     try {
@@ -265,9 +322,9 @@ describe('vault template codec: compress + expand', () => {
   })
 
   it('expandScript throws template-invalid when the payload length disagrees with the version it names', async () => {
-    // Header fields (version/region/originalLength) are left intact and
-    // correctly name a known version; only the payload itself is one byte
-    // short. This is the guard that stands between a corrupt blob and
+    // Header fields (version/region/originalLength/checksum) are left intact
+    // and correctly name a known version; only the payload itself is one
+    // byte short. This is the guard that stands between a corrupt blob and
     // `undefined` landing in the reconstructed bytes at a variable-run
     // offset (result[r.offset + i] = payload[payloadOffset + i]).
     const compressed = await compressScript(scriptBytes)
@@ -295,11 +352,53 @@ describe('vault template codec: compress + expand', () => {
     }
     expect(caught).toMatchObject({ code: 'template-invalid' })
   })
+
+  it('expandScript throws template-invalid when the checksum disagrees with the reconstructed bytes', async () => {
+    // The v2 header's whole reason for existing: flip one payload byte
+    // (still the right LENGTH, so the length/originalLength guards above
+    // don't fire) and confirm the corruption is still caught — by the
+    // checksum, computed over the FULL reconstructed bytes, not by any
+    // header field. Before v2, this exact mutation would have round-tripped
+    // into a structurally perfect but WRONG 959632-byte script with no error
+    // at all (wrong txid, broken merkle proof, unrecoverable deposit record).
+    const compressed = await compressScript(scriptBytes)
+    const tampered = compressed.slice()
+    tampered[HEADER_LENGTH] ^= 0xff // first payload byte (start of the commitment run)
+
+    let caught: unknown
+    try {
+      await expandScript(tampered)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+    expect((caught as Error).message).toMatch(/checksum/i)
+  })
+
+  it('expandScript still throws template-invalid on a checksum mismatch even when the corrupted bytes still happen to have the right length and originalLength', async () => {
+    // Belt-and-braces: corrupt a CONSTANT byte (outside every variable run,
+    // so matchesTemplate-style recognition plays no role here — expandScript
+    // never calls matchesTemplate) by tampering with the header's own
+    // checksum field instead of the payload, proving the checksum is checked
+    // against the RECONSTRUCTION, not merely echoed back.
+    const compressed = await compressScript(scriptBytes)
+    const tampered = compressed.slice()
+    tampered[7] ^= 0xff // first checksum byte
+
+    let caught: unknown
+    try {
+      await expandScript(tampered)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+    expect((caught as Error).message).toMatch(/checksum/i)
+  })
 })
 
 describe('vault template codec: region 0x02 (preimage scriptCode)', () => {
-  // Building the ~960 KB locking script (and diffing it inside
-  // describeVaultTemplate) is not free — build once for this whole block.
+  // Building the ~960 KB locking script is not free — build once for this
+  // whole block.
   let scriptCodeDescriptor: TemplateVersion
   let scriptBytes: number[]
   let scriptCodeBytes: number[]
@@ -334,7 +433,7 @@ describe('vault template codec: region 0x02 (preimage scriptCode)', () => {
     expect(scriptCodeDescriptor.variableRuns).toEqual([{ offset: 959549, length: 20 }])
   })
 
-  it('scriptCode constantHash matches the pinned reference recorded for version 1 region 0x02', () => {
+  it('scriptCode constantHash matches the pinned reference for the vendored template', () => {
     // Pinned literal, independently re-declared here (not imported) so a
     // one-sided edit to the implementation's pinned value can't silently
     // pass — mirrors the region-0x01 constantHash test above.
@@ -367,15 +466,15 @@ describe('vault template codec: region 0x02 (preimage scriptCode)', () => {
     // be — part of this payload. The commitment stays recoverable elsewhere:
     // the unlocking script pushes publicKey and salt verbatim, and
     // commitment = hash160(publicKey ‖ salt).
-    const payload = compressed.slice(7) // HEADER_LENGTH: marker(1)+version(1)+region(1)+originalLength(4)
+    const payload = compressed.slice(HEADER_LENGTH)
     expect(payload.length).toBe(20)
     expect(Utils.toHex(payload)).toBe(MAINNET_K1_PUBLIC_KEY_HASH_HEX)
   })
 
-  it('produces a 27-byte compressed scriptCode starting with the 0xff marker (7-byte header + 20-byte payload)', async () => {
+  it('produces a 31-byte compressed scriptCode starting with the 0xff marker (11-byte v2 header + 20-byte payload)', async () => {
     const compressed = await compressScriptCode(scriptCodeBytes)
     expect(compressed[0]).toBe(TEMPLATE_MARKER)
-    expect(compressed.length).toBe(27)
+    expect(compressed.length).toBe(31)
     expect(isCompressed(compressed)).toBe(true)
   })
 
@@ -388,38 +487,40 @@ describe('vault template codec: region 0x02 (preimage scriptCode)', () => {
   })
 })
 
-describe('vault template codec: same-length constant-byte drift is caught', () => {
-  // The failure mode this guards against: an @bsv/templates upgrade that
-  // keeps R1K1_LOCK_LEN (959632) bytes but alters one of the FIXED bytes in
-  // between. totalLength and originalLength checks can't see this — only
-  // comparing the live template's constantHash against a pinned reference
-  // can. This is exercised end-to-end (a real describeVaultTemplate() call,
-  // not a duplicated/extracted comparison helper), against a mocked
-  // buildVaultLockingScript that flips one constant byte the SAME way on
-  // every sample it builds — so the diffing logic still treats it as
-  // constant, not variable, and only its value has drifted.
-  //
-  // Runs inside jest.isolateModulesAsync so the mocked drift gets its own,
-  // separate `templateCodec` module instance (own `cachedDescriptors`,
+describe('vault template codec: vendored-asset corruption is caught', () => {
+  // The failure mode this guards against, now that the reference template is
+  // vendored rather than rebuilt: a corrupted or hand-edited
+  // vaultTemplateArtifact.ts whose inflated bytes disagree with
+  // PINNED_CONSTANT_HASH. This used to be caught by re-diffing live
+  // @bsv/templates builds on every describeVaultTemplate() call; now it's
+  // caught by ensureTemplateCache's masked-hash cross-check against the
+  // vendored asset it just inflated (see templateCodec.ts). Runs inside
+  // jest.isolateModulesAsync so the mocked corruption gets its own, separate
+  // templateCodec module instance (own module-level template cache),
   // untouched by whatever the other describe blocks in this file already
-  // cached) rather than contaminating the real one the rest of this suite
-  // relies on.
-  it('describeVaultTemplate throws template-unknown when a constant byte drifts at the same length', async () => {
+  // cached.
+  it('describeVaultTemplate throws template-invalid when the vendored asset is corrupted', async () => {
+    // Build a real reference template the same way vaultTemplateArtifact.ts
+    // was generated, flip one constant byte (well outside both variable
+    // runs), and re-gzip — reproducing a corrupted commit of that file
+    // without needing to touch the real one on disk.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- this file otherwise only imports fflate transitively; a plain require avoids a dynamic-import that this Jest/Babel setup doesn't support
+    const { gzipSync } = require('fflate')
+    const real = (await buildVaultLockingScript(fixture())).toBinary()
+    const masked = real.slice()
+    for (let i = 17; i < 17 + 20; i++) masked[i] = 0
+    for (let i = 959609; i < 959609 + 20; i++) masked[i] = 0
+    masked[0] ^= 0xff // corrupt a constant byte, same idea as the old drift test
+    const corruptedGzip = gzipSync(Uint8Array.from(masked), { level: 9 })
+    const corruptedBase64 = Buffer.from(corruptedGzip).toString('base64')
+
     let freshDescribe: (() => Promise<unknown>) | undefined
 
     await jest.isolateModulesAsync(async () => {
-      jest.doMock('@/services/vault/r1k1', () => {
-        const actual = jest.requireActual('@/services/vault/r1k1')
-        return {
-          ...actual,
-          buildVaultLockingScript: async (a: { r1PublicKey: string; salt: string; k1PublicKeyHash: number[] }) => {
-            const script = await actual.buildVaultLockingScript(a)
-            const bytes: number[] = script.toBinary()
-            bytes[0] ^= 0xff // outside both variable runs; same on every sample, so it reads as "constant" — just the wrong constant
-            return { toBinary: () => bytes }
-          }
-        }
-      })
+      jest.doMock('@/services/vault/vaultTemplateArtifact', () => ({
+        VAULT_TEMPLATE_GZIP_BASE64: corruptedBase64,
+        VAULT_TEMPLATE_RAW_LENGTH: 959_632
+      }))
       // eslint-disable-next-line @typescript-eslint/no-require-imports -- isolated module registry needs a fresh require, not the file's top-level import
       const mod = require('@/services/vault/templateCodec')
       freshDescribe = mod.describeVaultTemplate
@@ -431,64 +532,54 @@ describe('vault template codec: same-length constant-byte drift is caught', () =
     } catch (e) {
       caught = e
     }
-    expect(caught).toMatchObject({ code: 'template-unknown' })
+    expect(caught).toMatchObject({ code: 'template-invalid' })
   })
 })
 
-describe('vault template codec: coincidental sample agreement cannot narrow a real variable run', () => {
-  // Regression test for a subtle false-positive distinct from the drift test
-  // above: DIFF_SAMPLE_COUNT (4) throwaway samples are diffed to FIND the
-  // variable runs, so a genuinely-variable byte that happens to draw the
-  // SAME value on every sample — a real, if individually unlikely,
-  // per-process coincidence, not an actual template change — would make
-  // findVariableRuns split a real run and report it one byte narrower than
-  // it truly is. Without a backstop, that narrower run changes constantHash
-  // and makes describeVaultTemplate throw 'template-unknown' — a false
-  // diagnosis of an @bsv/templates upgrade when nothing changed, and (since
-  // only the success path is memoized) a ~114ms re-pay on every subsequent
-  // call until the coincidence stops recurring.
-  //
-  // describeVaultTemplate masks (unions) the sample-derived runs against
-  // PINNED_VARIABLE_RUNS_V1 precisely so a coincidental agreement can only
-  // ever widen a run, never split one. This mocks buildVaultLockingScript to
-  // force one byte inside the real commitment run (offsets 17..36) to the
-  // SAME value on every sample, reproducing that coincidence deterministically
-  // rather than waiting on real (im)probability.
-  //
-  // Runs inside jest.isolateModulesAsync for the same reason as the drift
-  // test above: an isolated module instance with its own `cachedDescriptors`.
-  it('describeVaultTemplate does not throw, and keeps the full pinned run geometry, when one byte inside a real variable run agrees on every sample', async () => {
-    let freshDescribe: (() => Promise<TemplateVersion[]>) | undefined
+describe('vault template codec: template cache release', () => {
+  it('releaseTemplateCache lets describeVaultTemplate/compress/expand keep working, transparently re-inflating the vendored asset', async () => {
+    // Prove the cache is genuinely gone and genuinely comes back: populate
+    // it, release it, then exercise every exported entry point afterwards —
+    // each one must re-populate on demand rather than depending on state left
+    // over from before the release.
+    await describeVaultTemplate()
+    releaseTemplateCache()
 
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('@/services/vault/r1k1', () => {
-        const actual = jest.requireActual('@/services/vault/r1k1')
-        return {
-          ...actual,
-          buildVaultLockingScript: async (a: { r1PublicKey: string; salt: string; k1PublicKeyHash: number[] }) => {
-            const script = await actual.buildVaultLockingScript(a)
-            const bytes: number[] = script.toBinary()
-            // Offset 25 sits inside the real 17..36 commitment run (a
-            // genuine hash160 output, ordinarily different on every sample).
-            // Forcing it to a fixed value on every sample simulates the rare
-            // coincidence without needing astronomical luck.
-            bytes[25] = 0x00
-            return { toBinary: () => bytes }
-          }
-        }
-      })
-      // eslint-disable-next-line @typescript-eslint/no-require-imports -- isolated module registry needs a fresh require, not the file's top-level import
-      const mod = require('@/services/vault/templateCodec')
-      freshDescribe = mod.describeVaultTemplate
-    })
+    const descriptors = await describeVaultTemplate()
+    expect(descriptors).toHaveLength(2)
+    expect(descriptors[0].totalLength).toBe(959632)
 
-    const descriptors = await freshDescribe!()
-    const region1 = descriptors.find((d) => d.region === 0x01)
-    expect(region1).toBeDefined()
-    // The full 20-byte commitment run, NOT split around offset 25.
-    expect(region1!.variableRuns).toEqual([
-      { offset: 17, length: 20 },
-      { offset: 959609, length: 20 }
-    ])
+    const scriptBytes = (await buildVaultLockingScript(fixture())).toBinary()
+    releaseTemplateCache()
+    const compressed = await compressScript(scriptBytes)
+    expect(compressed.length).toBe(51)
+
+    releaseTemplateCache()
+    const expanded = await expandScript(compressed)
+    expect(expanded).toEqual(scriptBytes)
+
+    // Leave the cache populated for whatever test runs next in this file —
+    // this test's job is to prove release-then-reuse works, not to leave
+    // global module state released for later tests that don't expect it.
+    await describeVaultTemplate()
+  })
+
+  it('matchesTemplate throws template-invalid, not a stale true/false, right after a release with no intervening describeVaultTemplate call', async () => {
+    const [descriptor] = await describeVaultTemplate()
+    const scriptBytes = (await buildVaultLockingScript(fixture())).toBinary()
+    expect(matchesTemplate(scriptBytes, descriptor)).toBe(true)
+
+    releaseTemplateCache()
+
+    let caught: unknown
+    try {
+      matchesTemplate(scriptBytes, descriptor)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+
+    // Restore populated state for subsequent tests in this file.
+    await describeVaultTemplate()
   })
 })

--- a/__tests__/vault/templateCodec.test.ts
+++ b/__tests__/vault/templateCodec.test.ts
@@ -69,4 +69,22 @@ describe('vault template codec: descriptor + exact recognition', () => {
     expect(p2pkh.length).toBe(25)
     expect(matchesTemplate(p2pkh, descriptor)).toBe(false)
   })
+
+  it('throws rather than silently answering false for a descriptor this process never cached', () => {
+    // Simulates the real footgun: TemplateVersion is documented as "small,
+    // serialisable", so nothing stops a caller from persisting one and
+    // rehydrating it in a later process that never awaited
+    // describeVaultTemplate() for that exact version/region. A version
+    // number this process has no cached reference bytes for reproduces that
+    // cold-call condition without needing to reset module state.
+    const neverCached: TemplateVersion = { ...descriptor, version: 999 }
+
+    let caught: unknown
+    try {
+      matchesTemplate(scriptBytes, neverCached)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toMatchObject({ code: 'template-invalid' })
+  })
 })

--- a/__tests__/vault/templateCodec.test.ts
+++ b/__tests__/vault/templateCodec.test.ts
@@ -1,0 +1,72 @@
+import { Hash, P2PKH, PrivateKey, Utils } from '@bsv/sdk'
+import { p256 } from '@noble/curves/nist.js'
+import { R1K1_LOCK_LEN, buildVaultLockingScript } from '@/services/vault/r1k1'
+import { describeVaultTemplate, matchesTemplate, TemplateVersion } from '@/services/vault/templateCodec'
+
+function fixture() {
+  const r1PublicKey = Utils.toHex(Array.from(p256.getPublicKey(p256.utils.randomSecretKey(), true)))
+  const salt = Utils.toHex(Array.from(crypto.getRandomValues(new Uint8Array(32))))
+  const k1PublicKeyHash = Hash.hash160(PrivateKey.fromRandom().toPublicKey().encode(true) as number[])
+  return { r1PublicKey, salt, k1PublicKeyHash }
+}
+
+describe('vault template codec: descriptor + exact recognition', () => {
+  // Building the ~960 KB template (several times over, inside
+  // describeVaultTemplate's diffing) is not free — build it once for the
+  // whole suite rather than per test.
+  let descriptor: TemplateVersion
+  let scriptBytes: number[]
+
+  beforeAll(async () => {
+    ;[descriptor] = await describeVaultTemplate()
+    scriptBytes = (await buildVaultLockingScript(fixture())).toBinary()
+  })
+
+  it('matches a freshly built locking script', () => {
+    expect(matchesTemplate(scriptBytes, descriptor)).toBe(true)
+  })
+
+  it('derives totalLength 959632 and the two pinned variable runs, from the library', () => {
+    // These are the plan's pinned, verbatim constants (Global Constraints:
+    // R1K1_LOCK_LEN = 959632; commitment at offsets 17..36; k1PublicKeyHash
+    // at offsets 959609..959628). describeVaultTemplate derives them by
+    // diffing built scripts rather than reading them from here — this
+    // assertion is what would fail if @bsv/templates ever changed the
+    // layout, instead of the change silently being adopted.
+    expect(descriptor.totalLength).toBe(959632)
+    expect(descriptor.totalLength).toBe(R1K1_LOCK_LEN)
+    expect(descriptor.variableRuns).toEqual([
+      { offset: 17, length: 20 },
+      { offset: 959609, length: 20 }
+    ])
+    expect(descriptor.constantHash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('rejects a script with one byte flipped outside a variable run', () => {
+    const mutated = scriptBytes.slice()
+    mutated[0] ^= 0xff // well outside both runs, and XOR-0xff always flips
+    expect(matchesTemplate(mutated, descriptor)).toBe(false)
+  })
+
+  it('still matches when a byte inside a variable run is flipped', () => {
+    const mutatedCommitment = scriptBytes.slice()
+    mutatedCommitment[17] ^= 0xff // first byte of the R1 commitment run
+    expect(matchesTemplate(mutatedCommitment, descriptor)).toBe(true)
+
+    const mutatedK1Hash = scriptBytes.slice()
+    mutatedK1Hash[959609] ^= 0xff // first byte of the k1PublicKeyHash run
+    expect(matchesTemplate(mutatedK1Hash, descriptor)).toBe(true)
+
+    const mutatedLastByte = scriptBytes.slice()
+    mutatedLastByte[959628] ^= 0xff // last byte of the k1PublicKeyHash run
+    expect(matchesTemplate(mutatedLastByte, descriptor)).toBe(true)
+  })
+
+  it('does not match a 25-byte P2PKH script', () => {
+    const pkh = Hash.hash160(PrivateKey.fromRandom().toPublicKey().encode(true) as number[])
+    const p2pkh = new P2PKH().lock(pkh).toBinary()
+
+    expect(p2pkh.length).toBe(25)
+    expect(matchesTemplate(p2pkh, descriptor)).toBe(false)
+  })
+})

--- a/docs/superpowers/plans/2026-08-18-vault-script-template-compression-plan.md
+++ b/docs/superpowers/plans/2026-08-18-vault-script-template-compression-plan.md
@@ -1,0 +1,113 @@
+# Plan: vault script template compression
+
+**Spec:** docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
+
+## Global Constraints
+
+- Marker byte is `0xff` (OP_INVALIDOPCODE). NEVER `OP_NOP7`/0xb6 — a compressed script must
+  fail closed and be unspendable if it ever escapes.
+- Header layout, exactly: `0xff` (1) ‖ version (1) ‖ region (1) ‖ originalLength (4, big-endian) ‖ payload.
+- Region codes: `0x01` = R1K1 locking script, `0x02` = R1K1 preimage scriptCode.
+- Region 0x01 payload: `commitment(20) ‖ k1PublicKeyHash(20)`. Region 0x02 payload: `k1PublicKeyHash(20)`.
+- Verified constants, use verbatim: `R1K1_LOCK_LEN` = 959632; commitment at offsets 17..36;
+  k1PublicKeyHash at offsets 959609..959628; preimage scriptCode = `lockingScript.subarray(60)`
+  and is 959572 bytes.
+- `expand(compress(x))` MUST equal `x` byte for byte. Never return approximate bytes; throw
+  `VaultError('template-unknown')` when a version cannot be reconstructed.
+- Recognition must be exact at every non-variable offset. A near-miss is returned unchanged.
+- No changes to `StorageExpoSQLite` or to any broadcast/BEEF path in this plan.
+- Existing tests must stay green: the suite is 990 tests / 83 suites at branch point.
+- TypeScript strict; `npx tsc --noEmit` clean apart from the pre-existing `funding-app/` errors.
+
+## Task 1: template descriptor and byte-exact recognition
+
+Create `services/vault/templateCodec.ts`.
+
+Export:
+- `const TEMPLATE_MARKER = 0xff`
+- `type TemplateRegion = 0x01 | 0x02`
+- `interface TemplateVersion { version: number; region: TemplateRegion; totalLength: number;
+  variableRuns: Array<{ offset: number; length: number }>; constantHash: string }`
+- `async function describeVaultTemplate(): Promise<TemplateVersion[]>` — builds the current
+  template once via `buildVaultLockingScript` with throwaway inputs and derives the descriptor
+  from it, so the pinned constants are checked against the library rather than transcribed.
+- `function matchesTemplate(bytes: number[], v: TemplateVersion): boolean` — true only when
+  length matches AND every byte outside `variableRuns` equals the template's.
+
+Recognition must not allocate a second copy of a ~960 KB script per call beyond what is
+unavoidable; compare in place.
+
+Tests in `__tests__/vault/templateCodec.test.ts`:
+- a freshly built locking script matches the descriptor
+- flipping ONE byte outside a variable run makes `matchesTemplate` false
+- flipping a byte INSIDE a variable run keeps it true
+- a P2PKH script (25 bytes) does not match
+- descriptor `totalLength` is exactly 959632 and the two runs are `{17,20}` and `{959609,20}`
+
+## Task 2: compress and expand, byte-exact
+
+Extend `services/vault/templateCodec.ts`.
+
+Export:
+- `async function compressScript(bytes: number[]): Promise<number[]>` — returns the compressed
+  form for a recognised region-0x01 script, else the input unchanged.
+- `async function expandScript(bytes: number[]): Promise<number[]>` — detects the `0xff` header,
+  validates `originalLength`, rebuilds the exact bytes; throws
+  `VaultError('template-unknown')` for an unknown version or region, and
+  `VaultError('template-invalid')` when `originalLength` disagrees with what the version
+  reconstructs.
+- `function isCompressed(bytes: number[]): boolean`
+
+Add `'template-unknown'` to `VaultErrorCode` in `services/vault/types.ts` if absent.
+
+Tests:
+- round trip on a freshly built script, asserted with `toEqual` over the full arrays
+- round trip on the REAL mainnet script fixture (see Task 4)
+- `compressScript` on a non-matching script returns the input unchanged and does not allocate
+  a header
+- `expandScript` on an unknown version throws `template-unknown`
+- `expandScript` on a truncated header throws rather than returning short bytes
+- a compressed script's first byte is `0xff` and its length is 47 (7-byte header + 40 payload)
+
+## Task 3: preimage scriptCode region
+
+Extend the codec for region `0x02`.
+
+- `compressScriptCode(bytes)` / handled by the same `expandScript` on the way back.
+- The 0x02 descriptor derives from the 0x01 template by dropping the first 60 bytes, and the
+  code must derive it that way rather than hardcoding 959572, so the two can never disagree.
+- Assert the relationship explicitly: a test that builds a locking script, slices `subarray(60)`,
+  and confirms the result is 959572 bytes and matches the 0x02 descriptor. If
+  `@bsv/templates` ever changes, THIS test fails and names the reason.
+
+Tests:
+- `expand(compress(scriptCode))` byte-exact
+- 0x02 payload is 20 bytes, not 40
+- the derived 0x02 length equals `R1K1_LOCK_LEN - 60`
+
+## Task 4: real-transaction fixture
+
+Add `__tests__/vault/fixtures/r1k1-mainnet-lockingScript.hex.md` documenting provenance, and
+commit the script bytes as a compressed fixture the tests can load.
+
+The script is 959,632 bytes; do NOT commit 1.9 MB of hex. Instead commit the 40 variable bytes
+plus a SHA-256 of the full script, and have the fixture helper rebuild the full script from the
+current template and assert the SHA-256 matches. That proves the pinned template still
+reproduces the real mainnet output without storing megabytes in git.
+
+Real values, from the device database:
+- txid `6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697`, vout 0
+- length 959632
+- commitment (offsets 17..36) and k1PublicKeyHash (offsets 959609..959628) are to be read from
+  the running fixture, not invented
+
+Tests:
+- SHA-256 of the rebuilt script matches the recorded digest
+- the recorded digest is stable across two builds
+
+## Task 5: docs
+
+Add a short section to `docs/` (wherever vault docs live; if none, create
+`docs/vault-script-compression.md`) covering: what the marker is, why `0xff` and not
+`OP_NOP7`, the header layout, the two regions, and the rule that compressed bytes never leave
+the device. Include the measured savings table from the spec.

--- a/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
+++ b/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
@@ -54,16 +54,17 @@ One pinned template therefore reconstructs both regions: rebuild the locking scr
 
 | | verbatim | compressed |
 |---|---|---|
-| deposit `rawTx` | 959,836 B | 246 B |
-| deposit as a backup record (base64) | 1,279,784 B | 328 B |
-| `outputs.lockingScript` | 959,632 B | 42 B |
-| R1 preimage | 959,733 B | 203 B |
-| R1 unlocking script | 959,871 B | 338 B |
-| withdrawal tx, 1 vault input | 960,075 B | 542 B |
-| withdrawal tx, 2 vault inputs | 1,919,946 B | 880 B |
-| backup per user per year (1 vault tx/month) | 15.4 MB | 3.8 KB |
+| deposit `rawTx` | 959,836 B | 251 B |
+| deposit as a backup record (base64) | 1,279,784 B | 336 B |
+| `outputs.lockingScript` | 959,632 B | 47 B |
+| R1 preimage | 959,733 B | 188 B |
+| R1 unlocking script | 959,871 B | 323 B |
+| withdrawal tx, 1 vault input | 960,075 B | 527 B |
+| withdrawal tx, 2 vault inputs | 1,919,946 B | 850 B |
+| DB per vault tx (stored twice) | 1,919,468 B | 298 B |
+| backup per user per year (1 vault tx/month) | 15.4 MB | 3.9 KB |
 
-Roughly 3,900x on a deposit and 1,771x on a withdrawal.
+Roughly 3,824x on a deposit and 1,822x on a withdrawal.
 
 ## Wire format
 

--- a/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
+++ b/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
@@ -1,0 +1,125 @@
+# Vault script template compression
+
+**Status:** approved by the project owner 2026-08-18
+**Supersedes:** the streaming/auth rethink of the backup service, which this makes unnecessary
+
+## Problem
+
+The R1-K1 vault locking script is 959,632 bytes. Storing it verbatim breaks three things at once:
+
+- A vault deposit's `rawTx` is 959,836 bytes, which base64-encodes to 1,279,784 bytes in a
+  backup chunk — 1.22x the backup server's 1 MiB blob cap. A wallet that has used the vault
+  can never push a backup again.
+- Encrypting and BRC-31-signing that payload blocks the JS thread for ~50 seconds per
+  attempt, once a minute, starving the rest of the wallet.
+- One such transaction occupies 26.6% of a real 7.2 MB wallet database, stored twice
+  (`proven_tx_reqs.rawTx` at 959,836 bytes and `outputs.lockingScript` at 959,632).
+
+Raising the server cap was rejected: it treats the symptom, and the same bytes still have to
+be encrypted, signed, buffered ~3x server-side, and downloaded again at restore.
+
+## Key insight
+
+The script is almost entirely constant. Verified against the mined mainnet transaction
+`6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697`:
+
+```
+built length                          : 959,632  (= R1K1_LOCK_LEN)
+bytes differing between two instances : 40
+variable runs                         : 17-36 (20B), 959609-959628 (20B)
+real vs freshly built                 : 40 bytes differ
+diffs OUTSIDE the known-variable runs : 0        <-- template identical
+```
+
+- offsets 17..36 — `r1Commitment` = `hash160(r1PublicKey ‖ salt)`, per the template's own
+  `expectedCommitment = lockingBytes.subarray(17, 37)`
+- offsets 959,609..959,628 — `k1PublicKeyHash`
+- the other 959,592 bytes are template, byte-identical across instances
+
+So a vault locking script is fully described by `{templateVersion, commitment, k1PublicKeyHash}`
+— 40 bytes of payload plus a version tag.
+
+The spend side matters as much. `R1K1Wallet.unlockR1` builds its preimage as
+
+```js
+formatPreimage(tx, inputIndex, source, new Script([], lockingBytes.subarray(60), void 0, false))
+```
+
+so the committed `scriptCode` is the locking script **with its first 60 bytes removed** —
+959,632 − 60 = 959,572, which is exactly the documented preimage arithmetic in `r1k1.ts`.
+One pinned template therefore reconstructs both regions: rebuild the locking script, slice
+60 bytes, and the `scriptCode` follows. No second template variant is required.
+
+## Savings (measured, not estimated)
+
+| | verbatim | compressed |
+|---|---|---|
+| deposit `rawTx` | 959,836 B | 246 B |
+| deposit as a backup record (base64) | 1,279,784 B | 328 B |
+| `outputs.lockingScript` | 959,632 B | 42 B |
+| R1 preimage | 959,733 B | 203 B |
+| R1 unlocking script | 959,871 B | 338 B |
+| withdrawal tx, 1 vault input | 960,075 B | 542 B |
+| withdrawal tx, 2 vault inputs | 1,919,946 B | 880 B |
+| backup per user per year (1 vault tx/month) | 15.4 MB | 3.8 KB |
+
+Roughly 3,900x on a deposit and 1,771x on a withdrawal.
+
+## Wire format
+
+A compressed region replaces the elided bytes with:
+
+```
+0xff              1 byte   marker: OP_INVALIDOPCODE
+version           1 byte   template version, monotonic, never reused
+region            1 byte   0x01 = R1K1 locking script, 0x02 = R1K1 preimage scriptCode
+length            4 bytes  big-endian length of the ORIGINAL elided run, for validation
+payload           N bytes  the variable fields for this region and version
+```
+
+`0xff` is chosen deliberately over `OP_NOP7`. `OP_NOP7` (0xb6) is a valid opcode that
+evaluates as a no-op, so a script left in template form could pass evaluation and reach the
+chain. `0xff` is not a defined opcode and is invalid in every context, so a compressed script
+fails closed: it can never be spent, mined, or accepted, and any code that mistakenly treats
+a compressed script as real gets an immediate, loud failure rather than silent wrong money.
+
+For region 0x01 the payload is `commitment(20) ‖ k1PublicKeyHash(20)`. Region 0x02 carries
+`k1PublicKeyHash(20)` only, because `subarray(60)` drops the commitment window at offsets
+17..36; the commitment is recoverable from the `publicKey` and `salt` the unlocking script
+pushes verbatim.
+
+## Requirements
+
+1. `compress(bytes)` returns the compressed form, or the input unchanged when it does not
+   match a known template.
+2. `expand(bytes)` returns the original bytes **byte for byte**, or throws
+   `VaultError('template-unknown')` for a version it cannot reconstruct. It never returns
+   approximately-right bytes.
+3. `expand(compress(x)) === x` for every fixture, asserted byte-wise, including the real
+   mainnet script above.
+4. Recognition is exact: a candidate is compressed only when it matches the pinned template
+   at every non-variable offset. A near-miss is left alone.
+5. Every historical template version stays reconstructable forever. Versions are pinned by
+   the constant bytes they describe, not by an `@bsv/templates` semver range —
+   `@bsv/templates` went 1.9.6 to 1.10.0 mid-development, and a byte-level change there must
+   surface as `template-unknown`, never as a wrong reconstruction.
+6. The `subarray(60)` offset is a load-bearing constant owned by `@bsv/templates`. It is
+   asserted in tests so a library change fails loudly rather than silently producing a wrong
+   `scriptCode`.
+7. Compression is never applied to bytes that leave the device. Broadcast, BEEF for a
+   third-party send, and txid computation all use expanded bytes.
+
+## Non-goals
+
+- The ~96,000 sat withdrawal fee. That is the ~960 KB unlocking script going on-chain: real
+  bytes a miner must accept.
+- Transient memory during a spend. BEEF for a third-party send needs genuine bytes, so a
+  withdrawal still materialises ~1.83 MB of `inputBEEF`.
+- A general answer for any large record. This works because the vault script is a known
+  template; the client's oversize guard stays as the backstop for everything else.
+
+## Open questions deferred by the owner
+
+- Whether to compress inside `StorageExpoSQLite` read/write paths (the owner chose the
+  storage representation as the target). Landing the codec first keeps that decision
+  reversible and reviewable on its own evidence.

--- a/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
+++ b/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
@@ -52,7 +52,13 @@ One pinned template therefore reconstructs both regions: rebuild the locking scr
 
 ## Savings (measured, not estimated)
 
-| | verbatim | compressed |
+**Superseded by the addendum below.** The table and wire format immediately following this
+note are the ORIGINAL (v1) design, kept for history — v1 never shipped (see the addendum),
+so none of these exact byte counts were ever realized in a stored record. Skip to "Addendum
+(2026-08-18, post-review): v2 header, vendored template, Uint8Array cache" for the
+current, implemented numbers.
+
+| | verbatim | compressed (v1, superseded) |
 |---|---|---|
 | deposit `rawTx` | 959,836 B | 251 B |
 | deposit as a backup record (base64) | 1,279,784 B | 336 B |
@@ -64,9 +70,9 @@ One pinned template therefore reconstructs both regions: rebuild the locking scr
 | DB per vault tx (stored twice) | 1,919,468 B | 298 B |
 | backup per user per year (1 vault tx/month) | 15.4 MB | 3.9 KB |
 
-Roughly 3,824x on a deposit and 1,822x on a withdrawal.
+Roughly 3,824x on a deposit and 1,822x on a withdrawal (v1; superseded).
 
-## Wire format
+## Wire format (v1, superseded — see addendum)
 
 A compressed region replaces the elided bytes with:
 
@@ -83,11 +89,14 @@ evaluates as a no-op, so a script left in template form could pass evaluation an
 chain. `0xff` is not a defined opcode and is invalid in every context, so a compressed script
 fails closed: it can never be spent, mined, or accepted, and any code that mistakenly treats
 a compressed script as real gets an immediate, loud failure rather than silent wrong money.
+(This guarantee is about *spending*, not *mining* — output scripts are never executed at
+creation, so a compressed blob can still be mined into a real output and burn the funds it
+holds. That's still true in v2, unchanged.)
 
 For region 0x01 the payload is `commitment(20) ‖ k1PublicKeyHash(20)`. Region 0x02 carries
 `k1PublicKeyHash(20)` only, because `subarray(60)` drops the commitment window at offsets
 17..36; the commitment is recoverable from the `publicKey` and `salt` the unlocking script
-pushes verbatim.
+pushes verbatim. Both of these are unchanged in v2.
 
 ## Requirements
 
@@ -103,7 +112,11 @@ pushes verbatim.
 5. Every historical template version stays reconstructable forever. Versions are pinned by
    the constant bytes they describe, not by an `@bsv/templates` semver range —
    `@bsv/templates` went 1.9.6 to 1.10.0 mid-development, and a byte-level change there must
-   surface as `template-unknown`, never as a wrong reconstruction.
+   surface loudly, never as a wrong reconstruction. (As implemented post-addendum, "surface
+   loudly" is a CI-visible test failure rather than a runtime `template-unknown` throw — see
+   the addendum's decision 2: the reference bytes are now vendored, not rebuilt from the
+   installed library, precisely so a library drift can be caught without being able to brick
+   an already-stored record.)
 6. The `subarray(60)` offset is a load-bearing constant owned by `@bsv/templates`. It is
    asserted in tests so a library change fails loudly rather than silently producing a wrong
    `scriptCode`.
@@ -124,3 +137,88 @@ pushes verbatim.
 - Whether to compress inside `StorageExpoSQLite` read/write paths (the owner chose the
   storage representation as the target). Landing the codec first keeps that decision
   reversible and reviewable on its own evidence.
+
+## Addendum (2026-08-18, post-review): v2 header, vendored template, Uint8Array cache
+
+The owner reviewed the initial implementation (PR #125) and made three decisions before
+merge, landed together since they interact. This addendum records them; the sections above
+are kept as the original design's history and are superseded where they conflict with this.
+
+**1. v2 header with a 4-byte checksum.** The v1 header (above) fully cross-checked its own
+fields but had no integrity check over the 40 payload bytes: a single bit flip would still
+splice cleanly into the reference template and pass every v1 check, producing a
+structurally perfect but wrong 959,632-byte script — wrong txid, a broken merkle proof, an
+unrecoverable deposit record, with no error anywhere. v2 adds a 4-byte checksum (the first
+4 bytes of SHA-256 of the full original/reconstructed bytes) to the header:
+
+```
+0xff (1) ‖ version (1) ‖ region (1) ‖ originalLength (4, big-endian) ‖ checksum (4) ‖ payload
+```
+
+`expandScript` verifies the checksum only *after* splicing the payload into the reference
+template, against the full reconstructed result — reconstruct, hash, compare, then return,
+never the reverse. v1 never shipped (nothing has ever called this codec outside its own
+tests), so there is no v1 record to keep reading and no migration to perform; an
+unrecognized version (including a literal v1 header) is simply rejected as
+`template-unknown`, the same as any other unknown version — a clean cut, not a
+compatibility gap.
+
+**2. Vendor the template, gzipped.** Requirement 5 above ("versions are pinned by the
+constant bytes they describe, not by an `@bsv/templates` semver range") turned out to be
+under-implemented: only a SHA-256 of the constant bytes was pinned, while the reference
+bytes themselves were rebuilt from whatever `@bsv/templates` was installed
+(`package.json` pins `^1.10.0`). A routine `npm i` that drifted the template even one byte
+made every previously-compressed record permanently unexpandable — not because the bytes
+needed to reconstruct it were gone (they were sitting right there in the compressed blob),
+but because the *reference* they'd be spliced into had silently changed underneath them.
+The template is now vendored: gzip-compressed, base64-encoded, committed to
+`services/vault/vaultTemplateArtifact.ts` (8,059 gzipped bytes for the 959,632-byte raw
+template, both variable runs zeroed before compression). Reconstruction reads only this
+file; the pinned constant-hash literals become a cross-check on the vendored asset rather
+than the only defence against a moving library, and a separate test still confirms the
+currently-installed `@bsv/templates` matches the vendored bytes, so a real upstream change
+is still caught loudly, in CI, without being able to brick a stored record. Decoding uses
+`fflate.gunzipSync` (already a dependency — see `patches/@bsv+templates+1.10.0.patch`,
+which moved `@bsv/templates` itself onto the same function), never Node's `zlib` or
+`DecompressionStream`, neither of which exist in React Native/Hermes.
+
+**3. `Uint8Array` references, cached per batch, released after.** The reference bytes were
+held as `number[]` — roughly 8 bytes per element in V8 even though every element fits in a
+byte — and held twice (one copy per region), measured at 15.5–16.4 MB retained for the
+process's lifetime: more than the 7.2 MB database this feature exists to shrink, alongside
+114–200 ms per cold derivation against this project's "no >100 ms JS block" goal. They are
+now `Uint8Array`s, with the region-0x02 reference a `subarray` view over region 0x01's
+buffer rather than a second copy, cutting the resident cache to under 1 MB. The vendored
+template plus the existing `PINNED_VARIABLE_RUNS` literal (cross-checked against the
+vendored bytes via the masked-hash comparison, not merely trusted) now supply the run
+geometry directly, so the sample-diffing machinery (`DIFF_SAMPLE_COUNT`, building several
+throwaway `@bsv/templates` instances and diffing them) is gone entirely — a cold
+`describeVaultTemplate()` call now measures single-digit milliseconds. `releaseTemplateCache()`
+frees the cache explicitly; a caller processing a batch of records should hold it open for
+the whole batch and release once at the end, not per record.
+
+### Savings, recomputed for v2
+
+Same derivation chain as the original table, with the v1 compressed component sizes (47,
+27) replaced by the v2 ones (51, 31 — the 4-byte checksum added to each): deposit `rawTx` =
+204 + lockingScript; R1 preimage = 161 + scriptCode; R1 unlocking script =
+65 + 34 + 33 + (2 + preimage) + 1; withdrawal tx = 204 + unlock × inputs; base64 backup
+record = ⌈n/3⌉ × 4; DB per vault tx = rawTx + lockingScript. (204 and 161 are the
+non-script overhead this codec doesn't touch — the difference between each verbatim row
+and the script/scriptCode length it wraps; unchanged from v1.)
+
+| | verbatim | compressed (v2) |
+|---|---|---|
+| deposit `rawTx` | 959,836 B | 255 B |
+| deposit as a backup record (base64) | 1,279,784 B | 340 B |
+| `outputs.lockingScript` | 959,632 B | 51 B |
+| R1 preimage | 959,733 B | 192 B |
+| R1 unlocking script | 959,871 B | 327 B |
+| withdrawal tx, 1 vault input | 960,075 B | 531 B |
+| withdrawal tx, 2 vault inputs | 1,919,946 B | 858 B |
+| DB per vault tx (stored twice) | 1,919,468 B | 306 B |
+| backup per user per year (1 vault tx/month) | 15.4 MB | ~4.0 KB |
+
+Roughly 3,764x on a deposit and 1,808x on a withdrawal (1 vault input) — down slightly
+from v1's 3,824x/1,822x, the cost of trading an unauthenticated payload for one a bit flip
+can no longer silently corrupt.

--- a/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
+++ b/docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md
@@ -163,6 +163,11 @@ unrecognized version (including a literal v1 header) is simply rejected as
 `template-unknown`, the same as any other unknown version — a clean cut, not a
 compatibility gap.
 
+This checksum is not a MAC: it carries no secret, so anyone able to rewrite a stored blob
+can recompute a matching checksum for their rewritten bytes. It catches accidental
+corruption only, and must not be leaned on for tamper-resistance at the storage boundary
+against a hostile writer.
+
 **2. Vendor the template, gzipped.** Requirement 5 above ("versions are pinned by the
 constant bytes they describe, not by an `@bsv/templates` semver range") turned out to be
 under-implemented: only a SHA-256 of the constant bytes was pinned, while the reference
@@ -202,10 +207,16 @@ the whole batch and release once at the end, not per record.
 Same derivation chain as the original table, with the v1 compressed component sizes (47,
 27) replaced by the v2 ones (51, 31 — the 4-byte checksum added to each): deposit `rawTx` =
 204 + lockingScript; R1 preimage = 161 + scriptCode; R1 unlocking script =
-65 + 34 + 33 + (2 + preimage) + 1; withdrawal tx = 204 + unlock × inputs; base64 backup
-record = ⌈n/3⌉ × 4; DB per vault tx = rawTx + lockingScript. (204 and 161 are the
+65 + 34 + 33 + (pushPrefix + preimage) + 1; withdrawal tx = 204 + unlock × inputs; base64
+backup record = ⌈n/3⌉ × 4; DB per vault tx = rawTx + lockingScript. (204 and 161 are the
 non-script overhead this codec doesn't touch — the difference between each verbatim row
-and the script/scriptCode length it wraps; unchanged from v1.)
+and the script/scriptCode length it wraps; unchanged from v1.) `pushPrefix` is not a
+constant 2 — it's the size of whichever script push opcode the preimage's length actually
+requires: 2 bytes (`OP_PUSHDATA1` + a 1-byte length) for the compressed 192-byte preimage,
+which fits in 255 bytes, but 5 bytes (`OP_PUSHDATA4` + a 4-byte length) for the verbatim
+959,733-byte preimage, which doesn't. That's 65+34+33+(2+192)+1 = 327 compressed, matching
+the table, and 65+34+33+(5+959733)+1 = 959,871 verbatim, also matching the table — the two
+cases need different `pushPrefix` values, not the same one.
 
 | | verbatim | compressed (v2) |
 |---|---|---|

--- a/docs/vault-script-compression.md
+++ b/docs/vault-script-compression.md
@@ -9,15 +9,18 @@ blob cap, and encrypting/signing that payload blocks the JS thread for tens of s
 
 The fix isn't a bigger cap. The script is almost entirely a fixed template: only 40 bytes
 (a 20-byte R1 commitment and a 20-byte K1 public-key hash) vary between any two vault
-outputs. `services/vault/templateCodec.ts` exploits that: it derives the constant template
-by diffing several freshly-built sample scripts, recognizes any script that matches it
-exactly, and replaces the constant bytes with a tiny header plus the few bytes that
-actually vary. `expand()` reverses this back to the original bytes, byte for byte.
+outputs. `services/vault/templateCodec.ts` exploits that: it recognizes any script that
+matches the template exactly, and replaces the constant bytes with a tiny header plus the
+few bytes that actually vary. `expandScript` reverses this back to the original bytes,
+byte for byte. The reference template itself is **vendored** — a gzip-compressed copy
+committed to this repo (`services/vault/vaultTemplateArtifact.ts`), not rebuilt from
+whatever `@bsv/templates` happens to be installed — see "The vendored template" below.
 
 This document explains the wire format and the reasoning behind it. For the problem
 statement, the measured evidence, and the full design rationale, see
 `docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md` — the
-savings table below is reproduced from there, not recomputed.
+savings table below matches that spec's "Savings, recomputed for v2" addendum, derived
+from the same chain, not adjusted by hand.
 
 ## Why the marker is `0xff`, not `OP_NOP7`
 
@@ -46,16 +49,17 @@ this codec's callers, not something `0xff` cryptographically guarantees on its o
 an explicit decision by the project owner, made and recorded when the format was designed —
 see the design spec's Wire Format section.
 
-## Header layout
+## Header layout (v2)
 
-Every compressed region uses the same 7-byte header, followed by a payload whose length
+Every compressed region uses the same 11-byte header, followed by a payload whose length
 depends on the region:
 
 ```
 0xff              1 byte   marker: OP_INVALIDOPCODE
-version           1 byte   template version, monotonic, never reused
+version           1 byte   template version — always 2; see "Why v2" below
 region            1 byte   0x01 = R1-K1 locking script, 0x02 = R1-K1 preimage scriptCode
 originalLength    4 bytes  big-endian length of the ORIGINAL elided run, for validation
+checksum          4 bytes  first 4 bytes of SHA-256 of the ORIGINAL (uncompressed) bytes
 payload           N bytes  the variable fields for this region and version
 ```
 
@@ -63,17 +67,44 @@ payload           N bytes  the variable fields for this region and version
 to `expandScript`, not a claim that the rest of the header is well-formed.
 `expandScript` validates everything else (a truncated header, an unrecognized
 version/region, an `originalLength` that disagrees with the version it names, a
-wrong-size payload) and throws rather than ever returning approximately-right bytes.
+wrong-size payload, a checksum that disagrees with the reconstructed bytes) and throws
+rather than ever returning approximately-right bytes.
+
+### Why v2: the checksum
+
+Version 1 (the format this codec originally shipped with) had a 7-byte header —
+marker/version/region/originalLength, no checksum — and relied entirely on
+`originalLength` and payload-size checks to validate a compressed blob. Neither check can
+see corruption *inside* the payload itself: a single bit flip in a stored or transmitted
+40-byte payload still produces the right length, still splices cleanly into the reference
+template, and still passes every v1 check — while reconstructing a **structurally
+perfect but wrong** 959,632-byte script: wrong txid, a merkle proof that no longer
+verifies, and an unrecoverable deposit record, with no error anywhere.
+
+v2 adds a 4-byte checksum — the first 4 bytes of SHA-256 of the full original
+(uncompressed) bytes — computed at compress time and verified at expand time only
+**after** the payload has been spliced into the reference template, against the full
+reconstructed result. That order matters: reconstruct, hash, compare, and only then
+return — never the reverse. Checking the reconstruction rather than the payload alone
+means corruption anywhere is caught, including (in principle) in the constant template
+itself, not just in the 20/40 bytes the payload carries.
+
+v1 never shipped: nothing has ever called `compressScript`/`compressScriptCode`/
+`expandScript` outside this codec's own tests (see "Nothing calls this codec yet" below),
+so no v1 record has ever been persisted anywhere. There is therefore no migration to
+perform and no v1 reader to maintain — a v1-tagged header (or any version this build
+doesn't recognize) is simply rejected with `template-unknown`, the same as any other
+unknown version.
 
 ## The two regions
 
 **Region 0x01 — the locking script.** Payload is `commitment(20) ‖ k1PublicKeyHash(20)`,
-40 bytes, making a compressed locking script exactly `7 + 40 = 47` bytes. `commitment` is
+40 bytes, making a compressed locking script exactly `11 + 40 = 51` bytes. `commitment` is
 `hash160(r1PublicKey ‖ salt)`, sitting at offsets 17..36 of the real script;
 `k1PublicKeyHash` sits at offsets 959,609..959,628.
 
 **Region 0x02 — the sighash preimage's `scriptCode`.** Payload is `k1PublicKeyHash(20)`
-alone, making a compressed scriptCode exactly `7 + 20 = 27` bytes — no commitment field at
+alone, making a compressed scriptCode exactly `11 + 20 = 31` bytes — no commitment field at
 all. This isn't an oversight: `R1K1Wallet.unlockR1` (in `@bsv/templates`) builds the
 committed `scriptCode` as `lockingScript.subarray(60)` — the locking script with its first
 60 bytes dropped. The R1 commitment lives at offsets 17..36, entirely inside that dropped
@@ -82,9 +113,63 @@ down by 60, survives into region 0x02's variable run. There is nothing to recove
 payload that was never there in the first place: the commitment is independently
 recoverable at spend time because the *unlocking* script pushes `publicKey` and `salt`
 verbatim, and `commitment = hash160(publicKey ‖ salt)` can be recomputed from those two
-values directly. One pinned template descriptor covers both regions — region 0x02 is
-derived by slicing region 0x01's samples, never built or hardcoded independently — see
-`describeVaultTemplate` in `services/vault/templateCodec.ts`.
+values directly. One vendored reference template covers both regions — region 0x02 is
+derived by slicing 60 bytes off the front of region 0x01's vendored bytes, never built or
+hardcoded independently — see `ensureTemplateCache` in `services/vault/templateCodec.ts`.
+
+## The vendored template
+
+The reference template that recognition and reconstruction are checked against is
+**vendored**: gzip-compressed and committed as base64 in
+`services/vault/vaultTemplateArtifact.ts` (8,059 gzipped bytes for a 959,632-byte raw
+template — about 11 KB as base64), not rebuilt from whatever `@bsv/templates` happens to
+be installed.
+
+This replaced an earlier design where `describeVaultTemplate` rebuilt the template from
+the installed `@bsv/templates` on first use and pinned only a SHA-256 of the result.
+`package.json` pins `@bsv/templates` at `^1.10.0`, so a routine `npm i` can move it — and
+the moment the installed library's output drifted from the pinned hash by even one byte,
+*every* previously-compressed record became permanently unexpandable, even though the 40
+bytes needed to reconstruct any given record were sitting right there in its own
+compressed blob. Re-pinning the hash to match the new library would have "fixed" the
+throw but silently reconstructed old records against the new template — wrong bytes, no
+error.
+
+Vendoring removes the installed library from the reconstruction path entirely: an
+`@bsv/templates` upgrade (or removal) cannot change what an already-compressed record
+expands back into, because expansion never asks it anything. `PINNED_CONSTANT_HASH`/
+`PINNED_CONSTANT_HASH_SCRIPT_CODE` in `templateCodec.ts` are still checked, but now as a
+cross-check on the vendored asset (catching a corrupted commit, or a stale
+`PINNED_VARIABLE_RUNS`), not as the only thing standing between a dependency bump and an
+unrecoverable deposit record. A separate test (`templateCodec.test.ts`) still builds a
+script with whatever `@bsv/templates` is currently installed and checks that it still
+matches the vendored bytes — so an upstream change is still caught loudly, in CI — it just
+can no longer make a stored record unreadable.
+
+Decoding happens with `fflate`'s `gunzipSync`, never Node's `zlib` or the DOM
+`DecompressionStream` — this codec ships to React Native/Hermes, which has neither.
+`fflate` is already a real dependency of this project (see `patches/@bsv+templates+1.10.0.patch`,
+which moved `@bsv/templates` itself onto `fflate.gunzipSync` for the same reason).
+
+### Reference-template cache and release
+
+The inflated reference bytes (~960 KB) are held as a module-level cache, populated lazily
+on first use and reused across calls — `ensureTemplateCache` in `templateCodec.ts`. They're
+held as `Uint8Array`, not `number[]`: a `number[]` of ~960,000 JS numbers costs roughly
+8 bytes per element (~7.5 MB) even though every element fits in a byte, and the previous
+implementation held *two* such arrays (one per region) — 15.5–16.4 MB retained for the
+life of the process, more than the 7.2 MB database this feature exists to shrink. The
+region-0x02 reference is a `subarray` **view** over region 0x01's buffer, not a copy, so
+the whole cache costs under 1 MB.
+
+`releaseTemplateCache()` clears this cache; the next `describeVaultTemplate` call
+transparently re-inflates and re-verifies it from the vendored asset. This is a
+memory-management knob only — nothing is discarded that isn't trivially reconstructible
+from bytes already committed to this repo. A caller processing a **batch** of vault
+records (compressing every `lockingScript` in a backup pass, or expanding every stored
+record on restore) should hold the cache open for the whole batch and release once at the
+end, not per record — releasing between records would turn one inflate-and-verify pass
+into one per record for no benefit.
 
 ## Compressed bytes never leave the device
 
@@ -97,44 +182,58 @@ script evaluation outright, per the marker choice above). The codec's job ends a
 ## Drift protection
 
 Recognizing "this is a compressed-eligible template" isn't just a length check.
-`describeVaultTemplate` pins the live template's fingerprint (`constantHash`, a SHA-256 of
-the built script with its variable runs zeroed out) against `PINNED_CONSTANT_HASH_V1`, a
-hardcoded literal computed once from the `@bsv/templates` version this codec was verified
-against.
+`ensureTemplateCache` checks the vendored template's fingerprint (`constantHash`, a SHA-256
+of the inflated bytes with the two variable runs masked to zero — a no-op against the
+vendored asset, since it was built with those exact positions already zeroed) against
+`PINNED_CONSTANT_HASH`/`PINNED_CONSTANT_HASH_SCRIPT_CODE`, literals computed once — before
+the template was vendored — from a genuine `@bsv/templates` sample.
 
-That literal is what makes a **same-length** constant-byte drift fail loudly instead of
-silently. `totalLength`/`originalLength` checks alone cannot see an upstream change that
+That masking-then-hashing (rather than a bare hash of the asset) is what makes this a
+cross-check and not a tautology: if the vendored asset were corrupted, or
+`PINNED_VARIABLE_RUNS` no longer named the positions the asset was actually zeroed at,
+masking would zero the wrong bytes and the resulting hash would disagree with these
+independently-sourced literals. `ensureTemplateCache` throws
+`VaultError('template-invalid')` rather than proceeding if that ever happens — this check
+runs on every process, not only in CI.
+
+A **same-length** constant-byte drift in `@bsv/templates` itself — an upstream change that
 keeps exactly 959,632 bytes but reorders or alters some of the fixed bytes in between (say,
-a reshuffled `OP_CHECKSIG` branch) — without the pinned hash, `expandScript` would happily
-splice a real payload into a stale reference template and hand back confidently wrong bytes
-for a real, already-mined, real-money output, with no error at all. With it, that drift
-changes `constantHash`, and `describeVaultTemplate` throws `VaultError('template-unknown')`
-instead. This check runs on every process, not only in CI, and changing the pinned literal
-is a deliberate, version-bumping act — never a "make the assertion pass again" edit.
+a reshuffled `OP_CHECKSIG` branch) — can no longer make an already-stored record
+unreadable, because reconstruction no longer consults `@bsv/templates` at all (see "The
+vendored template" above). It's still caught, just differently: a dedicated test builds a
+script with the currently-installed library, masks it the same way, and asserts the result
+still matches `PINNED_CONSTANT_HASH`. That test failing is the loud, CI-visible signal a
+library upgrade changed the template — the runtime path is simply no longer the mechanism
+that catches it, so it can't also be the mechanism a stale record dies to.
 
-Versions are pinned by the constant bytes they describe, not by an `@bsv/templates` semver
-range, as a precaution — that package went 1.9.6 to 1.10.0 mid-development, and a future
-byte-level change between minor versions must surface as `template-unknown`, never as a
-silent wrong reconstruction.
+Changing either pinned hash (or `PINNED_VARIABLE_RUNS`) is a deliberate, version-bumping
+act, done together with regenerating `vaultTemplateArtifact.ts` — never a "make the
+assertion pass again" edit. Versions are pinned by the constant bytes they describe, not by
+an `@bsv/templates` semver range — `package.json` pins `^1.10.0`, and a byte-level change
+within that range must surface as a loud test failure, never as a silent wrong
+reconstruction.
 
 ## Measured savings
 
-Reproduced from the design spec — measured against a real mined mainnet transaction
-(`6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697`), not estimated:
+Measured against a real mined mainnet transaction
+(`6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697`), not estimated. The
+compressed-side numbers below reflect the v2 header (51-byte locking script, 31-byte
+scriptCode); see the design spec for the full derivation chain.
 
 | | verbatim | compressed |
 |---|---|---|
-| deposit `rawTx` | 959,836 B | 251 B |
-| deposit as a backup record (base64) | 1,279,784 B | 336 B |
-| `outputs.lockingScript` | 959,632 B | 47 B |
-| R1 preimage | 959,733 B | 188 B |
-| R1 unlocking script | 959,871 B | 323 B |
-| withdrawal tx, 1 vault input | 960,075 B | 527 B |
-| withdrawal tx, 2 vault inputs | 1,919,946 B | 850 B |
-| DB per vault tx (stored twice) | 1,919,468 B | 298 B |
-| backup per user per year (1 vault tx/month) | 15.4 MB | 3.9 KB |
+| deposit `rawTx` | 959,836 B | 255 B |
+| deposit as a backup record (base64) | 1,279,784 B | 340 B |
+| `outputs.lockingScript` | 959,632 B | 51 B |
+| R1 preimage | 959,733 B | 192 B |
+| R1 unlocking script | 959,871 B | 327 B |
+| withdrawal tx, 1 vault input | 960,075 B | 531 B |
+| withdrawal tx, 2 vault inputs | 1,919,946 B | 858 B |
+| DB per vault tx (stored twice) | 1,919,468 B | 306 B |
+| backup per user per year (1 vault tx/month) | 15.4 MB | ~4.0 KB |
 
-Roughly 3,824x on a deposit and 1,822x on a withdrawal.
+Roughly 3,764x on a deposit and 1,808x on a withdrawal (1 vault input) — down slightly
+from v1's 3,824x/1,822x, the cost of the 4-byte checksum on an otherwise tiny payload.
 
 ## What this does not solve
 
@@ -158,8 +257,9 @@ Roughly 3,824x on a deposit and 1,822x on a withdrawal.
 
 | File | Role |
 |------|------|
-| `services/vault/templateCodec.ts` | Template descriptor derivation, exact recognition, compress/expand, drift protection |
+| `services/vault/templateCodec.ts` | Template descriptor, exact recognition, compress/expand, checksum, cache/release, drift protection |
+| `services/vault/vaultTemplateArtifact.ts` | The vendored reference template: gzip-compressed, base64-encoded, committed |
 | `services/vault/r1k1.ts` | R1-K1 locking-script construction and the preimage/unlock length constants this codec's regions are checked against |
-| `__tests__/vault/templateCodec.test.ts` | Descriptor derivation, round-trip (including the real mainnet fixture), region 0x02, and drift-detection tests |
+| `__tests__/vault/templateCodec.test.ts` | Descriptor, round-trip (including the real mainnet fixture), region 0x02, checksum, cache-release, and vendored-vs-installed-library tests |
 | `__tests__/vault/r1k1MainnetFixture.test.ts`, `__tests__/vault/fixtures/r1k1MainnetFixture.ts` | The pinned real mined mainnet script used as a template-drift fixture |
 | `__tests__/vault/r1k1.test.ts` | R1-K1 template arithmetic, including the `estimateLength` pin against `R1K1_R1_UNLOCK_LEN` that catches an upstream change to the scriptCode offset |

--- a/docs/vault-script-compression.md
+++ b/docs/vault-script-compression.md
@@ -72,8 +72,9 @@ rather than ever returning approximately-right bytes.
 
 ### Why v2: the checksum
 
-Version 1 (the format this codec originally shipped with) had a 7-byte header —
-marker/version/region/originalLength, no checksum — and relied entirely on
+Version 1 — a format that existed only during this branch's development, was never
+persisted by anything, and has no reader in this codec by design (see below) — had a
+7-byte header: marker/version/region/originalLength, no checksum. It relied entirely on
 `originalLength` and payload-size checks to validate a compressed blob. Neither check can
 see corruption *inside* the payload itself: a single bit flip in a stored or transmitted
 40-byte payload still produces the right length, still splices cleanly into the reference
@@ -88,6 +89,12 @@ reconstructed result. That order matters: reconstruct, hash, compare, and only t
 return — never the reverse. Checking the reconstruction rather than the payload alone
 means corruption anywhere is caught, including (in principle) in the constant template
 itself, not just in the 20/40 bytes the payload carries.
+
+**This checksum is not a MAC.** It's a plain SHA-256 prefix with no secret key, so anyone
+able to rewrite a stored blob can simply recompute the checksum to match their rewritten
+bytes — it detects accidental corruption only. It must never be relied on as a
+tamper-resistance guarantee at the storage boundary against a hostile writer; that is a
+different property, not one this codec provides.
 
 v1 never shipped: nothing has ever called `compressScript`/`compressScriptCode`/
 `expandScript` outside this codec's own tests (see "Nothing calls this codec yet" below),

--- a/docs/vault-script-compression.md
+++ b/docs/vault-script-compression.md
@@ -23,7 +23,8 @@ savings table below is reproduced from there, not recomputed.
 
 A compressed script is not a script anyone could ever be tricked into broadcasting — but
 the encoding is deliberately chosen so that even if compressed bytes somehow reached the
-network in place of a real locking script, they could never be spent or mined.
+network in place of a real locking script, they could never be *spent* — see below for why
+that guarantee doesn't extend to mining.
 
 The natural-looking choice would be `OP_NOP7` (`0xb6`): a defined Bitcoin Script opcode
 that evaluates as a no-op. That's exactly the problem. A script left in compressed form —
@@ -32,11 +33,18 @@ the interpreter. Depending on what those trailing bytes happened to disassemble 
 could pass evaluation and reach the chain as a spendable (or worse, always-true) output.
 
 `0xff` is `OP_INVALIDOPCODE` — not a defined opcode in any context. A script beginning
-with it fails evaluation immediately and unconditionally. So a compressed blob fails
-closed: it can never be spent, never be mined, and any code path that mistakenly treats a
-compressed script as a real one gets an immediate, loud failure instead of silently wrong
-money. This was an explicit decision by the project owner, made and recorded when the
-format was designed — see the design spec's Wire Format section.
+with it fails evaluation immediately and unconditionally, so a compressed blob can never be
+*spent*: any attempt to unlock an output whose locking script is compressed bytes fails
+script evaluation outright.
+
+That does **not** mean a compressed script can never be *mined*. Output scripts are never
+executed at creation, only at spend time, so a compressed blob can absolutely be mined into
+a real on-chain output — the only consequence is that the funds it holds become permanently
+unspendable (burnt), not that the network rejects the output. Keeping a compressed blob from
+ever reaching a `lockingScript` on its way to being broadcast is a procedural property of
+this codec's callers, not something `0xff` cryptographically guarantees on its own. This was
+an explicit decision by the project owner, made and recorded when the format was designed —
+see the design spec's Wire Format section.
 
 ## Header layout
 
@@ -105,8 +113,9 @@ instead. This check runs on every process, not only in CI, and changing the pinn
 is a deliberate, version-bumping act — never a "make the assertion pass again" edit.
 
 Versions are pinned by the constant bytes they describe, not by an `@bsv/templates` semver
-range, precisely because that package can (and did, mid-development) ship a byte-level
-change between minor versions.
+range, as a precaution — that package went 1.9.6 to 1.10.0 mid-development, and a future
+byte-level change between minor versions must surface as `template-unknown`, never as a
+silent wrong reconstruction.
 
 ## Measured savings
 
@@ -115,16 +124,17 @@ Reproduced from the design spec — measured against a real mined mainnet transa
 
 | | verbatim | compressed |
 |---|---|---|
-| deposit `rawTx` | 959,836 B | 246 B |
-| deposit as a backup record (base64) | 1,279,784 B | 328 B |
-| `outputs.lockingScript` | 959,632 B | 42 B |
-| R1 preimage | 959,733 B | 203 B |
-| R1 unlocking script | 959,871 B | 338 B |
-| withdrawal tx, 1 vault input | 960,075 B | 542 B |
-| withdrawal tx, 2 vault inputs | 1,919,946 B | 880 B |
-| backup per user per year (1 vault tx/month) | 15.4 MB | 3.8 KB |
+| deposit `rawTx` | 959,836 B | 251 B |
+| deposit as a backup record (base64) | 1,279,784 B | 336 B |
+| `outputs.lockingScript` | 959,632 B | 47 B |
+| R1 preimage | 959,733 B | 188 B |
+| R1 unlocking script | 959,871 B | 323 B |
+| withdrawal tx, 1 vault input | 960,075 B | 527 B |
+| withdrawal tx, 2 vault inputs | 1,919,946 B | 850 B |
+| DB per vault tx (stored twice) | 1,919,468 B | 298 B |
+| backup per user per year (1 vault tx/month) | 15.4 MB | 3.9 KB |
 
-Roughly 3,900x on a deposit and 1,771x on a withdrawal.
+Roughly 3,824x on a deposit and 1,822x on a withdrawal.
 
 ## What this does not solve
 
@@ -139,6 +149,10 @@ Roughly 3,900x on a deposit and 1,771x on a withdrawal.
 - **Anything other than this known template.** This works because the vault script has an
   exact, pinned shape. It is not a general answer for large records; the client's oversize
   guard remains the backstop for everything else.
+- **Nothing calls this codec yet.** No storage or backup path invokes `compressScript`,
+  `compressScriptCode`, or `expandScript` — the read/write wiring that would actually realise
+  the savings above is a deliberately separate change, so those numbers are what this codec
+  *makes possible*, not what the app currently achieves.
 
 ## Where this lives
 

--- a/docs/vault-script-compression.md
+++ b/docs/vault-script-compression.md
@@ -1,0 +1,151 @@
+# Vault Script Template Compression
+
+## Overview
+
+The YubiKey vault's R1-K1 locking script is 959,632 bytes. Storing it verbatim — once
+in `outputs.lockingScript`, again inside the deposit's raw transaction — breaks backup:
+a single vault deposit's `rawTx` base64-encodes to 1.28 MB, over the backup server's 1 MiB
+blob cap, and encrypting/signing that payload blocks the JS thread for tens of seconds.
+
+The fix isn't a bigger cap. The script is almost entirely a fixed template: only 40 bytes
+(a 20-byte R1 commitment and a 20-byte K1 public-key hash) vary between any two vault
+outputs. `services/vault/templateCodec.ts` exploits that: it derives the constant template
+by diffing several freshly-built sample scripts, recognizes any script that matches it
+exactly, and replaces the constant bytes with a tiny header plus the few bytes that
+actually vary. `expand()` reverses this back to the original bytes, byte for byte.
+
+This document explains the wire format and the reasoning behind it. For the problem
+statement, the measured evidence, and the full design rationale, see
+`docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md` — the
+savings table below is reproduced from there, not recomputed.
+
+## Why the marker is `0xff`, not `OP_NOP7`
+
+A compressed script is not a script anyone could ever be tricked into broadcasting — but
+the encoding is deliberately chosen so that even if compressed bytes somehow reached the
+network in place of a real locking script, they could never be spent or mined.
+
+The natural-looking choice would be `OP_NOP7` (`0xb6`): a defined Bitcoin Script opcode
+that evaluates as a no-op. That's exactly the problem. A script left in compressed form —
+`OP_NOP7` followed by version/region/length/payload bytes — is *still a valid script* to
+the interpreter. Depending on what those trailing bytes happened to disassemble to, it
+could pass evaluation and reach the chain as a spendable (or worse, always-true) output.
+
+`0xff` is `OP_INVALIDOPCODE` — not a defined opcode in any context. A script beginning
+with it fails evaluation immediately and unconditionally. So a compressed blob fails
+closed: it can never be spent, never be mined, and any code path that mistakenly treats a
+compressed script as a real one gets an immediate, loud failure instead of silently wrong
+money. This was an explicit decision by the project owner, made and recorded when the
+format was designed — see the design spec's Wire Format section.
+
+## Header layout
+
+Every compressed region uses the same 7-byte header, followed by a payload whose length
+depends on the region:
+
+```
+0xff              1 byte   marker: OP_INVALIDOPCODE
+version           1 byte   template version, monotonic, never reused
+region            1 byte   0x01 = R1-K1 locking script, 0x02 = R1-K1 preimage scriptCode
+originalLength    4 bytes  big-endian length of the ORIGINAL elided run, for validation
+payload           N bytes  the variable fields for this region and version
+```
+
+`isCompressed(bytes)` is a cheap `bytes[0] === 0xff` check — enough to route a candidate
+to `expandScript`, not a claim that the rest of the header is well-formed.
+`expandScript` validates everything else (a truncated header, an unrecognized
+version/region, an `originalLength` that disagrees with the version it names, a
+wrong-size payload) and throws rather than ever returning approximately-right bytes.
+
+## The two regions
+
+**Region 0x01 — the locking script.** Payload is `commitment(20) ‖ k1PublicKeyHash(20)`,
+40 bytes, making a compressed locking script exactly `7 + 40 = 47` bytes. `commitment` is
+`hash160(r1PublicKey ‖ salt)`, sitting at offsets 17..36 of the real script;
+`k1PublicKeyHash` sits at offsets 959,609..959,628.
+
+**Region 0x02 — the sighash preimage's `scriptCode`.** Payload is `k1PublicKeyHash(20)`
+alone, making a compressed scriptCode exactly `7 + 20 = 27` bytes — no commitment field at
+all. This isn't an oversight: `R1K1Wallet.unlockR1` (in `@bsv/templates`) builds the
+committed `scriptCode` as `lockingScript.subarray(60)` — the locking script with its first
+60 bytes dropped. The R1 commitment lives at offsets 17..36, entirely inside that dropped
+prefix, so it simply isn't part of the scriptCode's bytes; only `k1PublicKeyHash`, shifted
+down by 60, survives into region 0x02's variable run. There is nothing to recover from a
+payload that was never there in the first place: the commitment is independently
+recoverable at spend time because the *unlocking* script pushes `publicKey` and `salt`
+verbatim, and `commitment = hash160(publicKey ‖ salt)` can be recomputed from those two
+values directly. One pinned template descriptor covers both regions — region 0x02 is
+derived by slicing region 0x01's samples, never built or hardcoded independently — see
+`describeVaultTemplate` in `services/vault/templateCodec.ts`.
+
+## Compressed bytes never leave the device
+
+Compression is a **storage and backup representation only**. Broadcast, BEEF construction
+for a third-party send, and txid computation all operate on fully expanded bytes — a
+compressed script is never valid input to any of those paths, by construction (it fails
+script evaluation outright, per the marker choice above). The codec's job ends at
+"reconstruct the exact original bytes before anything wire-facing touches them."
+
+## Drift protection
+
+Recognizing "this is a compressed-eligible template" isn't just a length check.
+`describeVaultTemplate` pins the live template's fingerprint (`constantHash`, a SHA-256 of
+the built script with its variable runs zeroed out) against `PINNED_CONSTANT_HASH_V1`, a
+hardcoded literal computed once from the `@bsv/templates` version this codec was verified
+against.
+
+That literal is what makes a **same-length** constant-byte drift fail loudly instead of
+silently. `totalLength`/`originalLength` checks alone cannot see an upstream change that
+keeps exactly 959,632 bytes but reorders or alters some of the fixed bytes in between (say,
+a reshuffled `OP_CHECKSIG` branch) — without the pinned hash, `expandScript` would happily
+splice a real payload into a stale reference template and hand back confidently wrong bytes
+for a real, already-mined, real-money output, with no error at all. With it, that drift
+changes `constantHash`, and `describeVaultTemplate` throws `VaultError('template-unknown')`
+instead. This check runs on every process, not only in CI, and changing the pinned literal
+is a deliberate, version-bumping act — never a "make the assertion pass again" edit.
+
+Versions are pinned by the constant bytes they describe, not by an `@bsv/templates` semver
+range, precisely because that package can (and did, mid-development) ship a byte-level
+change between minor versions.
+
+## Measured savings
+
+Reproduced from the design spec — measured against a real mined mainnet transaction
+(`6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697`), not estimated:
+
+| | verbatim | compressed |
+|---|---|---|
+| deposit `rawTx` | 959,836 B | 246 B |
+| deposit as a backup record (base64) | 1,279,784 B | 328 B |
+| `outputs.lockingScript` | 959,632 B | 42 B |
+| R1 preimage | 959,733 B | 203 B |
+| R1 unlocking script | 959,871 B | 338 B |
+| withdrawal tx, 1 vault input | 960,075 B | 542 B |
+| withdrawal tx, 2 vault inputs | 1,919,946 B | 880 B |
+| backup per user per year (1 vault tx/month) | 15.4 MB | 3.8 KB |
+
+Roughly 3,900x on a deposit and 1,771x on a withdrawal.
+
+## What this does not solve
+
+- **The withdrawal fee.** A vault withdrawal still puts a ~960 KB unlocking script
+  on-chain — that's ~96,000 sat of real, uncompressible bytes a miner has to accept. This
+  codec never touches broadcast bytes (see above), so it cannot and does not change that
+  cost.
+- **Transient spend-time memory.** Building a withdrawal for a third-party send still
+  needs genuine, expanded bytes for BEEF construction, which still materializes roughly
+  1.83 MB of `inputBEEF` in memory during that operation. Compression shrinks what's
+  *stored*, not what a spend transiently needs to *build*.
+- **Anything other than this known template.** This works because the vault script has an
+  exact, pinned shape. It is not a general answer for large records; the client's oversize
+  guard remains the backstop for everything else.
+
+## Where this lives
+
+| File | Role |
+|------|------|
+| `services/vault/templateCodec.ts` | Template descriptor derivation, exact recognition, compress/expand, drift protection |
+| `services/vault/r1k1.ts` | R1-K1 locking-script construction and the preimage/unlock length constants this codec's regions are checked against |
+| `__tests__/vault/templateCodec.test.ts` | Descriptor derivation, round-trip (including the real mainnet fixture), region 0x02, and drift-detection tests |
+| `__tests__/vault/r1k1MainnetFixture.test.ts`, `__tests__/vault/fixtures/r1k1MainnetFixture.ts` | The pinned real mined mainnet script used as a template-drift fixture |
+| `__tests__/vault/r1k1.test.ts` | R1-K1 template arithmetic, including the `estimateLength` pin against `R1K1_R1_UNLOCK_LEN` that catches an upstream change to the scriptCode offset |

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -27,6 +27,7 @@ import { Hash, Utils } from '@bsv/sdk'
 import { p256 } from '@noble/curves/nist.js'
 import { buildVaultLockingScript } from './r1k1'
 import { randomBytes } from './random'
+import { VaultError } from './types'
 
 /** Marker byte for a compressed script. OP_INVALIDOPCODE (0xff) — NEVER
  * OP_NOP7/0xb6 or any other NOP-like opcode. If a compressed blob ever escapes
@@ -67,8 +68,10 @@ const DIFF_SAMPLE_COUNT = 4
  * anywhere outside the variable runs is caught on the first differing byte
  * without touching the rest of the ~960 KB script. Populated as a side effect
  * of `describeVaultTemplate`; a `TemplateVersion` whose reference was never
- * cached (e.g. a hand-built object rather than one this module produced)
- * fails closed rather than matching. */
+ * cached in THIS process (e.g. rehydrated from persisted/serialised form, or
+ * simply never obtained via `describeVaultTemplate`) makes `matchesTemplate`
+ * throw rather than silently answer `false` — see its doc comment for why a
+ * cache miss must never look like an ordinary non-match. */
 const referenceBytesByKey = new Map<string, number[]>()
 
 function versionKey(version: number, region: TemplateRegion): string {
@@ -153,12 +156,28 @@ export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
  * copy of the candidate, no hashing — and returns on the first differing
  * byte, so a non-matching script (the common case for anything that isn't a
  * vault output) is rejected in O(distance to first mismatch), not O(960 KB).
+ *
+ * Throws `VaultError('template-invalid')`, rather than returning `false`, if
+ * this process never cached reference bytes for `v.version`/`v.region` (i.e.
+ * `describeVaultTemplate()` was never awaited here). `TemplateVersion` is a
+ * small, serialisable value, so nothing stops a caller from persisting one
+ * and rehydrating it in a later process; without this check, doing so would
+ * make every real vault script silently and permanently "not match" — no
+ * exception, no log — in that process, which is a compression path quietly
+ * going dark rather than a corruption risk. A cache miss must never come
+ * back looking like an ordinary non-match.
  */
 export function matchesTemplate(bytes: number[], v: TemplateVersion): boolean {
-  if (bytes.length !== v.totalLength) return false
-
   const reference = referenceBytesByKey.get(versionKey(v.version, v.region))
-  if (!reference) return false
+  if (!reference) {
+    throw new VaultError(
+      'template-invalid',
+      `matchesTemplate has no cached reference for version ${v.version} region ${v.region} in this process — ` +
+        'describeVaultTemplate() must be awaited before recognition is attempted'
+    )
+  }
+
+  if (bytes.length !== v.totalLength) return false
 
   const runs = [...v.variableRuns].sort((a, b) => a.offset - b.offset)
   let runIdx = 0

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -1,0 +1,172 @@
+/**
+ * Template descriptor and byte-exact recognition for the R1-K1 vault locking
+ * script (and, in later tasks, its preimage scriptCode).
+ *
+ * The vault's locking script is 99.996% a fixed template: only a handful of
+ * bytes vary between outputs (the R1 commitment and the K1 public-key hash).
+ * Storing the whole ~960 KB verbatim per output is what breaks the backup
+ * system; this module gives the rest of the codec a byte-exact description
+ * of "the constant part" so it can be recompressed to a few dozen bytes and
+ * reconstructed exactly.
+ *
+ * The descriptor is DERIVED from `buildVaultLockingScript`, not transcribed
+ * from the plan's pinned constants. Building the same template twice with
+ * different throwaway inputs and diffing the two outputs finds exactly the
+ * byte ranges that vary; everything else is, by construction, the template's
+ * fixed bytes. This means an `@bsv/templates` change that shifts the layout
+ * changes the DERIVED descriptor too — callers that additionally assert the
+ * derived values against the plan's pinned constants (see
+ * templateCodec.test.ts) will see that as a test failure, never a silent
+ * drift.
+ *
+ * SECURITY: nothing secret passes through this module. `describeVaultTemplate`
+ * generates its own throwaway keys/salts purely to build sample scripts for
+ * diffing; none of that key material is retained or returned.
+ */
+import { Hash, Utils } from '@bsv/sdk'
+import { p256 } from '@noble/curves/nist.js'
+import { buildVaultLockingScript } from './r1k1'
+import { randomBytes } from './random'
+
+/** Marker byte for a compressed script. OP_INVALIDOPCODE (0xff) — NEVER
+ * OP_NOP7/0xb6 or any other NOP-like opcode. If a compressed blob ever escapes
+ * onto the wire in place of a real script, it must fail to execute rather
+ * than be interpreted as some other spendable script. */
+export const TEMPLATE_MARKER = 0xff
+
+/** 0x01 = R1K1 locking script, 0x02 = R1K1 preimage scriptCode. */
+export type TemplateRegion = 0x01 | 0x02
+
+/**
+ * A byte-exact description of one template version: its total length, the
+ * byte ranges that vary between instances, and a fingerprint (`constantHash`)
+ * of everything else. Intentionally holds no script bytes itself — those are
+ * cached separately (see `describeVaultTemplate`) — so this stays a small,
+ * serialisable value.
+ */
+export interface TemplateVersion {
+  version: number
+  region: TemplateRegion
+  totalLength: number
+  variableRuns: { offset: number; length: number }[]
+  constantHash: string
+}
+
+/** How many independently-random sample builds to diff when deriving
+ * variable-byte runs. Each sample's variable bytes come from an independent
+ * hash160/random draw, so the chance that every sample happens to agree at a
+ * given variable byte position is astronomically small once more than one or
+ * two samples are compared; a handful of samples makes it negligible without
+ * meaningfully slowing this down (building the template is fast — well under
+ * a second for all samples combined). */
+const DIFF_SAMPLE_COUNT = 4
+
+/** Cache of the raw constant reference bytes for a version, keyed by
+ * `${version}:${region}`. `matchesTemplate` compares candidate bytes directly
+ * against this in place (no masked copy, no hash-then-compare) so a mismatch
+ * anywhere outside the variable runs is caught on the first differing byte
+ * without touching the rest of the ~960 KB script. Populated as a side effect
+ * of `describeVaultTemplate`; a `TemplateVersion` whose reference was never
+ * cached (e.g. a hand-built object rather than one this module produced)
+ * fails closed rather than matching. */
+const referenceBytesByKey = new Map<string, number[]>()
+
+function versionKey(version: number, region: TemplateRegion): string {
+  return `${version}:${region}`
+}
+
+/** One random-but-valid input triple for `buildVaultLockingScript`. Only used
+ * to build throwaway sample scripts for diffing; the keys are discarded
+ * immediately after. */
+function throwawayInputs(): { r1PublicKey: string; salt: string; k1PublicKeyHash: number[] } {
+  const r1PublicKey = Utils.toHex(Array.from(p256.getPublicKey(p256.utils.randomSecretKey(), true)))
+  const salt = Utils.toHex(randomBytes(32))
+  const k1PublicKeyHash = randomBytes(20)
+  return { r1PublicKey, salt, k1PublicKeyHash }
+}
+
+/** Merge the byte offsets where the samples disagree into contiguous runs. */
+function findVariableRuns(samples: number[][]): { offset: number; length: number }[] {
+  const length = samples[0].length
+  const runs: { offset: number; length: number }[] = []
+  let runStart = -1
+  for (let i = 0; i < length; i++) {
+    const first = samples[0][i]
+    const varies = samples.some((s) => s[i] !== first)
+    if (varies) {
+      if (runStart === -1) runStart = i
+    } else if (runStart !== -1) {
+      runs.push({ offset: runStart, length: i - runStart })
+      runStart = -1
+    }
+  }
+  if (runStart !== -1) runs.push({ offset: runStart, length: length - runStart })
+  return runs
+}
+
+/** SHA-256 (hex) of `bytes` with every variable run zeroed out first, so the
+ * hash fingerprints only the constant template and is identical regardless of
+ * which real commitment/hash values occupy the variable runs. */
+function constantHashOf(bytes: number[], runs: { offset: number; length: number }[]): string {
+  const masked = bytes.slice()
+  for (const r of runs) {
+    for (let i = r.offset; i < r.offset + r.length; i++) masked[i] = 0
+  }
+  return Utils.toHex(Hash.sha256(masked))
+}
+
+let cachedDescriptors: TemplateVersion[] | undefined
+
+/**
+ * Build the current R1-K1 locking-script template (with throwaway inputs)
+ * several times, diff the results to find the variable byte runs, and return
+ * the resulting descriptor(s). Memoized: the template never changes within a
+ * process, and rebuilding a ~960 KB script several times per call would be
+ * wasteful for callers (e.g. the compress/expand path) that call this on
+ * every backup or restore.
+ */
+export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
+  if (cachedDescriptors) return cachedDescriptors
+
+  const samples: number[][] = []
+  for (let i = 0; i < DIFF_SAMPLE_COUNT; i++) {
+    const script = await buildVaultLockingScript(throwawayInputs())
+    samples.push(script.toBinary())
+  }
+
+  const totalLength = samples[0].length
+  const variableRuns = findVariableRuns(samples)
+  const constantHash = constantHashOf(samples[0], variableRuns)
+
+  const version = 1
+  const region: TemplateRegion = 0x01
+  referenceBytesByKey.set(versionKey(version, region), samples[0])
+
+  cachedDescriptors = [{ version, region, totalLength, variableRuns, constantHash }]
+  return cachedDescriptors
+}
+
+/**
+ * True only when `bytes` is exactly `v.totalLength` long AND every byte
+ * outside `v.variableRuns` equals the cached reference template's byte at
+ * that offset. Compares in place against the cached reference — no masked
+ * copy of the candidate, no hashing — and returns on the first differing
+ * byte, so a non-matching script (the common case for anything that isn't a
+ * vault output) is rejected in O(distance to first mismatch), not O(960 KB).
+ */
+export function matchesTemplate(bytes: number[], v: TemplateVersion): boolean {
+  if (bytes.length !== v.totalLength) return false
+
+  const reference = referenceBytesByKey.get(versionKey(v.version, v.region))
+  if (!reference) return false
+
+  const runs = [...v.variableRuns].sort((a, b) => a.offset - b.offset)
+  let runIdx = 0
+  for (let i = 0; i < bytes.length; i++) {
+    while (runIdx < runs.length && i >= runs[runIdx].offset + runs[runIdx].length) runIdx++
+    const inRun = runIdx < runs.length && i >= runs[runIdx].offset
+    if (inRun) continue
+    if (bytes[i] !== reference[i]) return false
+  }
+  return true
+}

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -13,32 +13,42 @@
  * `scriptCode` — the piece that makes SPENDING transactions huge, since
  * `R1K1Wallet.unlockR1` pushes the whole preimage (commitment locking script
  * included) into the unlocking script. Its descriptor is derived from the
- * region-0x01 one, not built independently — see `describeVaultTemplate`.
+ * region-0x01 one, not built independently — see `ensureTemplateCache`.
  *
- * The descriptor is DERIVED from `buildVaultLockingScript`, not transcribed
- * from the plan's pinned constants. Building the same template twice with
- * different throwaway inputs and diffing the two outputs finds exactly the
- * byte ranges that vary; everything else is, by construction, the template's
- * fixed bytes. This means an `@bsv/templates` change that shifts the layout
- * changes the DERIVED descriptor too — callers that additionally assert the
- * derived values against the plan's pinned constants (see
- * templateCodec.test.ts) will see that as a test failure, never a silent
- * drift. A layout change that DOESN'T shift the length or the variable-run
- * offsets — i.e. one that keeps 959,632 bytes but alters some of the fixed
- * bytes in between — would NOT show up in `totalLength`/`variableRuns` at
- * all, which is why `describeVaultTemplate` additionally checks the live
- * template's `constantHash` against a pinned literal at runtime (see
- * `PINNED_CONSTANT_HASH_V1`) and throws rather than silently reconstructing
- * against stale bytes. That check runs on every process, not just CI.
+ * THE REFERENCE TEMPLATE IS VENDORED, NOT REBUILT. Earlier versions of this
+ * module rebuilt the ~960 KB template from whatever `@bsv/templates` was
+ * installed (diffing several throwaway builds to find the variable-byte
+ * runs) and pinned only a SHA-256 of the result. That made a routine
+ * dependency bump — package.json pins `@bsv/templates` at `^1.10.0`, so a
+ * plain `npm i` can move it — potentially unable to reconstruct EVERY
+ * previously-compressed record, forever, the moment the installed library's
+ * output drifted from the pinned hash: `describeVaultTemplate` would throw
+ * `template-unknown` even though the 40 bytes needed to reconstruct any given
+ * record were sitting right there in its own compressed blob. Re-pinning the
+ * hash to match the new library would "fix" the throw but silently
+ * reconstruct OLD records against the NEW template — wrong bytes, no error.
  *
- * SECURITY: nothing secret passes through this module. `describeVaultTemplate`
- * generates its own throwaway keys/salts purely to build sample scripts for
- * diffing; none of that key material is retained or returned.
+ * `services/vault/vaultTemplateArtifact.ts` now vendors the reference
+ * template itself — gzip-compressed, base64-encoded, committed to this repo
+ * — so reconstruction never depends on what `@bsv/templates` happens to be
+ * installed. `PINNED_CONSTANT_HASH`/`PINNED_CONSTANT_HASH_SCRIPT_CODE` below
+ * are still checked, but now as a CROSS-CHECK on the vendored asset (catching
+ * a corrupted commit or a stale `PINNED_VARIABLE_RUNS`), not as the only
+ * defence against a moving `@bsv/templates`. A separate test
+ * (templateCodec.test.ts) still builds a script with whatever
+ * `@bsv/templates` is CURRENTLY installed and checks it still matches the
+ * vendored template — so an upstream change is still caught loudly, in CI —
+ * it just can no longer make an already-stored record unreadable.
+ *
+ * SECURITY: nothing secret passes through this module. The vendored
+ * reference template's variable-byte positions are zeroed, not populated
+ * with real key material; `expandScript` always overwrites them with a
+ * compressed record's own payload before returning.
  */
 import { Hash, Utils } from '@bsv/sdk'
-import { p256 } from '@noble/curves/nist.js'
-import { R1K1_LOCK_LEN, buildVaultLockingScript } from './r1k1'
-import { randomBytes } from './random'
+import { gunzipSync } from 'fflate'
+import { R1K1_LOCK_LEN } from './r1k1'
+import { VAULT_TEMPLATE_GZIP_BASE64, VAULT_TEMPLATE_RAW_LENGTH } from './vaultTemplateArtifact'
 import { VaultError } from './types'
 
 /** Marker byte for a compressed script. OP_INVALIDOPCODE (0xff) — NEVER
@@ -53,9 +63,9 @@ export type TemplateRegion = 0x01 | 0x02
 /**
  * A byte-exact description of one template version: its total length, the
  * byte ranges that vary between instances, and a fingerprint (`constantHash`)
- * of everything else. Intentionally holds no script bytes itself — those are
- * cached separately (see `describeVaultTemplate`) — so this stays a small,
- * serialisable value.
+ * of everything else. Intentionally holds no script bytes itself — those live
+ * in the module-level template cache (see `ensureTemplateCache`) — so this
+ * stays a small, serialisable value.
  */
 export interface TemplateVersion {
   version: number
@@ -65,106 +75,116 @@ export interface TemplateVersion {
   constantHash: string
 }
 
-/** How many independently-random sample builds to diff when deriving
- * variable-byte runs. Each sample's variable bytes come from an independent
- * hash160/random draw, so the chance that every sample happens to agree at a
- * given variable byte position is small once more than one or two samples are
- * compared; a handful of samples makes it negligible without meaningfully
- * slowing this down (building the template is fast — well under a second for
- * all samples combined). "Negligible" is not zero, though: a coincidental
- * agreement at one byte inside a real variable run would make `findVariableRuns`
- * split that run and narrow it by one byte, changing `constantHashOf`'s mask
- * and misdiagnosing an ordinary sampling coincidence as an `@bsv/templates`
- * upgrade. `describeVaultTemplate` below does not trust the sample diff alone
- * for that reason — see `PINNED_VARIABLE_RUNS_V1` and `unionRuns`. */
-const DIFF_SAMPLE_COUNT = 4
+/**
+ * The only wire-format version this codec has ever emitted or will ever
+ * accept.
+ *
+ * Version 1 — the original 7-byte header (marker/version/region/
+ * originalLength, no checksum) — never shipped: nothing in this codebase has
+ * ever called `compressScript`/`compressScriptCode`/`expandScript` outside
+ * tests (see docs/vault-script-compression.md's "nothing calls this codec
+ * yet"), so no v1 record has ever been persisted anywhere, on any device.
+ * There is therefore nothing to migrate. A v1-tagged header is simply an
+ * unrecognised version to this build — `expandScript` rejects it with
+ * `template-unknown` the exact same way it rejects version 250 or version
+ * 999 (see the descriptor lookup in `expandScript`), because `describeVaultTemplate`
+ * only ever returns version-2 descriptors. Do not read this as a
+ * compatibility gap and do not add "v1 read support" — that would mean
+ * teaching this codec to reconstruct a header shape with no integrity check
+ * over its payload (see the checksum doc below for exactly why that shape
+ * was replaced), for records that provably do not exist.
+ */
+const TEMPLATE_VERSION = 2
 
-/** Cache of the raw constant reference bytes for a version, keyed by
- * `${version}:${region}`. `matchesTemplate` compares candidate bytes directly
- * against this in place (no masked copy, no hash-then-compare) so a mismatch
- * anywhere outside the variable runs is caught on the first differing byte
- * without touching the rest of the ~960 KB script. Populated as a side effect
- * of `describeVaultTemplate`; a `TemplateVersion` whose reference was never
- * cached in THIS process (e.g. rehydrated from persisted/serialised form, or
- * simply never obtained via `describeVaultTemplate`) makes `matchesTemplate`
- * throw rather than silently answer `false` — see its doc comment for why a
- * cache miss must never look like an ordinary non-match. */
-const referenceBytesByKey = new Map<string, number[]>()
+/** Number of bytes `R1K1Wallet.unlockR1` drops from the FRONT of the locking
+ * script before committing the remainder into the sighash preimage's
+ * `scriptCode`:
+ *
+ *   formatPreimage(tx, inputIndex, source, new Script([], lockingBytes.subarray(60), void 0, false))
+ *
+ * (verified against the `@bsv/templates` source — see R1K1Wallet.js's
+ * `unlockR1`). This is the one load-bearing constant region 0x02 is built
+ * from: `ensureTemplateCache` derives the ENTIRE region-0x02 reference by
+ * slicing this many bytes off the front of the vendored region-0x01
+ * reference, rather than hardcoding 959,572 (959,632 − 60) or re-deriving the
+ * k1PublicKeyHash offset independently. If `@bsv/templates` ever changes how
+ * many bytes `unlockR1` drops, this is the one constant to update —
+ * everything else in region 0x02 (its length, its variable run, its pinned
+ * constant hash) recomputes from it automatically. */
+const PREIMAGE_SCRIPT_CODE_OFFSET = 60
 
-function versionKey(version: number, region: TemplateRegion): string {
-  return `${version}:${region}`
-}
+/**
+ * The region-0x01 (R1-K1 locking script) template's `constantHash` (see
+ * `constantHashOf`): SHA-256 of the vendored reference template
+ * (`vaultTemplateArtifact.ts`) with `PINNED_VARIABLE_RUNS` masked to zero
+ * first — which is a no-op, since the vendored asset was built with those
+ * exact positions already zeroed (see that file's doc comment), so this
+ * reduces to SHA-256 of the asset as committed.
+ *
+ * That masking-then-hashing (rather than a bare `sha256(vendored)` call) is
+ * what makes this a genuine CROSS-CHECK and not a tautology: this literal was
+ * originally computed — before the template was vendored — from a REAL
+ * per-instance sample built by `@bsv/templates`, with its (non-zero, genuinely
+ * random) commitment/k1PublicKeyHash bytes masked out by `PINNED_VARIABLE_RUNS`.
+ * If the vendored asset were corrupted, or `PINNED_VARIABLE_RUNS` no longer
+ * named the positions the asset was actually zeroed at, masking would zero
+ * the WRONG bytes (leaving some real template bytes in the hash, or leaving
+ * some non-zero corruption unmasked) and the hash computed here would
+ * disagree with this independently-sourced literal. `ensureTemplateCache`
+ * throws `VaultError('template-invalid')` rather than proceeding if that ever
+ * happens — this is a same-process, every-process check, not a CI-only one.
+ *
+ * Changing this literal is a deliberate act, not routine maintenance: it must
+ * happen together with minting a NEW version number and regenerating
+ * `vaultTemplateArtifact.ts` — never as a silent "make the assertion pass
+ * again" edit.
+ */
+const PINNED_CONSTANT_HASH = '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b'
 
-/** One random-but-valid input triple for `buildVaultLockingScript`. Only used
- * to build throwaway sample scripts for diffing; the keys are discarded
- * immediately after. */
-function throwawayInputs(): { r1PublicKey: string; salt: string; k1PublicKeyHash: number[] } {
-  const r1PublicKey = Utils.toHex(Array.from(p256.getPublicKey(p256.utils.randomSecretKey(), true)))
-  const salt = Utils.toHex(randomBytes(32))
-  const k1PublicKeyHash = randomBytes(20)
-  return { r1PublicKey, salt, k1PublicKeyHash }
-}
+/**
+ * The region-0x01 template's variable-run geometry — the plan's Global
+ * Constraints (R1 commitment at offset 17, length 20; k1PublicKeyHash at
+ * offset 959609, length 20) — and, since the template is now vendored rather
+ * than diffed from throwaway samples on every process start, the ONLY source
+ * of this geometry at runtime. `ensureTemplateCache` cross-checks it against
+ * the vendored bytes via `PINNED_CONSTANT_HASH` above (masking the wrong
+ * positions would produce the wrong hash), rather than merely trusting this
+ * literal — see that constant's doc comment for exactly how.
+ */
+const PINNED_VARIABLE_RUNS: { offset: number; length: number }[] = [
+  { offset: 17, length: 20 },
+  { offset: 959609, length: 20 }
+]
 
-/** Merge the byte offsets where the samples disagree into contiguous runs. */
-function findVariableRuns(samples: number[][]): { offset: number; length: number }[] {
-  const length = samples[0].length
-  const runs: { offset: number; length: number }[] = []
-  let runStart = -1
-  for (let i = 0; i < length; i++) {
-    const first = samples[0][i]
-    const varies = samples.some((s) => s[i] !== first)
-    if (varies) {
-      if (runStart === -1) runStart = i
-    } else if (runStart !== -1) {
-      runs.push({ offset: runStart, length: i - runStart })
-      runStart = -1
-    }
-  }
-  if (runStart !== -1) runs.push({ offset: runStart, length: length - runStart })
-  return runs
-}
-
-/** SHA-256 (hex) of `bytes` with every variable run zeroed out first, so the
- * hash fingerprints only the constant template and is identical regardless of
- * which real commitment/hash values occupy the variable runs. */
-function constantHashOf(bytes: number[], runs: { offset: number; length: number }[]): string {
-  const masked = bytes.slice()
-  for (const r of runs) {
-    for (let i = r.offset; i < r.offset + r.length; i++) masked[i] = 0
-  }
-  return Utils.toHex(Hash.sha256(masked))
-}
-
-/** Merge two lists of byte ranges into the minimal set of non-overlapping,
- * non-adjacent runs that covers every byte position present in either list.
- * Used to widen sample-diffed variable runs with a pinned reference geometry
- * so a run can only ever grow, never shrink, regardless of how the sample
- * diff came out — see `PINNED_VARIABLE_RUNS_V1`. */
-function unionRuns(
-  a: { offset: number; length: number }[],
-  b: { offset: number; length: number }[]
-): { offset: number; length: number }[] {
-  const all = [...a, ...b].sort((x, y) => x.offset - y.offset)
-  const merged: { offset: number; length: number }[] = []
-  for (const r of all) {
-    if (r.length <= 0) continue
-    const last = merged[merged.length - 1]
-    if (last && r.offset <= last.offset + last.length) {
-      last.length = Math.max(last.offset + last.length, r.offset + r.length) - last.offset
-    } else {
-      merged.push({ offset: r.offset, length: r.length })
-    }
-  }
-  return merged
-}
+/**
+ * The region-0x02 (preimage scriptCode) template's `constantHash`, pinned the
+ * same way as `PINNED_CONSTANT_HASH` above and cross-checked the same way:
+ * SHA-256 of the vendored region-0x02 reference (region-0x01's vendored bytes
+ * sliced at `PREIMAGE_SCRIPT_CODE_OFFSET`) with its variable run masked —
+ * again a no-op against the vendored asset, but a genuine check against this
+ * independently-sourced literal.
+ *
+ * This does NOT give independent coverage against a corrupted vendored asset
+ * the way `PINNED_CONSTANT_HASH` does: region 0x02's bytes are a slice of the
+ * SAME vendored buffer region 0x01's check above already verified, and that
+ * check always runs first in `ensureTemplateCache` and throws before this one
+ * is ever reached. What this guard actually catches is a maintainer
+ * hand-editing `PREIMAGE_SCRIPT_CODE_OFFSET` itself to the wrong value —
+ * without updating this literal to match — which would shift which slice of
+ * the already-verified bytes becomes "scriptCode" and change this hash
+ * without touching region 0x01's. Changing this literal (together with
+ * `PREIMAGE_SCRIPT_CODE_OFFSET`, deliberately, as one act) is tied to minting
+ * a new version, never a silent "make the assertion pass again" edit.
+ */
+const PINNED_CONSTANT_HASH_SCRIPT_CODE = 'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
 
 /** Shift a set of runs by subtracting `offset` from each, dropping any run
  * that falls entirely below zero and clipping one that straddles it — the
- * same transformation `samples[i].slice(offset)` applies to the bytes those
- * runs describe. Used to derive the region-0x02 pinned run geometry from the
- * region-0x01 pinned literal below, the same way `describeVaultTemplate`
- * derives the region-0x02 SAMPLES from the region-0x01 samples: never built
- * or hardcoded independently, so the two can never drift out of sync. */
+ * same transformation `region1.subarray(offset)` applies to the bytes those
+ * runs describe. Used to derive the region-0x02 pinned run geometry from
+ * `PINNED_VARIABLE_RUNS` above, the same way `ensureTemplateCache` derives the
+ * region-0x02 REFERENCE BYTES from the region-0x01 vendored bytes: never
+ * built or hardcoded independently, so the two can never drift out of sync. */
 function shiftRuns(
   runs: { offset: number; length: number }[],
   offset: number
@@ -180,209 +200,180 @@ function shiftRuns(
   return shifted
 }
 
+/** SHA-256 (hex) of `bytes` with every variable run zeroed out first, so the
+ * hash fingerprints only the constant template and is identical regardless of
+ * which real commitment/hash values occupy the variable runs. Copies `bytes`
+ * first (`Uint8Array.slice`, not `subarray`) so masking never mutates a
+ * shared reference. */
+function constantHashOf(bytes: Uint8Array, runs: { offset: number; length: number }[]): string {
+  const masked = bytes.slice()
+  for (const r of runs) {
+    for (let i = r.offset; i < r.offset + r.length; i++) masked[i] = 0
+  }
+  return Utils.toHex(Hash.sha256(masked))
+}
+
 /**
- * The version-1/region-0x01 template's `constantHash` (see `constantHashOf`),
- * pinned as a literal — computed once from the CURRENT `@bsv/templates`
- * R1K1Wallet output and hardcoded here deliberately, per the design spec:
- * versions are pinned "by the constant bytes they describe, not by an
- * `@bsv/templates` semver range."
+ * The in-memory reference-template cache: the vendored template, inflated
+ * once and held as a `Uint8Array` until `releaseTemplateCache` clears it.
  *
- * This is what makes a same-length constant-byte drift fail loudly instead
- * of silently: `originalLength`/`totalLength` alone cannot catch a library
- * upgrade that keeps 959,632 bytes but changes some of the fixed template
- * bytes (e.g. a reordered OP_CHECKSIG branch) — `expandScript` would splice
- * a real compressed payload into a WRONG reference template and hand back
- * confidently wrong bytes for a real, already-mined, real-money output, with
- * no error at all. Comparing the live template's freshly-computed
- * `constantHash` against this pinned value at `describeVaultTemplate` time
- * closes that gap: any drift in the constant bytes changes the hash, and
- * `describeVaultTemplate` throws `template-unknown` rather than accepting a
- * template it was never verified against.
- *
- * Changing this literal is a deliberate act, not routine maintenance: it
- * must happen together with minting a NEW version number (and, if the
- * variable-run shape also changed, updating the compress/expand code that
- * assumes it) — never as a silent "make the assertion pass again" edit.
+ * `region2` is a `subarray` VIEW over `region1`'s buffer (offset
+ * `PREIMAGE_SCRIPT_CODE_OFFSET`), not a copy — it costs nothing beyond a
+ * pointer/offset/length triple. Holding both regions as `Uint8Array` rather
+ * than `number[]` is itself the bulk of the memory fix this cache exists for:
+ * a `number[]` of ~960,000 JS numbers costs roughly 8 bytes per element
+ * (~7.5 MB) even though every element fits in a single byte; a `Uint8Array`
+ * of the same length costs 1 byte per element (~960 KB) — and the previous
+ * implementation held TWO such `number[]` copies (one per region) totalling
+ * 15.5–16.4 MB retained for the lifetime of the process, more than the 7.2 MB
+ * database this feature exists to shrink.
  */
-const PINNED_CONSTANT_HASH_V1 = '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b'
+interface TemplateCacheEntry {
+  region1: Uint8Array
+  region2: Uint8Array
+}
+
+let templateCache: TemplateCacheEntry | undefined
 
 /**
- * The version-1/region-0x01 template's variable-run geometry, pinned as a
- * literal exactly like `PINNED_CONSTANT_HASH_V1` above — the plan's Global
- * Constraints (R1 commitment at offset 17, length 20; k1PublicKeyHash at
- * offset 959609, length 20).
+ * Populate (or reuse) `templateCache`: base64-decode and gunzip the vendored
+ * asset, verify its length and both regions' masked-constant hashes against
+ * the pinned literals above, and cache the inflated bytes for reuse across
+ * calls in this process — until `releaseTemplateCache` clears it, at which
+ * point the NEXT call re-inflates and re-verifies from scratch. Inflating an
+ * 8 KB gzip payload into ~960 KB, plus two SHA-256 passes over that much
+ * data, is comfortably sub-frame-budget — nowhere near the 114–200 ms the old
+ * sample-diffing implementation cost per cold call (four full `@bsv/templates`
+ * builds plus hashing), and nothing here calls `@bsv/templates` at all.
  *
- * `describeVaultTemplate` diffs `DIFF_SAMPLE_COUNT` throwaway samples to find
- * this same geometry in the overwhelmingly common case, but a single sample
- * byte that happens to draw the identical value on every sample — an
- * independent per-byte coincidence with a small but non-zero probability, not
- * an actual template change — would make `findVariableRuns` split a real
- * variable run and report it one byte narrower than it truly is. That
- * narrower run would then make `constantHashOf` mask one fewer byte than
- * `PINNED_CONSTANT_HASH_V1` was computed against, disagree with it, and
- * misdiagnose an ordinary sampling coincidence as an `@bsv/templates`
- * upgrade. `describeVaultTemplate` unions the sample-derived runs with this
- * pinned geometry (see `unionRuns`) before hashing or returning them, so a
- * coincidental agreement can only ever be absorbed into a wider run, never
- * split one — the derived-vs-pinned comparison stays stable regardless of
- * sampling luck. A GENUINE upstream change to the run geometry is still
- * caught: it would change `totalLength` and/or leave real constant-byte
- * differences outside this pinned window, which still changes
- * `constantHash` and still throws below.
+ * Throws `VaultError('template-invalid')` if the vendored asset disagrees
+ * with what this codec was verified against in ANY way — wrong inflated
+ * length, or a masked hash that disagrees with `PINNED_CONSTANT_HASH`/
+ * `PINNED_CONSTANT_HASH_SCRIPT_CODE`. This indicates a corrupted or
+ * mismatched build of THIS repo (not a moving `@bsv/templates`, which this
+ * function never consults), so there is no separate "unknown template"
+ * classification here the way there is for an unrecognised wire-format
+ * version in `expandScript` — a broken vendored asset is always a build
+ * problem, never a legitimately-different-but-unsupported one.
  */
-const PINNED_VARIABLE_RUNS_V1: { offset: number; length: number }[] = [
-  { offset: 17, length: 20 },
-  { offset: 959609, length: 20 }
-]
+function ensureTemplateCache(): TemplateCacheEntry {
+  if (templateCache) return templateCache
+
+  const gzip = Uint8Array.from(Utils.toArray(VAULT_TEMPLATE_GZIP_BASE64, 'base64'))
+  const region1 = gunzipSync(gzip)
+
+  if (region1.length !== VAULT_TEMPLATE_RAW_LENGTH || region1.length !== R1K1_LOCK_LEN) {
+    throw new VaultError(
+      'template-invalid',
+      `vendored template inflated to ${region1.length} bytes, expected ${VAULT_TEMPLATE_RAW_LENGTH} ` +
+        `(R1K1_LOCK_LEN ${R1K1_LOCK_LEN}) — the committed asset is corrupt or was built for a different version`
+    )
+  }
+
+  const constantHash = constantHashOf(region1, PINNED_VARIABLE_RUNS)
+  if (constantHash !== PINNED_CONSTANT_HASH) {
+    throw new VaultError(
+      'template-invalid',
+      `vendored template's masked constantHash ${constantHash} disagrees with the pinned ${PINNED_CONSTANT_HASH} ` +
+        '— the committed asset is corrupt, or PINNED_VARIABLE_RUNS no longer names the positions it was zeroed at'
+    )
+  }
+
+  const region2 = region1.subarray(PREIMAGE_SCRIPT_CODE_OFFSET)
+  const scriptCodeRuns = shiftRuns(PINNED_VARIABLE_RUNS, PREIMAGE_SCRIPT_CODE_OFFSET)
+  const scriptCodeConstantHash = constantHashOf(region2, scriptCodeRuns)
+  if (scriptCodeConstantHash !== PINNED_CONSTANT_HASH_SCRIPT_CODE) {
+    throw new VaultError(
+      'template-invalid',
+      `vendored scriptCode's masked constantHash ${scriptCodeConstantHash} disagrees with the pinned ` +
+        `${PINNED_CONSTANT_HASH_SCRIPT_CODE}`
+    )
+  }
+
+  templateCache = { region1, region2 }
+  return templateCache
+}
 
 /**
- * Number of bytes `R1K1Wallet.unlockR1` drops from the FRONT of the locking
- * script before committing the remainder into the sighash preimage's
- * `scriptCode`:
+ * Release the in-memory reference-template cache populated by
+ * `ensureTemplateCache` (called, in turn, by `describeVaultTemplate` and thus
+ * transitively by `compressScript`/`compressScriptCode`/`expandScript`).
+ * Frees the ~960 KB inflated `Uint8Array` — `region2` is a view over the same
+ * buffer, so this is the entire cost — held since the first call in this
+ * process.
  *
- *   formatPreimage(tx, inputIndex, source, new Script([], lockingBytes.subarray(60), void 0, false))
+ * This is a memory-management knob only: every exported function in this
+ * module keeps working correctly afterwards, transparently re-inflating and
+ * re-verifying the vendored asset from `vaultTemplateArtifact.ts` on the next
+ * `describeVaultTemplate` call. Nothing is discarded that isn't trivially
+ * reconstructible from bytes already committed to this repo.
  *
- * (verified against the `@bsv/templates` source — see R1K1Wallet.js's
- * `unlockR1`). This is the one load-bearing constant region 0x02 is built
- * from: `describeVaultTemplate` derives the ENTIRE region-0x02 descriptor by
- * slicing this many bytes off the region-0x01 samples it already built,
- * rather than hardcoding 959,572 (959,632 − 60) or re-deriving the
- * commitment/k1PublicKeyHash offsets independently. If `@bsv/templates` ever
- * changes how many bytes `unlockR1` drops, this is the one constant to
- * update — everything else in region 0x02 (its length, its variable run, its
- * pinned constant hash) recomputes from it automatically and any drift shows
- * up as a `template-unknown` throw below, not a silent wrong reconstruction.
+ * A caller processing a BATCH of vault records — compressing every
+ * `lockingScript` in a backup pass, or expanding every stored record on
+ * restore — should hold the cache open for the WHOLE batch and call this
+ * once at the end, not per record. Calling it between records would turn one
+ * inflate-and-verify pass into one per record for no benefit: the cache
+ * costs under 1 MB to hold, and the whole point of a per-batch release is to
+ * give that megabyte back when there's a long idle stretch until the next
+ * batch, not to avoid holding it for the (short) duration of one.
  */
-const PREIMAGE_SCRIPT_CODE_OFFSET = 60
+export function releaseTemplateCache(): void {
+  templateCache = undefined
+}
+
+/** Sum of every variable run's length — the payload size a version's header
+ * must be followed by. */
+function payloadLengthOf(v: TemplateVersion): number {
+  return v.variableRuns.reduce((sum, r) => sum + r.length, 0)
+}
 
 /**
- * The version-1/region-0x02 (preimage scriptCode) template's `constantHash`,
- * pinned the same way as `PINNED_CONSTANT_HASH_V1` above: computed once from
- * the CURRENT `@bsv/templates` output (region-0x01 samples sliced by
- * `PREIMAGE_SCRIPT_CODE_OFFSET`) and hardcoded here.
- *
- * This does NOT give independent coverage against an `@bsv/templates`
- * upgrade the way `PINNED_CONSTANT_HASH_V1` does: `scriptCodeSamples` is
- * sliced from the SAME `samples` that region 0x01's check above already
- * diffed and hashed, and that region-0x01 check always runs first and throws
- * `template-unknown` before this one is ever reached — any real upstream
- * drift in the bytes this guard covers would already have tripped that check.
- * What this guard actually catches is a maintainer hand-editing
- * `PREIMAGE_SCRIPT_CODE_OFFSET` itself to the wrong value — the one constant
- * this module documents as safe to edit locally — without updating this
- * literal to match: that shifts which slice of the already-verified bytes
- * becomes "scriptCode" and changes this hash without touching region 0x01's,
- * so this is the one check that would catch it. Changing this literal
- * (together with `PREIMAGE_SCRIPT_CODE_OFFSET`, deliberately, as one act) is
- * tied to minting a new version, never a silent "make the assertion pass
- * again" edit.
+ * Look up the cached reference bytes for `version`/`region`, or `undefined`
+ * if that exact version/region isn't the one currently cached — either
+ * because `ensureTemplateCache` was never called in this process (no
+ * `describeVaultTemplate` await yet, or a `releaseTemplateCache` since the
+ * last one), or because `version` names something other than this codec's
+ * one supported version.
  */
-const PINNED_CONSTANT_HASH_V1_SCRIPT_CODE = 'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
-
-let cachedDescriptors: TemplateVersion[] | undefined
+function referenceBytesFor(version: number, region: TemplateRegion): Uint8Array | undefined {
+  if (version !== TEMPLATE_VERSION || !templateCache) return undefined
+  if (region === 0x01) return templateCache.region1
+  if (region === 0x02) return templateCache.region2
+  return undefined
+}
 
 /**
- * Build the current R1-K1 locking-script template (with throwaway inputs)
- * several times, diff the results to find the variable byte runs, and return
- * the resulting descriptor(s). Memoized: the template never changes within a
- * process, and rebuilding a ~960 KB script several times per call would be
- * wasteful for callers (e.g. the compress/expand path) that call this on
- * every backup or restore.
+ * Return this codec's only supported template version's descriptor for both
+ * regions (0x01 locking script, 0x02 preimage scriptCode), populating (or
+ * reusing) the in-memory reference-template cache as a side effect — see
+ * `ensureTemplateCache`.
  *
- * Throws `VaultError('template-unknown')` if the live template disagrees
- * with the pinned reference in ANY way this codec was verified against —
- * `totalLength !== R1K1_LOCK_LEN` (an `@bsv/templates` upgrade that changed
- * the script's length; also caught downstream by `originalLength` checks,
- * but checked here too so the failure surfaces at the earliest possible
- * point) or `constantHash !== PINNED_CONSTANT_HASH_V1` (a same-length drift
- * in the constant bytes, which nothing else in this module would ever
- * detect — see `PINNED_CONSTANT_HASH_V1`'s doc comment). This is the check
- * that makes a library upgrade fail loudly on a real device rather than
- * merely fail this repo's CI.
+ * The descriptors themselves are tiny (a couple of numbers, two short run
+ * lists, two hash strings) and are rebuilt fresh on every call rather than
+ * memoized separately from the byte cache — so a call shortly after
+ * `releaseTemplateCache()` correctly reflects a freshly re-verified cache
+ * rather than stale metadata from before the release. Async for API
+ * stability (a caller can keep `await`ing this) even though, unlike the old
+ * sample-diffing implementation, nothing here actually awaits anything.
  */
 export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
-  if (cachedDescriptors) return cachedDescriptors
+  const cache = ensureTemplateCache()
 
-  const samples: number[][] = []
-  for (let i = 0; i < DIFF_SAMPLE_COUNT; i++) {
-    const script = await buildVaultLockingScript(throwawayInputs())
-    samples.push(script.toBinary())
+  const region1: TemplateVersion = {
+    version: TEMPLATE_VERSION,
+    region: 0x01,
+    totalLength: cache.region1.length,
+    variableRuns: PINNED_VARIABLE_RUNS,
+    constantHash: PINNED_CONSTANT_HASH
   }
-
-  const totalLength = samples[0].length
-  const sampleDerivedRuns = findVariableRuns(samples)
-  // Union with the pinned run geometry rather than trusting the sample diff
-  // alone — see PINNED_VARIABLE_RUNS_V1's doc comment for why a coincidental
-  // same-value draw across every sample must never narrow a real run. Only
-  // meaningful (and safe to compute — the pinned offsets may run past a
-  // wrong-length script) when the length actually matches what those pinned
-  // offsets describe; otherwise the length check below fails regardless and
-  // the exact runs used here don't matter.
-  const variableRuns =
-    totalLength === R1K1_LOCK_LEN ? unionRuns(sampleDerivedRuns, PINNED_VARIABLE_RUNS_V1) : sampleDerivedRuns
-  const constantHash = constantHashOf(samples[0], variableRuns)
-
-  if (totalLength !== R1K1_LOCK_LEN || constantHash !== PINNED_CONSTANT_HASH_V1) {
-    throw new VaultError(
-      'template-unknown',
-      `live R1-K1 template disagrees with the pinned reference (length ${totalLength} vs ${R1K1_LOCK_LEN} expected` +
-        `, constantHash ${constantHash} vs ${PINNED_CONSTANT_HASH_V1} expected) — an @bsv/templates upgrade changed ` +
-        'the template; this requires a new pinned version, not a silent reconstruction against stale bytes'
-    )
+  const region2: TemplateVersion = {
+    version: TEMPLATE_VERSION,
+    region: 0x02,
+    totalLength: cache.region2.length,
+    variableRuns: shiftRuns(PINNED_VARIABLE_RUNS, PREIMAGE_SCRIPT_CODE_OFFSET),
+    constantHash: PINNED_CONSTANT_HASH_SCRIPT_CODE
   }
-
-  const version = 1
-  const region: TemplateRegion = 0x01
-  referenceBytesByKey.set(versionKey(version, region), samples[0])
-
-  // Region 0x02: the sighash preimage's scriptCode. DERIVED from the same
-  // region-0x01 samples above by dropping their first
-  // `PREIMAGE_SCRIPT_CODE_OFFSET` bytes — never built independently and never
-  // hardcoded — so the two descriptors can never disagree about where the
-  // scriptCode starts or how long it is. Because the R1 commitment's variable
-  // run (offset 17, length 20) lies entirely below the offset, it drops out
-  // of `scriptCodeSamples` altogether; only the k1PublicKeyHash run survives,
-  // shifted down by the same offset. That is why region 0x02's payload ends
-  // up 20 bytes (k1PublicKeyHash only), not the 40-byte commitment +
-  // k1PublicKeyHash pair region 0x01 carries.
-  const scriptCodeSamples = samples.map((s) => s.slice(PREIMAGE_SCRIPT_CODE_OFFSET))
-  const scriptCodeLength = scriptCodeSamples[0].length
-  const scriptCodeSampleDerivedRuns = findVariableRuns(scriptCodeSamples)
-  // Same coincidental-agreement backstop as region 0x01 above, using the
-  // region-0x02 pinned geometry DERIVED from PINNED_VARIABLE_RUNS_V1 by the
-  // same shift `scriptCodeSamples` itself already went through — never a
-  // second independently-hardcoded literal. `totalLength === R1K1_LOCK_LEN`
-  // is already guaranteed here (the check above would have thrown otherwise),
-  // so this union is always safe to compute.
-  const scriptCodeVariableRuns = unionRuns(
-    scriptCodeSampleDerivedRuns,
-    shiftRuns(PINNED_VARIABLE_RUNS_V1, PREIMAGE_SCRIPT_CODE_OFFSET)
-  )
-  const scriptCodeConstantHash = constantHashOf(scriptCodeSamples[0], scriptCodeVariableRuns)
-
-  if (scriptCodeConstantHash !== PINNED_CONSTANT_HASH_V1_SCRIPT_CODE) {
-    throw new VaultError(
-      'template-unknown',
-      `live R1-K1 preimage scriptCode disagrees with the pinned reference (constantHash ${scriptCodeConstantHash} ` +
-        `vs ${PINNED_CONSTANT_HASH_V1_SCRIPT_CODE} expected) — an @bsv/templates upgrade changed the template; ` +
-        'this requires a new pinned version, not a silent reconstruction against stale bytes'
-    )
-  }
-
-  const scriptCodeRegion: TemplateRegion = 0x02
-  referenceBytesByKey.set(versionKey(version, scriptCodeRegion), scriptCodeSamples[0])
-
-  cachedDescriptors = [
-    { version, region, totalLength, variableRuns, constantHash },
-    {
-      version,
-      region: scriptCodeRegion,
-      totalLength: scriptCodeLength,
-      variableRuns: scriptCodeVariableRuns,
-      constantHash: scriptCodeConstantHash
-    }
-  ]
-  return cachedDescriptors
+  return [region1, region2]
 }
 
 /**
@@ -394,22 +385,24 @@ export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
  * vault output) is rejected in O(distance to first mismatch), not O(960 KB).
  *
  * Throws `VaultError('template-invalid')`, rather than returning `false`, if
- * this process never cached reference bytes for `v.version`/`v.region` (i.e.
- * `describeVaultTemplate()` was never awaited here). `TemplateVersion` is a
- * small, serialisable value, so nothing stops a caller from persisting one
- * and rehydrating it in a later process; without this check, doing so would
- * make every real vault script silently and permanently "not match" — no
- * exception, no log — in that process, which is a compression path quietly
- * going dark rather than a corruption risk. A cache miss must never come
- * back looking like an ordinary non-match.
+ * this process has no cached reference for `v.version`/`v.region` right now
+ * (never populated, or released since — see `referenceBytesFor`).
+ * `TemplateVersion` is a small, serialisable value, so nothing stops a caller
+ * from persisting one and rehydrating it in a later process, or calling this
+ * after `releaseTemplateCache()`; without this check, doing so would make
+ * every real vault script silently and permanently "not match" — no
+ * exception, no log — which is a compression path quietly going dark rather
+ * than a corruption risk. A cache miss must never come back looking like an
+ * ordinary non-match.
  */
 export function matchesTemplate(bytes: number[], v: TemplateVersion): boolean {
-  const reference = referenceBytesByKey.get(versionKey(v.version, v.region))
+  const reference = referenceBytesFor(v.version, v.region)
   if (!reference) {
     throw new VaultError(
       'template-invalid',
       `matchesTemplate has no cached reference for version ${v.version} region ${v.region} in this process — ` +
-        'describeVaultTemplate() must be awaited before recognition is attempted'
+        'describeVaultTemplate() must be awaited (and the cache must not have been released since) before ' +
+        'recognition is attempted'
     )
   }
 
@@ -430,33 +423,56 @@ export function matchesTemplate(bytes: number[], v: TemplateVersion): boolean {
  * ---------------------------------------------------------------------------
  * Compress / expand
  *
- * On-wire (and on-disk, for backup) layout of a compressed script, exactly
- * (pinned by the plan's Global Constraints):
+ * On-wire (and on-disk, for backup) layout of a compressed script, exactly:
  *
- *   0xff (1) ‖ version (1) ‖ region (1) ‖ originalLength (4, big-endian) ‖ payload
+ *   0xff (1) ‖ version (1) ‖ region (1) ‖ originalLength (4, big-endian) ‖
+ *     checksum (4) ‖ payload
  *
  * 0xff is OP_INVALIDOPCODE: not a defined opcode anywhere, so a compressed
  * blob that somehow escaped onto the wire in place of a real locking script
  * would fail script evaluation outright rather than being interpreted as
  * some other (spendable, or worse, always-true) script. OP_NOP7 (0xb6) was
  * explicitly rejected for this role: it IS a valid, defined no-op opcode, so
- * a compressed script left in place could still pass evaluation. See the
- * plan's Global Constraints for this decision.
+ * a compressed script left in place could still pass evaluation. Note that
+ * this guarantee is about SPENDING, not mining — a compressed script can
+ * still be mined into a real on-chain output (output scripts are never
+ * executed at creation), which is why `compressForRegion` below refuses
+ * (rather than passes through) bytes that already look marker-led but match
+ * no known template. See the plan's Global Constraints for the 0xff
+ * decision.
+ *
+ * `checksum` is the first 4 bytes of SHA-256 of the ORIGINAL (uncompressed)
+ * bytes — added in version 2. Version 1 shipped without it: the 7-byte
+ * header (marker/version/region/originalLength) was fully cross-checked, but
+ * the 40 payload bytes carried no integrity check of their own, so a single
+ * bit flip in a stored/transmitted compressed blob would silently splice a
+ * WRONG (but structurally perfect — right length, plausible-looking
+ * commitment/k1PublicKeyHash bytes) reconstruction: wrong txid, a merkle
+ * proof that no longer verifies, and an unrecoverable deposit record, with
+ * `expandScript` never noticing because nothing it checked could see a
+ * corruption confined to the payload. `checksum` covers the RECONSTRUCTED
+ * bytes, not just the payload, so corruption anywhere — including in the
+ * ~960 KB of constant template the payload doesn't even carry — is caught.
+ * `expandScript` verifies it only AFTER splicing the payload into the
+ * reference template, comparing against the FULL reconstructed result: it
+ * must reconstruct, hash, compare, and only then return, never the reverse.
+ * See `TEMPLATE_VERSION`'s doc comment above for why there is no v1 read
+ * path to preserve.
  *
  * The payload is just the bytes of each variable run, concatenated in
  * ascending offset order — for region 0x01 that is commitment(20) ‖
  * k1PublicKeyHash(20), 40 bytes, making a compressed locking script exactly
- * 7 + 40 = 47 bytes; for region 0x02 (the preimage scriptCode) that is
+ * 11 + 40 = 51 bytes; for region 0x02 (the preimage scriptCode) that is
  * k1PublicKeyHash(20) alone — the commitment run doesn't survive the
- * scriptCode's leading 60-byte cut, see `describeVaultTemplate` — making a
- * compressed scriptCode exactly 7 + 20 = 27 bytes. Nothing here hardcodes
+ * scriptCode's leading 60-byte cut, see `ensureTemplateCache` — making a
+ * compressed scriptCode exactly 11 + 20 = 31 bytes. Nothing here hardcodes
  * either shape though: both directions walk `TemplateVersion.variableRuns`,
  * so a version with different/more runs is handled by the same code without
  * change.
  * ---------------------------------------------------------------------------
  */
 
-const HEADER_LENGTH = 7 // marker(1) + version(1) + region(1) + originalLength(4)
+const HEADER_LENGTH = 11 // marker(1) + version(1) + region(1) + originalLength(4) + checksum(4)
 
 function writeUInt32BE(n: number): number[] {
   return [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]
@@ -468,10 +484,11 @@ function readUInt32BE(bytes: number[], offset: number): number {
   )
 }
 
-/** Sum of every variable run's length — the payload size a version's header
- * must be followed by. */
-function payloadLengthOf(v: TemplateVersion): number {
-  return v.variableRuns.reduce((sum, r) => sum + r.length, 0)
+/** First 4 bytes of SHA-256 of `bytes` — the v2 header's integrity check,
+ * computed over the FULL original/reconstructed bytes (see the wire-format
+ * doc above), never over the payload alone. */
+function checksumOf(bytes: number[] | Uint8Array): number[] {
+  return Hash.sha256(bytes).slice(0, 4)
 }
 
 /** True iff `bytes` opens with the compressed-script marker. A quick,
@@ -484,7 +501,7 @@ export function isCompressed(bytes: number[]): boolean {
 }
 
 /**
- * Compress a recognised template instance of `region` down to its 7-byte
+ * Compress a recognised template instance of `region` down to its 11-byte
  * header plus the concatenated variable-run bytes. Bytes that don't match any
  * known version of `region` — including a merely near-miss, per
  * `matchesTemplate`'s exactness — are returned unchanged (a fresh copy, not
@@ -527,7 +544,8 @@ async function compressForRegion(bytes: number[], region: TemplateRegion): Promi
       for (let i = r.offset; i < r.offset + r.length; i++) payload.push(bytes[i])
     }
 
-    return [TEMPLATE_MARKER, v.version, v.region, ...writeUInt32BE(v.totalLength), ...payload]
+    const checksum = checksumOf(bytes)
+    return [TEMPLATE_MARKER, v.version, v.region, ...writeUInt32BE(v.totalLength), ...checksum, ...payload]
   }
 
   if (bytes.length > 0 && bytes[0] === TEMPLATE_MARKER) {
@@ -568,9 +586,10 @@ export async function compressScriptCode(bytes: number[]): Promise<number[]> {
  * Reverse of both `compressScript` (region 0x01) and `compressScriptCode`
  * (region 0x02) — one expander for every region, dispatching purely on the
  * header's region byte: detects the `0xff` header, resolves it against a
- * known template version, and rebuilds the exact original bytes by splicing
- * the header's payload back into a copy of that version's cached reference
- * template.
+ * known template version, rebuilds the exact original bytes by splicing the
+ * header's payload back into a copy of that version's cached reference
+ * template, and ONLY THEN verifies the header's checksum against the fully
+ * reconstructed result.
  *
  * Fails closed in every direction — never returns bytes that are merely
  * approximately right:
@@ -583,11 +602,15 @@ export async function compressScriptCode(bytes: number[]): Promise<number[]> {
  *   header of a real one.
  * - marker-led but fewer than `HEADER_LENGTH` bytes (can't even read a full
  *   header): throws `template-invalid`.
- * - a marker-led version/region this build's codec has no descriptor for:
- *   throws `template-unknown`.
+ * - a marker-led version/region this build's codec has no descriptor for
+ *   (including version 1 — see `TEMPLATE_VERSION`'s doc comment for why that
+ *   is correct, not a migration gap): throws `template-unknown`.
  * - a well-known version/region whose `originalLength` field disagrees with
  *   that version's actual template length, or whose payload is the wrong
  *   size for that version's variable runs: throws `template-invalid`.
+ * - a well-known version/region whose reconstructed bytes hash to something
+ *   other than the header's `checksum` field: throws `template-invalid`. This
+ *   is the check version 1 never had — see the wire-format doc above.
  *
  * Awaits `describeVaultTemplate()` itself, both to resolve the header's
  * version/region and to guarantee the reference bytes it splices from are
@@ -612,6 +635,7 @@ export async function expandScript(bytes: number[]): Promise<number[]> {
   const version = bytes[1]
   const region = bytes[2]
   const originalLength = readUInt32BE(bytes, 3)
+  const checksum = bytes.slice(7, HEADER_LENGTH)
 
   const descriptors = await describeVaultTemplate()
   const match = descriptors.find((d) => d.version === version && d.region === region)
@@ -635,19 +659,18 @@ export async function expandScript(bytes: number[]): Promise<number[]> {
     )
   }
 
-  const reference = referenceBytesByKey.get(versionKey(match.version, match.region))
+  const reference = referenceBytesFor(match.version, match.region)
   if (!reference) {
-    // describeVaultTemplate() above just (re)populated this for every
-    // descriptor it returned, and `match` came from that same array — this
-    // is unreachable in practice. Fail closed rather than reconstruct from
-    // nothing if it ever somehow isn't.
+    // describeVaultTemplate() above just (re)populated the cache `match` was
+    // built from — this is unreachable in practice. Fail closed rather than
+    // reconstruct from nothing if it ever somehow isn't.
     throw new VaultError(
       'template-invalid',
       `no cached reference bytes for version ${version} region ${region}`
     )
   }
 
-  const result = reference.slice()
+  const result = Array.from(reference)
   let payloadOffset = 0
   const runs = [...match.variableRuns].sort((a, b) => a.offset - b.offset)
   for (const r of runs) {
@@ -655,16 +678,29 @@ export async function expandScript(bytes: number[]): Promise<number[]> {
     payloadOffset += r.length
   }
 
-  // Last-line check before handing reconstructed bytes back: unreachable
-  // today (result is a copy of `reference`, which is exactly `match.totalLength`
-  // long, and `originalLength` was already checked against that same value
-  // above) but the cheapest possible guard against ever returning a
-  // wrong-length reconstruction if that invariant is ever violated by a
-  // future change.
+  // Last-line check before the checksum: unreachable today (result is a copy
+  // of `reference`, which is exactly `match.totalLength` long, and
+  // `originalLength` was already checked against that same value above) but
+  // the cheapest possible guard against ever hashing/returning a wrong-length
+  // reconstruction if that invariant is ever violated by a future change.
   if (result.length !== originalLength) {
     throw new VaultError(
       'template-invalid',
       `reconstructed ${result.length} bytes but originalLength was ${originalLength} for version ${version} region ${region}`
+    )
+  }
+
+  // Verify the checksum AFTER full reconstruction, against the reconstructed
+  // bytes — never the payload alone, never the header — so corruption
+  // anywhere (including in the constant bytes the payload doesn't even
+  // carry) is caught before anything is returned. Reconstruct, hash,
+  // compare, THEN return — never the other order.
+  const actualChecksum = checksumOf(result)
+  if (Utils.toHex(actualChecksum) !== Utils.toHex(checksum)) {
+    throw new VaultError(
+      'template-invalid',
+      `checksum mismatch for version ${version} region ${region}: header says ${Utils.toHex(checksum)}, ` +
+        `reconstructed bytes hash to ${Utils.toHex(actualChecksum)} — refusing to return a possibly-corrupt reconstruction`
     )
   }
 

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -17,7 +17,13 @@
  * changes the DERIVED descriptor too — callers that additionally assert the
  * derived values against the plan's pinned constants (see
  * templateCodec.test.ts) will see that as a test failure, never a silent
- * drift.
+ * drift. A layout change that DOESN'T shift the length or the variable-run
+ * offsets — i.e. one that keeps 959,632 bytes but alters some of the fixed
+ * bytes in between — would NOT show up in `totalLength`/`variableRuns` at
+ * all, which is why `describeVaultTemplate` additionally checks the live
+ * template's `constantHash` against a pinned literal at runtime (see
+ * `PINNED_CONSTANT_HASH_V1`) and throws rather than silently reconstructing
+ * against stale bytes. That check runs on every process, not just CI.
  *
  * SECURITY: nothing secret passes through this module. `describeVaultTemplate`
  * generates its own throwaway keys/salts purely to build sample scripts for
@@ -25,7 +31,7 @@
  */
 import { Hash, Utils } from '@bsv/sdk'
 import { p256 } from '@noble/curves/nist.js'
-import { buildVaultLockingScript } from './r1k1'
+import { R1K1_LOCK_LEN, buildVaultLockingScript } from './r1k1'
 import { randomBytes } from './random'
 import { VaultError } from './types'
 
@@ -118,6 +124,32 @@ function constantHashOf(bytes: number[], runs: { offset: number; length: number 
   return Utils.toHex(Hash.sha256(masked))
 }
 
+/**
+ * The version-1/region-0x01 template's `constantHash` (see `constantHashOf`),
+ * pinned as a literal — computed once from the CURRENT `@bsv/templates`
+ * R1K1Wallet output and hardcoded here deliberately, per the design spec:
+ * versions are pinned "by the constant bytes they describe, not by an
+ * `@bsv/templates` semver range."
+ *
+ * This is what makes a same-length constant-byte drift fail loudly instead
+ * of silently: `originalLength`/`totalLength` alone cannot catch a library
+ * upgrade that keeps 959,632 bytes but changes some of the fixed template
+ * bytes (e.g. a reordered OP_CHECKSIG branch) — `expandScript` would splice
+ * a real compressed payload into a WRONG reference template and hand back
+ * confidently wrong bytes for a real, already-mined, real-money output, with
+ * no error at all. Comparing the live template's freshly-computed
+ * `constantHash` against this pinned value at `describeVaultTemplate` time
+ * closes that gap: any drift in the constant bytes changes the hash, and
+ * `describeVaultTemplate` throws `template-unknown` rather than accepting a
+ * template it was never verified against.
+ *
+ * Changing this literal is a deliberate act, not routine maintenance: it
+ * must happen together with minting a NEW version number (and, if the
+ * variable-run shape also changed, updating the compress/expand code that
+ * assumes it) — never as a silent "make the assertion pass again" edit.
+ */
+const PINNED_CONSTANT_HASH_V1 = '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b'
+
 let cachedDescriptors: TemplateVersion[] | undefined
 
 /**
@@ -127,6 +159,17 @@ let cachedDescriptors: TemplateVersion[] | undefined
  * process, and rebuilding a ~960 KB script several times per call would be
  * wasteful for callers (e.g. the compress/expand path) that call this on
  * every backup or restore.
+ *
+ * Throws `VaultError('template-unknown')` if the live template disagrees
+ * with the pinned reference in ANY way this codec was verified against —
+ * `totalLength !== R1K1_LOCK_LEN` (an `@bsv/templates` upgrade that changed
+ * the script's length; also caught downstream by `originalLength` checks,
+ * but checked here too so the failure surfaces at the earliest possible
+ * point) or `constantHash !== PINNED_CONSTANT_HASH_V1` (a same-length drift
+ * in the constant bytes, which nothing else in this module would ever
+ * detect — see `PINNED_CONSTANT_HASH_V1`'s doc comment). This is the check
+ * that makes a library upgrade fail loudly on a real device rather than
+ * merely fail this repo's CI.
  */
 export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
   if (cachedDescriptors) return cachedDescriptors
@@ -140,6 +183,15 @@ export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
   const totalLength = samples[0].length
   const variableRuns = findVariableRuns(samples)
   const constantHash = constantHashOf(samples[0], variableRuns)
+
+  if (totalLength !== R1K1_LOCK_LEN || constantHash !== PINNED_CONSTANT_HASH_V1) {
+    throw new VaultError(
+      'template-unknown',
+      `live R1-K1 template disagrees with the pinned reference (length ${totalLength} vs ${R1K1_LOCK_LEN} expected` +
+        `, constantHash ${constantHash} vs ${PINNED_CONSTANT_HASH_V1} expected) — an @bsv/templates upgrade changed ` +
+        'the template; this requires a new pinned version, not a silent reconstruction against stale bytes'
+    )
+  }
 
   const version = 1
   const region: TemplateRegion = 0x01
@@ -357,5 +409,19 @@ export async function expandScript(bytes: number[]): Promise<number[]> {
     for (let i = 0; i < r.length; i++) result[r.offset + i] = payload[payloadOffset + i]
     payloadOffset += r.length
   }
+
+  // Last-line check before handing reconstructed bytes back: unreachable
+  // today (result is a copy of `reference`, which is exactly `match.totalLength`
+  // long, and `originalLength` was already checked against that same value
+  // above) but the cheapest possible guard against ever returning a
+  // wrong-length reconstruction if that invariant is ever violated by a
+  // future change.
+  if (result.length !== originalLength) {
+    throw new VaultError(
+      'template-invalid',
+      `reconstructed ${result.length} bytes but originalLength was ${originalLength} for version ${version} region ${region}`
+    )
+  }
+
   return result
 }

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -68,10 +68,15 @@ export interface TemplateVersion {
 /** How many independently-random sample builds to diff when deriving
  * variable-byte runs. Each sample's variable bytes come from an independent
  * hash160/random draw, so the chance that every sample happens to agree at a
- * given variable byte position is astronomically small once more than one or
- * two samples are compared; a handful of samples makes it negligible without
- * meaningfully slowing this down (building the template is fast — well under
- * a second for all samples combined). */
+ * given variable byte position is small once more than one or two samples are
+ * compared; a handful of samples makes it negligible without meaningfully
+ * slowing this down (building the template is fast — well under a second for
+ * all samples combined). "Negligible" is not zero, though: a coincidental
+ * agreement at one byte inside a real variable run would make `findVariableRuns`
+ * split that run and narrow it by one byte, changing `constantHashOf`'s mask
+ * and misdiagnosing an ordinary sampling coincidence as an `@bsv/templates`
+ * upgrade. `describeVaultTemplate` below does not trust the sample diff alone
+ * for that reason — see `PINNED_VARIABLE_RUNS_V1` and `unionRuns`. */
 const DIFF_SAMPLE_COUNT = 4
 
 /** Cache of the raw constant reference bytes for a version, keyed by
@@ -130,6 +135,51 @@ function constantHashOf(bytes: number[], runs: { offset: number; length: number 
   return Utils.toHex(Hash.sha256(masked))
 }
 
+/** Merge two lists of byte ranges into the minimal set of non-overlapping,
+ * non-adjacent runs that covers every byte position present in either list.
+ * Used to widen sample-diffed variable runs with a pinned reference geometry
+ * so a run can only ever grow, never shrink, regardless of how the sample
+ * diff came out — see `PINNED_VARIABLE_RUNS_V1`. */
+function unionRuns(
+  a: { offset: number; length: number }[],
+  b: { offset: number; length: number }[]
+): { offset: number; length: number }[] {
+  const all = [...a, ...b].sort((x, y) => x.offset - y.offset)
+  const merged: { offset: number; length: number }[] = []
+  for (const r of all) {
+    if (r.length <= 0) continue
+    const last = merged[merged.length - 1]
+    if (last && r.offset <= last.offset + last.length) {
+      last.length = Math.max(last.offset + last.length, r.offset + r.length) - last.offset
+    } else {
+      merged.push({ offset: r.offset, length: r.length })
+    }
+  }
+  return merged
+}
+
+/** Shift a set of runs by subtracting `offset` from each, dropping any run
+ * that falls entirely below zero and clipping one that straddles it — the
+ * same transformation `samples[i].slice(offset)` applies to the bytes those
+ * runs describe. Used to derive the region-0x02 pinned run geometry from the
+ * region-0x01 pinned literal below, the same way `describeVaultTemplate`
+ * derives the region-0x02 SAMPLES from the region-0x01 samples: never built
+ * or hardcoded independently, so the two can never drift out of sync. */
+function shiftRuns(
+  runs: { offset: number; length: number }[],
+  offset: number
+): { offset: number; length: number }[] {
+  const shifted: { offset: number; length: number }[] = []
+  for (const r of runs) {
+    const start = r.offset - offset
+    const end = r.offset + r.length - offset
+    if (end <= 0) continue
+    const clippedStart = Math.max(start, 0)
+    shifted.push({ offset: clippedStart, length: end - clippedStart })
+  }
+  return shifted
+}
+
 /**
  * The version-1/region-0x01 template's `constantHash` (see `constantHashOf`),
  * pinned as a literal — computed once from the CURRENT `@bsv/templates`
@@ -157,6 +207,35 @@ function constantHashOf(bytes: number[], runs: { offset: number; length: number 
 const PINNED_CONSTANT_HASH_V1 = '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b'
 
 /**
+ * The version-1/region-0x01 template's variable-run geometry, pinned as a
+ * literal exactly like `PINNED_CONSTANT_HASH_V1` above — the plan's Global
+ * Constraints (R1 commitment at offset 17, length 20; k1PublicKeyHash at
+ * offset 959609, length 20).
+ *
+ * `describeVaultTemplate` diffs `DIFF_SAMPLE_COUNT` throwaway samples to find
+ * this same geometry in the overwhelmingly common case, but a single sample
+ * byte that happens to draw the identical value on every sample — an
+ * independent per-byte coincidence with a small but non-zero probability, not
+ * an actual template change — would make `findVariableRuns` split a real
+ * variable run and report it one byte narrower than it truly is. That
+ * narrower run would then make `constantHashOf` mask one fewer byte than
+ * `PINNED_CONSTANT_HASH_V1` was computed against, disagree with it, and
+ * misdiagnose an ordinary sampling coincidence as an `@bsv/templates`
+ * upgrade. `describeVaultTemplate` unions the sample-derived runs with this
+ * pinned geometry (see `unionRuns`) before hashing or returning them, so a
+ * coincidental agreement can only ever be absorbed into a wider run, never
+ * split one — the derived-vs-pinned comparison stays stable regardless of
+ * sampling luck. A GENUINE upstream change to the run geometry is still
+ * caught: it would change `totalLength` and/or leave real constant-byte
+ * differences outside this pinned window, which still changes
+ * `constantHash` and still throws below.
+ */
+const PINNED_VARIABLE_RUNS_V1: { offset: number; length: number }[] = [
+  { offset: 17, length: 20 },
+  { offset: 959609, length: 20 }
+]
+
+/**
  * Number of bytes `R1K1Wallet.unlockR1` drops from the FRONT of the locking
  * script before committing the remainder into the sighash preimage's
  * `scriptCode`:
@@ -180,12 +259,23 @@ const PREIMAGE_SCRIPT_CODE_OFFSET = 60
  * The version-1/region-0x02 (preimage scriptCode) template's `constantHash`,
  * pinned the same way as `PINNED_CONSTANT_HASH_V1` above: computed once from
  * the CURRENT `@bsv/templates` output (region-0x01 samples sliced by
- * `PREIMAGE_SCRIPT_CODE_OFFSET`) and hardcoded here deliberately, so a
- * same-length drift in the scriptCode's constant bytes fails loudly instead
- * of silently reconstructing wrong bytes for a real spend. Changing this
- * literal is a deliberate act tied to minting a new version, never a silent
- * "make the assertion pass again" edit — see `PINNED_CONSTANT_HASH_V1`'s
- * fuller doc comment, which this mirrors.
+ * `PREIMAGE_SCRIPT_CODE_OFFSET`) and hardcoded here.
+ *
+ * This does NOT give independent coverage against an `@bsv/templates`
+ * upgrade the way `PINNED_CONSTANT_HASH_V1` does: `scriptCodeSamples` is
+ * sliced from the SAME `samples` that region 0x01's check above already
+ * diffed and hashed, and that region-0x01 check always runs first and throws
+ * `template-unknown` before this one is ever reached — any real upstream
+ * drift in the bytes this guard covers would already have tripped that check.
+ * What this guard actually catches is a maintainer hand-editing
+ * `PREIMAGE_SCRIPT_CODE_OFFSET` itself to the wrong value — the one constant
+ * this module documents as safe to edit locally — without updating this
+ * literal to match: that shifts which slice of the already-verified bytes
+ * becomes "scriptCode" and changes this hash without touching region 0x01's,
+ * so this is the one check that would catch it. Changing this literal
+ * (together with `PREIMAGE_SCRIPT_CODE_OFFSET`, deliberately, as one act) is
+ * tied to minting a new version, never a silent "make the assertion pass
+ * again" edit.
  */
 const PINNED_CONSTANT_HASH_V1_SCRIPT_CODE = 'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
 
@@ -220,7 +310,16 @@ export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
   }
 
   const totalLength = samples[0].length
-  const variableRuns = findVariableRuns(samples)
+  const sampleDerivedRuns = findVariableRuns(samples)
+  // Union with the pinned run geometry rather than trusting the sample diff
+  // alone — see PINNED_VARIABLE_RUNS_V1's doc comment for why a coincidental
+  // same-value draw across every sample must never narrow a real run. Only
+  // meaningful (and safe to compute — the pinned offsets may run past a
+  // wrong-length script) when the length actually matches what those pinned
+  // offsets describe; otherwise the length check below fails regardless and
+  // the exact runs used here don't matter.
+  const variableRuns =
+    totalLength === R1K1_LOCK_LEN ? unionRuns(sampleDerivedRuns, PINNED_VARIABLE_RUNS_V1) : sampleDerivedRuns
   const constantHash = constantHashOf(samples[0], variableRuns)
 
   if (totalLength !== R1K1_LOCK_LEN || constantHash !== PINNED_CONSTANT_HASH_V1) {
@@ -248,7 +347,17 @@ export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
   // k1PublicKeyHash pair region 0x01 carries.
   const scriptCodeSamples = samples.map((s) => s.slice(PREIMAGE_SCRIPT_CODE_OFFSET))
   const scriptCodeLength = scriptCodeSamples[0].length
-  const scriptCodeVariableRuns = findVariableRuns(scriptCodeSamples)
+  const scriptCodeSampleDerivedRuns = findVariableRuns(scriptCodeSamples)
+  // Same coincidental-agreement backstop as region 0x01 above, using the
+  // region-0x02 pinned geometry DERIVED from PINNED_VARIABLE_RUNS_V1 by the
+  // same shift `scriptCodeSamples` itself already went through — never a
+  // second independently-hardcoded literal. `totalLength === R1K1_LOCK_LEN`
+  // is already guaranteed here (the check above would have thrown otherwise),
+  // so this union is always safe to compute.
+  const scriptCodeVariableRuns = unionRuns(
+    scriptCodeSampleDerivedRuns,
+    shiftRuns(PINNED_VARIABLE_RUNS_V1, PREIMAGE_SCRIPT_CODE_OFFSET)
+  )
   const scriptCodeConstantHash = constantHashOf(scriptCodeSamples[0], scriptCodeVariableRuns)
 
   if (scriptCodeConstantHash !== PINNED_CONSTANT_HASH_V1_SCRIPT_CODE) {
@@ -382,6 +491,23 @@ export function isCompressed(bytes: number[]): boolean {
  * the header format): this must never turn unrecognised bytes into something
  * that looks compressed.
  *
+ * The one exception: bytes that already begin with `TEMPLATE_MARKER` (0xff)
+ * but don't match any known version are refused with a thrown
+ * `VaultError('template-invalid')` rather than passed through. Passing them
+ * through unchanged would make `isCompressed` report `true` for bytes that
+ * are not a legitimately compressed header — and a storage layer following
+ * this module's own documented `isCompressed(b) ? expandScript(b) : b`
+ * pattern would then hand them to `expandScript`, which resolves a
+ * marker-led header purely from its version/region/length fields and splices
+ * the trailing bytes into the cached reference template regardless of
+ * whether they were ever produced by `compressForRegion`. Since output
+ * scripts are not executed at creation, a counterparty could mint a real
+ * on-chain output whose locking script is exactly such attacker-chosen bytes;
+ * silently "compressing" (i.e. passing through) that input would let it
+ * later inflate into a fabricated ~960 KB script that disagrees with the
+ * chain. Throwing here is what keeps `expand(compress(x)) === x` true for
+ * every constructible `x`, not just for legitimate template instances.
+ *
  * Awaits `describeVaultTemplate()` itself before consulting `matchesTemplate`
  * so the normal path can never hit that function's "no cached reference"
  * throw — this is always called with the descriptors it just (re)populated
@@ -402,6 +528,16 @@ async function compressForRegion(bytes: number[], region: TemplateRegion): Promi
     }
 
     return [TEMPLATE_MARKER, v.version, v.region, ...writeUInt32BE(v.totalLength), ...payload]
+  }
+
+  if (bytes.length > 0 && bytes[0] === TEMPLATE_MARKER) {
+    throw new VaultError(
+      'template-invalid',
+      `cannot compress region ${region} bytes that already begin with the compressed-script ` +
+        `marker 0x${TEMPLATE_MARKER.toString(16)} but match no known template version — passing ` +
+        'them through unchanged would make isCompressed() report a false positive for bytes that ' +
+        'are not actually a compressed header'
+    )
   }
 
   return bytes.slice()
@@ -438,11 +574,17 @@ export async function compressScriptCode(bytes: number[]): Promise<number[]> {
  *
  * Fails closed in every direction — never returns bytes that are merely
  * approximately right:
- * - fewer than `HEADER_LENGTH` bytes (can't even read a full header):
- *   throws `template-invalid`.
- * - a version/region this build's codec has no descriptor for (including a
- *   `bytes[0]` that isn't the `0xff` marker at all, since that decodes to no
- *   version this codec issued): throws `template-unknown`.
+ * - `bytes[0]` isn't the `0xff` marker at all (including an empty array,
+ *   which has no byte 0 to be the marker): decodes to no version this codec
+ *   ever issued, so this is simply not a compressed script — throws
+ *   `template-unknown`. Checked FIRST, before the length check below, so a
+ *   short array that was never meant to be a compressed header in the first
+ *   place is diagnosed as "unrecognised", not misreported as a truncated
+ *   header of a real one.
+ * - marker-led but fewer than `HEADER_LENGTH` bytes (can't even read a full
+ *   header): throws `template-invalid`.
+ * - a marker-led version/region this build's codec has no descriptor for:
+ *   throws `template-unknown`.
  * - a well-known version/region whose `originalLength` field disagrees with
  *   that version's actual template length, or whose payload is the wrong
  *   size for that version's variable runs: throws `template-invalid`.
@@ -453,16 +595,17 @@ export async function compressScriptCode(bytes: number[]): Promise<number[]> {
  * `matchesTemplate`-style "no cached reference" failures.
  */
 export async function expandScript(bytes: number[]): Promise<number[]> {
+  if (bytes.length === 0 || bytes[0] !== TEMPLATE_MARKER) {
+    throw new VaultError(
+      'template-unknown',
+      `expected compressed-script marker 0x${TEMPLATE_MARKER.toString(16)}, got ` +
+        (bytes.length === 0 ? 'an empty array' : `0x${bytes[0].toString(16)}`)
+    )
+  }
   if (bytes.length < HEADER_LENGTH) {
     throw new VaultError(
       'template-invalid',
       `compressed-script header truncated: got ${bytes.length} bytes, need at least ${HEADER_LENGTH}`
-    )
-  }
-  if (bytes[0] !== TEMPLATE_MARKER) {
-    throw new VaultError(
-      'template-unknown',
-      `expected compressed-script marker 0x${TEMPLATE_MARKER.toString(16)}, got 0x${bytes[0].toString(16)}`
     )
   }
 

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -363,7 +363,7 @@ export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
     version: TEMPLATE_VERSION,
     region: 0x01,
     totalLength: cache.region1.length,
-    variableRuns: PINNED_VARIABLE_RUNS,
+    variableRuns: PINNED_VARIABLE_RUNS.map(r => ({ ...r })), // fresh copies, not the live module array/objects
     constantHash: PINNED_CONSTANT_HASH
   }
   const region2: TemplateVersion = {

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -1,6 +1,6 @@
 /**
  * Template descriptor and byte-exact recognition for the R1-K1 vault locking
- * script (and, in later tasks, its preimage scriptCode).
+ * script and its sighash preimage's scriptCode.
  *
  * The vault's locking script is 99.996% a fixed template: only a handful of
  * bytes vary between outputs (the R1 commitment and the K1 public-key hash).
@@ -8,6 +8,12 @@
  * system; this module gives the rest of the codec a byte-exact description
  * of "the constant part" so it can be recompressed to a few dozen bytes and
  * reconstructed exactly.
+ *
+ * As of region 0x02, this module also describes the R1-K1 sighash preimage's
+ * `scriptCode` — the piece that makes SPENDING transactions huge, since
+ * `R1K1Wallet.unlockR1` pushes the whole preimage (commitment locking script
+ * included) into the unlocking script. Its descriptor is derived from the
+ * region-0x01 one, not built independently — see `describeVaultTemplate`.
  *
  * The descriptor is DERIVED from `buildVaultLockingScript`, not transcribed
  * from the plan's pinned constants. Building the same template twice with
@@ -150,6 +156,39 @@ function constantHashOf(bytes: number[], runs: { offset: number; length: number 
  */
 const PINNED_CONSTANT_HASH_V1 = '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b'
 
+/**
+ * Number of bytes `R1K1Wallet.unlockR1` drops from the FRONT of the locking
+ * script before committing the remainder into the sighash preimage's
+ * `scriptCode`:
+ *
+ *   formatPreimage(tx, inputIndex, source, new Script([], lockingBytes.subarray(60), void 0, false))
+ *
+ * (verified against the `@bsv/templates` source — see R1K1Wallet.js's
+ * `unlockR1`). This is the one load-bearing constant region 0x02 is built
+ * from: `describeVaultTemplate` derives the ENTIRE region-0x02 descriptor by
+ * slicing this many bytes off the region-0x01 samples it already built,
+ * rather than hardcoding 959,572 (959,632 − 60) or re-deriving the
+ * commitment/k1PublicKeyHash offsets independently. If `@bsv/templates` ever
+ * changes how many bytes `unlockR1` drops, this is the one constant to
+ * update — everything else in region 0x02 (its length, its variable run, its
+ * pinned constant hash) recomputes from it automatically and any drift shows
+ * up as a `template-unknown` throw below, not a silent wrong reconstruction.
+ */
+const PREIMAGE_SCRIPT_CODE_OFFSET = 60
+
+/**
+ * The version-1/region-0x02 (preimage scriptCode) template's `constantHash`,
+ * pinned the same way as `PINNED_CONSTANT_HASH_V1` above: computed once from
+ * the CURRENT `@bsv/templates` output (region-0x01 samples sliced by
+ * `PREIMAGE_SCRIPT_CODE_OFFSET`) and hardcoded here deliberately, so a
+ * same-length drift in the scriptCode's constant bytes fails loudly instead
+ * of silently reconstructing wrong bytes for a real spend. Changing this
+ * literal is a deliberate act tied to minting a new version, never a silent
+ * "make the assertion pass again" edit — see `PINNED_CONSTANT_HASH_V1`'s
+ * fuller doc comment, which this mirrors.
+ */
+const PINNED_CONSTANT_HASH_V1_SCRIPT_CODE = 'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
+
 let cachedDescriptors: TemplateVersion[] | undefined
 
 /**
@@ -197,7 +236,43 @@ export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
   const region: TemplateRegion = 0x01
   referenceBytesByKey.set(versionKey(version, region), samples[0])
 
-  cachedDescriptors = [{ version, region, totalLength, variableRuns, constantHash }]
+  // Region 0x02: the sighash preimage's scriptCode. DERIVED from the same
+  // region-0x01 samples above by dropping their first
+  // `PREIMAGE_SCRIPT_CODE_OFFSET` bytes — never built independently and never
+  // hardcoded — so the two descriptors can never disagree about where the
+  // scriptCode starts or how long it is. Because the R1 commitment's variable
+  // run (offset 17, length 20) lies entirely below the offset, it drops out
+  // of `scriptCodeSamples` altogether; only the k1PublicKeyHash run survives,
+  // shifted down by the same offset. That is why region 0x02's payload ends
+  // up 20 bytes (k1PublicKeyHash only), not the 40-byte commitment +
+  // k1PublicKeyHash pair region 0x01 carries.
+  const scriptCodeSamples = samples.map((s) => s.slice(PREIMAGE_SCRIPT_CODE_OFFSET))
+  const scriptCodeLength = scriptCodeSamples[0].length
+  const scriptCodeVariableRuns = findVariableRuns(scriptCodeSamples)
+  const scriptCodeConstantHash = constantHashOf(scriptCodeSamples[0], scriptCodeVariableRuns)
+
+  if (scriptCodeConstantHash !== PINNED_CONSTANT_HASH_V1_SCRIPT_CODE) {
+    throw new VaultError(
+      'template-unknown',
+      `live R1-K1 preimage scriptCode disagrees with the pinned reference (constantHash ${scriptCodeConstantHash} ` +
+        `vs ${PINNED_CONSTANT_HASH_V1_SCRIPT_CODE} expected) — an @bsv/templates upgrade changed the template; ` +
+        'this requires a new pinned version, not a silent reconstruction against stale bytes'
+    )
+  }
+
+  const scriptCodeRegion: TemplateRegion = 0x02
+  referenceBytesByKey.set(versionKey(version, scriptCodeRegion), scriptCodeSamples[0])
+
+  cachedDescriptors = [
+    { version, region, totalLength, variableRuns, constantHash },
+    {
+      version,
+      region: scriptCodeRegion,
+      totalLength: scriptCodeLength,
+      variableRuns: scriptCodeVariableRuns,
+      constantHash: scriptCodeConstantHash
+    }
+  ]
   return cachedDescriptors
 }
 
@@ -260,12 +335,15 @@ export function matchesTemplate(bytes: number[], v: TemplateVersion): boolean {
  * plan's Global Constraints for this decision.
  *
  * The payload is just the bytes of each variable run, concatenated in
- * ascending offset order — for the current region-0x01 version that is
- * commitment(20) ‖ k1PublicKeyHash(20), 40 bytes, making a compressed
- * locking script exactly 7 + 40 = 47 bytes. Nothing here hardcodes that
- * shape though: both directions walk `TemplateVersion.variableRuns`, so a
- * version with different/more runs (e.g. Task 3's region 0x02) is handled
- * by the same code without change.
+ * ascending offset order — for region 0x01 that is commitment(20) ‖
+ * k1PublicKeyHash(20), 40 bytes, making a compressed locking script exactly
+ * 7 + 40 = 47 bytes; for region 0x02 (the preimage scriptCode) that is
+ * k1PublicKeyHash(20) alone — the commitment run doesn't survive the
+ * scriptCode's leading 60-byte cut, see `describeVaultTemplate` — making a
+ * compressed scriptCode exactly 7 + 20 = 27 bytes. Nothing here hardcodes
+ * either shape though: both directions walk `TemplateVersion.variableRuns`,
+ * so a version with different/more runs is handled by the same code without
+ * change.
  * ---------------------------------------------------------------------------
  */
 
@@ -297,23 +375,24 @@ export function isCompressed(bytes: number[]): boolean {
 }
 
 /**
- * Compress a recognised region-0x01 (R1-K1 locking script) template instance
- * down to its 7-byte header plus the concatenated variable-run bytes. A
- * script that does not match any known template — including one that is
- * merely near-miss, per `matchesTemplate`'s exactness — is returned
- * unchanged (a fresh copy, not the header format): this function must never
- * turn an unrecognised script into something that looks compressed.
+ * Compress a recognised template instance of `region` down to its 7-byte
+ * header plus the concatenated variable-run bytes. Bytes that don't match any
+ * known version of `region` — including a merely near-miss, per
+ * `matchesTemplate`'s exactness — are returned unchanged (a fresh copy, not
+ * the header format): this must never turn unrecognised bytes into something
+ * that looks compressed.
  *
  * Awaits `describeVaultTemplate()` itself before consulting `matchesTemplate`
  * so the normal path can never hit that function's "no cached reference"
  * throw — this is always called with the descriptors it just (re)populated
- * the cache for, in the same tick.
+ * the cache for, in the same tick. Shared by `compressScript` (region 0x01)
+ * and `compressScriptCode` (region 0x02) so the two never fork behaviour.
  */
-export async function compressScript(bytes: number[]): Promise<number[]> {
+async function compressForRegion(bytes: number[], region: TemplateRegion): Promise<number[]> {
   const descriptors = await describeVaultTemplate()
 
   for (const v of descriptors) {
-    if (v.region !== 0x01) continue // only the locking-script region compresses here; see compressScriptCode for 0x02
+    if (v.region !== region) continue
     if (!matchesTemplate(bytes, v)) continue
 
     const runs = [...v.variableRuns].sort((a, b) => a.offset - b.offset)
@@ -329,10 +408,33 @@ export async function compressScript(bytes: number[]): Promise<number[]> {
 }
 
 /**
- * Reverse of `compressScript` (and, from Task 3, of `compressScriptCode`):
- * detects the `0xff` header, resolves it against a known template version,
- * and rebuilds the exact original bytes by splicing the header's payload
- * back into a copy of that version's cached reference template.
+ * Compress a recognised region-0x01 (R1-K1 locking script) template
+ * instance. See `compressForRegion` for the shared behaviour and exactness
+ * guarantees.
+ */
+export async function compressScript(bytes: number[]): Promise<number[]> {
+  return compressForRegion(bytes, 0x01)
+}
+
+/**
+ * Compress a recognised region-0x02 (R1-K1 sighash preimage `scriptCode`)
+ * template instance — the piece that makes a SPENDING transaction huge,
+ * since `R1K1Wallet.unlockR1` pushes the whole preimage into the unlocking
+ * script. See `compressForRegion` for the shared behaviour and exactness
+ * guarantees; `expandScript` reverses this the same way it reverses
+ * `compressScript`, dispatching on the header's region byte.
+ */
+export async function compressScriptCode(bytes: number[]): Promise<number[]> {
+  return compressForRegion(bytes, 0x02)
+}
+
+/**
+ * Reverse of both `compressScript` (region 0x01) and `compressScriptCode`
+ * (region 0x02) — one expander for every region, dispatching purely on the
+ * header's region byte: detects the `0xff` header, resolves it against a
+ * known template version, and rebuilds the exact original bytes by splicing
+ * the header's payload back into a copy of that version's cached reference
+ * template.
  *
  * Fails closed in every direction — never returns bytes that are merely
  * approximately right:

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -189,3 +189,173 @@ export function matchesTemplate(bytes: number[], v: TemplateVersion): boolean {
   }
   return true
 }
+
+/*
+ * ---------------------------------------------------------------------------
+ * Compress / expand
+ *
+ * On-wire (and on-disk, for backup) layout of a compressed script, exactly
+ * (pinned by the plan's Global Constraints):
+ *
+ *   0xff (1) ‖ version (1) ‖ region (1) ‖ originalLength (4, big-endian) ‖ payload
+ *
+ * 0xff is OP_INVALIDOPCODE: not a defined opcode anywhere, so a compressed
+ * blob that somehow escaped onto the wire in place of a real locking script
+ * would fail script evaluation outright rather than being interpreted as
+ * some other (spendable, or worse, always-true) script. OP_NOP7 (0xb6) was
+ * explicitly rejected for this role: it IS a valid, defined no-op opcode, so
+ * a compressed script left in place could still pass evaluation. See the
+ * plan's Global Constraints for this decision.
+ *
+ * The payload is just the bytes of each variable run, concatenated in
+ * ascending offset order — for the current region-0x01 version that is
+ * commitment(20) ‖ k1PublicKeyHash(20), 40 bytes, making a compressed
+ * locking script exactly 7 + 40 = 47 bytes. Nothing here hardcodes that
+ * shape though: both directions walk `TemplateVersion.variableRuns`, so a
+ * version with different/more runs (e.g. Task 3's region 0x02) is handled
+ * by the same code without change.
+ * ---------------------------------------------------------------------------
+ */
+
+const HEADER_LENGTH = 7 // marker(1) + version(1) + region(1) + originalLength(4)
+
+function writeUInt32BE(n: number): number[] {
+  return [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]
+}
+
+function readUInt32BE(bytes: number[], offset: number): number {
+  return (
+    ((bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0
+  )
+}
+
+/** Sum of every variable run's length — the payload size a version's header
+ * must be followed by. */
+function payloadLengthOf(v: TemplateVersion): number {
+  return v.variableRuns.reduce((sum, r) => sum + r.length, 0)
+}
+
+/** True iff `bytes` opens with the compressed-script marker. A quick,
+ * length-1 check only — it tells a caller "this looks like a compressed
+ * script, route it to `expandScript`", not "this is a well-formed one".
+ * `expandScript` still validates the rest of the header and throws on
+ * anything malformed; nothing here should be used as a substitute for that. */
+export function isCompressed(bytes: number[]): boolean {
+  return bytes.length > 0 && bytes[0] === TEMPLATE_MARKER
+}
+
+/**
+ * Compress a recognised region-0x01 (R1-K1 locking script) template instance
+ * down to its 7-byte header plus the concatenated variable-run bytes. A
+ * script that does not match any known template — including one that is
+ * merely near-miss, per `matchesTemplate`'s exactness — is returned
+ * unchanged (a fresh copy, not the header format): this function must never
+ * turn an unrecognised script into something that looks compressed.
+ *
+ * Awaits `describeVaultTemplate()` itself before consulting `matchesTemplate`
+ * so the normal path can never hit that function's "no cached reference"
+ * throw — this is always called with the descriptors it just (re)populated
+ * the cache for, in the same tick.
+ */
+export async function compressScript(bytes: number[]): Promise<number[]> {
+  const descriptors = await describeVaultTemplate()
+
+  for (const v of descriptors) {
+    if (v.region !== 0x01) continue // only the locking-script region compresses here; see compressScriptCode for 0x02
+    if (!matchesTemplate(bytes, v)) continue
+
+    const runs = [...v.variableRuns].sort((a, b) => a.offset - b.offset)
+    const payload: number[] = []
+    for (const r of runs) {
+      for (let i = r.offset; i < r.offset + r.length; i++) payload.push(bytes[i])
+    }
+
+    return [TEMPLATE_MARKER, v.version, v.region, ...writeUInt32BE(v.totalLength), ...payload]
+  }
+
+  return bytes.slice()
+}
+
+/**
+ * Reverse of `compressScript` (and, from Task 3, of `compressScriptCode`):
+ * detects the `0xff` header, resolves it against a known template version,
+ * and rebuilds the exact original bytes by splicing the header's payload
+ * back into a copy of that version's cached reference template.
+ *
+ * Fails closed in every direction — never returns bytes that are merely
+ * approximately right:
+ * - fewer than `HEADER_LENGTH` bytes (can't even read a full header):
+ *   throws `template-invalid`.
+ * - a version/region this build's codec has no descriptor for (including a
+ *   `bytes[0]` that isn't the `0xff` marker at all, since that decodes to no
+ *   version this codec issued): throws `template-unknown`.
+ * - a well-known version/region whose `originalLength` field disagrees with
+ *   that version's actual template length, or whose payload is the wrong
+ *   size for that version's variable runs: throws `template-invalid`.
+ *
+ * Awaits `describeVaultTemplate()` itself, both to resolve the header's
+ * version/region and to guarantee the reference bytes it splices from are
+ * cached in this process — the normal path can never hit
+ * `matchesTemplate`-style "no cached reference" failures.
+ */
+export async function expandScript(bytes: number[]): Promise<number[]> {
+  if (bytes.length < HEADER_LENGTH) {
+    throw new VaultError(
+      'template-invalid',
+      `compressed-script header truncated: got ${bytes.length} bytes, need at least ${HEADER_LENGTH}`
+    )
+  }
+  if (bytes[0] !== TEMPLATE_MARKER) {
+    throw new VaultError(
+      'template-unknown',
+      `expected compressed-script marker 0x${TEMPLATE_MARKER.toString(16)}, got 0x${bytes[0].toString(16)}`
+    )
+  }
+
+  const version = bytes[1]
+  const region = bytes[2]
+  const originalLength = readUInt32BE(bytes, 3)
+
+  const descriptors = await describeVaultTemplate()
+  const match = descriptors.find((d) => d.version === version && d.region === region)
+  if (!match) {
+    throw new VaultError('template-unknown', `no known template for version ${version} region ${region}`)
+  }
+
+  if (originalLength !== match.totalLength) {
+    throw new VaultError(
+      'template-invalid',
+      `originalLength ${originalLength} disagrees with version ${version} region ${region}'s length ${match.totalLength}`
+    )
+  }
+
+  const payload = bytes.slice(HEADER_LENGTH)
+  const expectedPayloadLength = payloadLengthOf(match)
+  if (payload.length !== expectedPayloadLength) {
+    throw new VaultError(
+      'template-invalid',
+      `compressed payload is ${payload.length} bytes, expected ${expectedPayloadLength} for version ${version} region ${region}`
+    )
+  }
+
+  const reference = referenceBytesByKey.get(versionKey(match.version, match.region))
+  if (!reference) {
+    // describeVaultTemplate() above just (re)populated this for every
+    // descriptor it returned, and `match` came from that same array — this
+    // is unreachable in practice. Fail closed rather than reconstruct from
+    // nothing if it ever somehow isn't.
+    throw new VaultError(
+      'template-invalid',
+      `no cached reference bytes for version ${version} region ${region}`
+    )
+  }
+
+  const result = reference.slice()
+  let payloadOffset = 0
+  const runs = [...match.variableRuns].sort((a, b) => a.offset - b.offset)
+  for (const r of runs) {
+    for (let i = 0; i < r.length; i++) result[r.offset + i] = payload[payloadOffset + i]
+    payloadOffset += r.length
+  }
+  return result
+}

--- a/services/vault/types.ts
+++ b/services/vault/types.ts
@@ -19,6 +19,12 @@ export type VaultErrorCode =
    * something a user can cause or fix. Distinct from 'wrong-key', which
    * vaultErrorFromNative may reclassify to 'nfc-lost'. */
   | 'template-invalid'
+  /** A compressed script's header names a version/region this build's codec
+   * has no template for — e.g. written by a newer build, or corrupted beyond
+   * the header's own internal consistency (see 'template-invalid' for the
+   * case where the version/region IS known but the header disagrees with
+   * what that version reconstructs). */
+  | 'template-unknown'
   | 'serial-mismatch'
   | 'user-cancelled'
   | 'not-enrolled'

--- a/services/vault/vaultTemplateArtifact.ts
+++ b/services/vault/vaultTemplateArtifact.ts
@@ -1,0 +1,169 @@
+/**
+ * Vendored, gzip-compressed reference copy of the R1-K1 vault locking
+ * script's constant template -- see the "vendor the template" decision in
+ * services/vault/templateCodec.ts.
+ *
+ * WHY THIS EXISTS: templateCodec.ts used to rebuild the ~960 KB template from
+ * whatever @bsv/templates happens to be installed (package.json pins
+ * ^1.10.0, so a routine npm i can move it), and only pinned a SHA-256 of the
+ * result. That meant a routine dependency bump that drifted the template
+ * even by one byte made describeVaultTemplate() throw 'template-unknown' for
+ * EVERY previously-compressed record -- including ones stored long before
+ * the bump -- because the 40 payload bytes those records carry were being
+ * spliced into a freshly (and now differently) rebuilt reference, not the
+ * one they were originally compressed against. The 40 bytes needed to
+ * reconstruct exactly were sitting right there in the stored blob the whole
+ * time; nothing about the drift made them unrecoverable. Re-pinning the hash
+ * to match the new library output would "fix" the throw but silently
+ * reconstruct OLD records against the NEW template -- wrong bytes, no error.
+ *
+ * The fix is to stop asking the installed library at all. This asset IS the
+ * version-2 reference template, byte for byte, frozen at the moment this
+ * codec was verified against a real mined mainnet transaction. Reconstruction
+ * reads only this file (via templateCodec.ts's ensureTemplateCache); an
+ * @bsv/templates upgrade -- or removal -- cannot change what a previously
+ * (or newly) compressed record expands back into. PINNED_CONSTANT_HASH in
+ * templateCodec.ts now serves as a CROSS-CHECK on this vendored asset (and,
+ * separately, on whatever @bsv/templates is currently installed, via the
+ * "installed library still matches the vendored template" test in
+ * templateCodec.test.ts) rather than the only thing standing between a
+ * dependency bump and an unrecoverable deposit record.
+ *
+ * PROVENANCE: built from @bsv/templates@1.10.0's R1K1Wallet().lock() output
+ * (R1K1_LOCK_LEN = 959,632 bytes), with both variable runs -- offsets 17..36
+ * (the 20-byte R1 commitment) and 959609..959628 (the 20-byte
+ * k1PublicKeyHash) -- zeroed before compression. Those runs are never read
+ * back out of this asset: expandScript always overwrites them with a
+ * compressed record's own payload bytes, so it does not matter that this
+ * copy holds zeros there rather than any particular real script's values.
+ * Zeroing them here (rather than vendoring one arbitrary instance's real
+ * random values) is what lets PINNED_CONSTANT_HASH's masking-then-hashing
+ * cross-check reduce to a plain SHA-256 of this asset, as documented there.
+ *
+ * Regenerating this file (only ever appropriate alongside minting a new
+ * template version, never as a routine refresh):
+ *   1. const bytes = (await new R1K1Wallet().lock(new Array(20).fill(0), new Array(20).fill(0))).toBinary()
+ *   2. zero bytes[17..36] and bytes[959609..959628] (they already are, with
+ *      the all-zero inputs above, but do it explicitly -- see templateCodec.ts)
+ *   3. gzip level 9 (measured: 959,632 -> 8,059 bytes) -- Node's zlib is fine
+ *      for this one-off, maintainer-run build step; only the RUNTIME decode
+ *      path needs to avoid it (see below)
+ *   4. base64-encode the gzip bytes and split into the lines below
+ *
+ * Decoded at runtime with fflate's gunzipSync, never Node's zlib or the DOM
+ * DecompressionStream -- this file ships to React Native/Hermes, which has
+ * neither. fflate is already a real dependency (see package.json and
+ * patches/@bsv+templates+1.10.0.patch, which moved @bsv/templates itself
+ * onto fflate.gunzipSync for exactly this reason) and is a standard gzip
+ * decoder, so it reads gzip bytes produced by any conformant encoder
+ * (verified: Node zlib's output here decodes byte-identically via
+ * fflate.gunzipSync).
+ *
+ * Do not hand-edit the payload below.
+ */
+
+/** Gzip-compressed bytes of the 959,632-byte zeroed reference template,
+ * base64-encoded and split across lines for a readable diff. Join and
+ * base64-decode, then gunzip, to recover the raw template -- see
+ * ensureTemplateCache in templateCodec.ts. */
+export const VAULT_TEMPLATE_GZIP_BASE64: string = [
+  'H4sIAAAAAAACE+3de5CcZZ0F4O4stau1f2ypSFREZ0RUFBREQC5igoIoKs50zyUkhEgEggkBxelMX5hJIhpUiMZMCA4hBEXDXVQEA+FiVFTACHgDg6Ii',
+  'QUQEiUFAwK3JFrtgWUs+qWHPMk9PVbqKOn3q/S79PjOT8Otaadn0vv75c8ptp3fWmwPnbFn6B48Ta/3z51SHqs3m4JzWYN8WEzf9t/Nq55ZaHYPNZmvg',
+  '2fvUVy4NzGu/Y/mxU1Y99/zzVu5970kHLpwz5ebW1UtmT9hvp6OPv2fi0OAW15QWt53ZtvWM/d9w123bvO+snuNm9xzytyc/Bpe0T5y42w0nTb3pqr1W',
+  'HPDl9bdeeNljfxcpzV7a7Otf3Fpaa1vxFGUr+p+6rXVya2jJ0PyZ5ba5Y+AyzSq3tYYG59Tmz+mY29kaaA3U5s8pb7u4Y+6249pL12wxODTxnuOP3mm/',
+  'CbOXXN26ecqchQeedO/eK887/7mrphy7/I7yTp2NgZEXlScOtI+rX3nEwEO3Xn5+14rDlqxd8O//Nu60R9btuPY1t0y6f97krR4cf+oFR53dHHnML7cv',
+  'a7WXnuoxUG4f7GvOL09Y1ppQepqPgfKEwb5KozlcaZw9Rt57zXLbYGuMHOtYOc7+z3bW2zu2m/7ImmtXbThh+fiVFzy8fvV/b1ylUmnT8xnDm5sb7mp0',
+  'DPbXOhe0KgtOa87rXDpzrJzJWn9nvdJoLWl/0tb/hEf58bP0OC5Fsv2VAuGhzY+2HTjtplfvs/favR64qHL9Rf+6zeGrP35qreuKu7925+I9z71512sO',
+  'Xrz5XbX+WoFFdtYLhBUrVqxYsWLFihUrziiWlZWVlbVZy8rKysrKysrKysrKysrK+mWFkyYrKysrKysrKysrKysrK/s/2WZfrXPprAX9T/2K1lBret+R',
+  'c2bUCtUv66w/dfqM4UpjuKdRbQy3hiv12pKn/v9/Hu+v1guEFStWrFixYsWKFSvOKJaVlZWV/b/JokixYsWKFStWrFixYsWKFStWrFixYsWKFcf+xaDT',
+  '9v/3L2qdYqfYDeRCW4RFOLqxdAPZMv2rEfeE97Nib2g7mxvetXOKnTZ3plNsEb6rcZkVeyu5M5012ysPXDp0PL3iaqOv1j3y2eGb/Yquenej0ijwggkz',
+  'x994/6932PcdD65ef8f0sybcP+dfjp+34927rPjzmXvsd/Opa0456PZ9f/PYSwZPW3jn3e9q/cfyrV63dpeemTtPXXvdJRNm7H5Vx8ZKo9qYWWnMbG76',
+  'apXbBsfIB7uPlQ+wbzU3/25q33DM9hsPmLbjuoXr9t/4nPsu3u3x5LhSqfToyPPiznpnvaPQVLJKvb/AJ9dX680Cn01fZBmFhr8XmgDXVW8WiFcLZPub',
+  'rQLp3kKH2Fmv1rsaRfqr9ZM3P1zgmtearQLpQqekWejWqxYZ+l/gXFQafZVGX3XTn81ms1IfVypf2rl0eq2/Uu8qfBlqXY0i99ukQndnb6F0q7tR4AS3',
+  'uoqk+zvrlXq12JmpFDoz1ULpSr2/Uu+u9xRaUaEjrjZG6f1VaRR5g1WKbQqbvmEZjWVXijU3m80ZYAITmJ4OTH8rgQlMYAITmMAUBNNjYAITmMAEJjAl',
+  'wfQomMAEJjCBCUxJMD0CJjCBCUxgAlMSTH8FE5jABCYwgSkJpofBBCYwgQlMYEqC6SEwgQlMYAITmJJgehBMYAITmMAEpiSY/gImMIEJTGACUxJMD4AJ',
+  'TGACE5jAlATTRjCBCUxgAhOYkmD6M5jABCYwgQlMSTBtABOYwAQmMIEpCab7wQQmMIEJTGBKgulPYAITmMAEJjAlwXQfmMAEJjCBCUxJMN0LJjCBCUxg',
+  'AlMSTH8EE5jABCYwgSkJpnvABCYwgQlMYEqC6Q9gAhOYwAQmMCXBdDeYwAQmMIEJTEkw/R5MYAITmMAEpiSY7gITmMAEJjCBKQmm34EJTGACE5jAlATT',
+  'nWACE5jABCYwJcG0HkxgAhOYwASmJJjuABOYwAQmMIEpCabfgglMYAITmMCUBNPtYAITmMAEJjAlwfQbMIEJTGACE5iSYPo1mMAEJjCBCUxJMP0KTGAC',
+  'E5jABKYkmG4DE5jABCYwgSkJpl+CCUxgAhOYwJQE0y/ABCYwgQlMYEqC6VYwgQlMYAITmJJgWgcmMIEJTGACUxJMPwcTmMAEJjCBKQmmW8AEJjCBCUxg',
+  'SoLpZjCBCUxgAhOYkmD6GZjABCYwgQlMSTD9FExgAhOYwASmJJh+AiYwgQlMYAJTEkw/BhOYwAQmMIEpCaYfgQlMYAITmMCUBNNNYAITmMAEJjAlwXQj',
+  'mMAEJjCBCUxJMN0AJjCBCUxgAlMSTD8EE5jABCYwgSkJprVgAhOYwAQmMCXB9AMwgQlMYAITmJJguh5MYAITmMAEpiSYrgMTmMAEJjCBKQmma8EEJjCB',
+  'CUxgSoLp+2ACE5jABCYwJcH0PTCBCUxgAhOYkmD6LpjABCYwgQlMSTBdAyYwgQlMYAJTEkzfAROYwAQmMIEpCaZvgwlMYAITmMCUBNO3wAQmMIEJTGBK',
+  'gmkNmMAEJjCBCUxJMH0TTGACE5jABKYkmK4GE5jABCYwgSkJpqvABCYwgQlMYEqC6UowgQlMYAITmJJgugJMYAITmMAEpiSYVoMJTGACE5jAlATT5WAC',
+  'E5jABCYwJcF0GZjABCYwgQlMSTCtAhOYwAQmMIEpCaZvgAlMYAITmMCUBNOlYAITmMAEJjAlwXQJmMAEJjCBCUxJMH0dTGACE5jABKYkmC4GE5jABCYw',
+  'gSkJpq+BCUxgAhOYwJQE01fBBCYwgQlMYEqC6StgAhOYwAQmMCXBdBGYwAQmMIEJTEkwfRlMYAITmMAEpiSYLgQTmMAEJjCBKQmmC8AEJjCBCUxgSoLp',
+  'fDCBCUxgAhOYkmA6D0xgAhOYwASmJJjOBROYwAQmMIEpCaZzwAQmMIEJTGBKgulsMIEJTGACE5iSYFoJJjCBCUxgAlMSTF8CE5jABCYwgSkJpi+CCUxg',
+  'AhOYwJQE01lgAhOYwAQmMCXB9AUwgQlMYAITmJJg+jyYwAQmMIEJTEkwnQkmMIEJTGACUxJMK8AEJjCBCUxgSoLpDDCBCUxgAhOYkmBaDiYwgQlMYAJT',
+  'EkyngwlMYAITmMCUBNMyMIEJTGACE5iSYDoNTGACE5jABKYkmIbBBCYwgQlMYEqC6XNgAhOYwAQmMCXBdCqYwAQmMIEJTEkwLQUTmMAEJjCBKQmmU8AE',
+  'JjCBCUxgSoJpCZjABCYwgQlMSTANgQlMYAITmMCUBNNiMIEJTGACE5iSYPosmMAEJjCBCUxJMC0CE5jABCYwgSkJps+ACUxgAhOYwJQE06fBBCYwgQlM',
+  'YEqCaSGYwAQmMIEJTEkwnQwmMIEJTGACUxJMJ4EJTGACE5jAlATTp8AEJjCBCUxgSoLpk2ACE5jABCYwJcH0CTCBCUxgAhOYkmA6EUxgAhOYwASmJJgW',
+  'gAlMYAITmMCUBNPHwQQmMIEJTGBKguljYAITmMAEJjAlwXQCmMAEJjCBCUxJMH0UTGACE5jABKYkmOaDCUxgAhOYwJQE0zwwgQlMYAITmJJgmgsmMIEJ',
+  'TGACUxBM5UEucYlLXOISl4JcGuASl7jEJS5xKcil47nEJS5xiUtcCnKpxSUucYlLXOJSkEtNLnGJS1ziEpeCXGpwiUtc4hKXuBTkUp1LXOISl7jEpSCX',
+  '+rnEJS5xiUtcCnJpDpe4xCUucYlLQS7VuMQlLnGJS1wKcqmPS1ziEpe4xKUglz7CJS5xiUtc4lKQS8dxiUtc4hKXuBTk0oe5xCUucYlLXApy6UNc4hKX',
+  'uMQlLgW5dCyXuMQlLnGJS0EuHcMlLnGJS1ziUpBLs7nEJS5xiUtcCnLpaC5xiUtc4hKXglyaxSUucYlLXOJSkEszucQlLnGJS1wKcumDXOISl7jEJS4F',
+  'uXQUl7jEJS5xiUtBLs3gEpe4xCUucSnIpSO5xCUucYlLXApy6QgucYlLXOISl4JcOpxLXOISl7jEpSCXPsAlLnGJS1ziUpBL07nEJS5xiUtcCnLpMC5x',
+  'iUtc4hKXglx6P5e4xCUucYlLQS5N4xKXuMQlLnEpyKVDucQlLnGJS1wKcmkql7jEJS5xiUtBLh3CJS5xiUtc4lKQS1O4xCUucYlLXApyaTKXuMQlLnGJ',
+  'S0EuHcwlLnGJS1ziUpBLk7jEJS5xiUtcCnKpl0tc4hKXuMSlIJd6uMQlLnGJS1wKcqmbS1ziEpe4xKUgl7q4xCUucYlLXApyqcolLnGJS1ziUpBLFS5x',
+  'iUtc4hKXglzq5BKXuMQlLnEpyKUOLnGJS1ziEpeCXHofl7jEJS5xiUtBLh3EJS5xiUtc4lKQS+/lEpe4xCUucSnIpfdwiUtc4hKXuBTk0ru5xCUucYlL',
+  'XApy6UAucYlLXOISl4JceheXuMQlLnGJS0EuvZNLXOISl7jEpSCXDuASl7jEJS5xKcild3CJS1ziEpe4FOTS/lziEpe4xCUuBbm0H5e4xCUucYlLQS69',
+  'nUtc4hKXuMSlIJfexiUucYlLXOJSkEv7colLXOISl7gU5NJELnGJS1ziEpeCXJrAJS5xiUtc4lKQS2/lEpe4xCUucSnIpX24xCUucYlLXApy6S1c4hKX',
+  'uMQlLgW5tDeXuMQlLnGJS0Eu7cUlLnGJS1ziUpBLe3KJS1ziEpe4FOTSHlziEpe4xCUuBbn0Zi5xiUtc4hKXglzanUtc4hKXuMSlIJd24xKXuMQlLnEp',
+  'yKVducQlLnGJS1wKculNXOISl7jEJS4FubQLl7jEJS5xiUtBLr2RS1ziEpe4xKUgl3bmEpe4xCUucSnIpZ24xCUucYlLXApy6Q1c4hKXuMQlLgW59Hou',
+  'cYlLXOISl4Jc2pFLXOISl7jEpSCXduASl7jEJS5xKcil13GJS1ziEpe4FOTSa7nEJS5xiUtcCnJpey5xiUtc4hKXglx6DZe4xCUucYlLQS69mktc4hKX',
+  'uMSlIJdexSUucYlLXOJSkEvbcYlLXOISl7gU5NIrucQlLnGJS1wKcmlbLnGJS1ziEpeCXHoFl7jEJS5xiUtBLrVziUtc4hKXuBTkUhuXuMQlLnGJS0Eu',
+  'vZxLXOISl7jEpSCXXsYlLnGJS1ziUpBL23CJS1ziEpe4FOTSS7nEJS5xiUtcCnJpay5xiUtc4hKXglx6CZe4xCUucYlLQS69mEtc4hKXuMSlIJdexCUu',
+  'cYlLXOJSkEvjucQlLnGJS1wKcmkrLnGJS1ziEpeCXHohl7jEJS5xiUtBLm3JJS5xiUtc4lKQSy/gEpe4xCUucSnIpedziUtc4hKXuBTk0vO4xCUucYlL',
+  'XMpxaRqWsIQlLGEJSzksHYolLGEJS1jCUg5LU7GEJSxhCUtYymHpECxhCUtYwhKWcliagiUsYQlLWMJSDkuTsYQlLGEJS1jKYelgLGEJS1jCEpZyWJqE',
+  'JSxhCUtYwlIOS71YwhKWsIQlLOWw1IMlLGEJS1jCUg5L3VjCEpawhCUs5bDUhSUsYQlLWMJSDktVLGEJS1jCEpZyWKpgCUtYwhKWsJTDUieWsIQlLGEJ',
+  'SzksLaQSlahEJSpRKeeHpaXTRy7Apq233l3vrffUe0cTpymF7tDJxXCaVAin3iLp2SPnp6vePZo8dRdKd43w1FufhKe/O4mjxVNXYZ6qjUXVxqLhEdcq',
+  'je5NX8ACFrD+abCazWZ3vXvkp4QiO32hDbK1uMge3DWKa6kWWku1UR3FtVQKraXY9+X9RXYMvXr16tWrV69evXqfoV5ZWVlZWXu1rKysrKysrKysrKys',
+  'rKysrN+Z69WrV69evXr16tWrV69evXr16tWrV69evXr16tWrV69evXqfqTW0+mrFJqXUmoVm6BUaadQsNsxv00yQvla5fW65bbCv1OoYbDZbA8/ep7F0',
+  'qAOzZs2qNGY2x84Rj6FDHSi3DY6BwyyXBua1xspxNts7tpv+yJprV204Yfn4lRc8vH71E3fxJ+3c7RuO2X7jAdN2XLdw3f4bn3Pfxbs9nhxXKpUeHXle',
+  'PDJjq8OsNLPSzEp7GsM9x5XKPgvB1GlTp//3dZg6DSYwPaMw/a0EJjCBCUxgAlMQTI+BCUxgAhOYwJQE06NgAhOYwAQmMCXB9AiYwAQmMIEJTEkw/RVM',
+  'YAITmMAEpiSYHgYTmMAEJjCBKQmmh8AEJjCBCUxgSoLpQTCBCUxgAhOYkmD6C5jABCYwgQlMSTA9ACYwgQlMYAJTEkwbwQQmMIEJTGBKgunPYAITmMAE',
+  'JjAlwbQBTGACE5jABKYkmO4HE5jABCYwgSkJpj+BCUxgAhOYwJQE031gAhOYwAQmMCXBdC+YwAQmMIEJTEkw/RFMYAITmMAEpiSY7gETmMAEJjCBKQmm',
+  'P4AJTGACE5jAlATT3WACE5jABCYwJcH0ezCBCUxgAhOYkmC6C0xgAhOYwASmJJh+ByYwgQlMYAJTEkx3gglMYAITmMCUBNN6MIEJTGACE5iSYLoDTGAC',
+  'E5jABKYkmH4LJjCBCUxgAlMSTLeDCUxgAhOYwJQE02/ABCYwgQlMYEqC6ddgAhOYwAQmMCXB9CswgQlMYAITmJJgug1MYAITmMAEpiSYfgkmMIEJTGAC',
+  'UxJMvwATmMAEJjCBKQmmW8EEJjCBCUxgSoJpHZjABCYwgQlMSTD9HExgAhOYwASmJJhuAROYwAQmMIEpCaabwQQmMIEJTGBKgulnYAITmMAEJjAlwfRT',
+  'MIEJTGACE5iSYPoJmMAEJjCBCUxJMP0YTGACE5jABKYkmH4EJjCBCUxgAlMSTDeBCUxgAhOYwJQE041gAhOYwAQmMCXBdAOYwAQmMIEJTEkw/RBMYAIT',
+  'mMAEpiSY1oIJTGACE5jAlATTD8AEJjCBCUxgSoLpejCBCUxgAhOYkmC6DkxgAhOYwASmJJiuBROYwAQmMIEpCabvgwlMYAITmMCUBNP3wAQmMIEJTGBK',
+  'gum7YAITmMAEJjAlwXQNmMAEJjCBCUxJMH0HTGACE5jABKYkmL4NJjCBCUxgAlMSTN8CE5jABCYwgSkJpjVgAhOYwAQmMCXB9E0wgQlMYAITmJJguhpM',
+  'YAITmMAEpiSYrgITmMAEJjCBKQmmK8EEJjCBCUxgSoLpCjCBCUxgAhOYkmBaDSYwgQlMYAJTEkyXgwlMYAITmMCUBNNlYAITmMAEJjAlwbQKTGACE5jA',
+  'BKYkmL4BJjCBCUxgAlMSTJeCCUxgAhOYwJQE0yVgAhOYwAQmMCXB9HUwgQlMYAITmJJguhhMYAITmMAEpiSYvgYmMIEJTGACUxJMXwUTmMAEJjCBKQmm',
+  'r4AJTGACE5jAlATTRWACE5jABCYwJcH0ZTCBCUxgAhOYkmC6EExgAhOYwASmJJguABOYwAQmMIEpCabzwQQmMIEJTGBKguk8MIEJTGACE5iSYDoXTGAC',
+  'E5jABKYkmM4BE5jABCYwgSkJprPBBCYwgQlMYEqCaSWYwAQmMIEJTEkwfQlMYAITmMAEpiSYvggmMIEJTGACUxJMZ4EJTGACE5jAlATTF8AEJjCBCUxg',
+  'SoLp82ACE5jABCYwJcF0JpjABCYwgQlMSTCtABOYwAQmMIEpCaYzwAQmMIEJTGBKgmk5mMAEJjCBCUxJMJ0OJjCBCUxgAlMSTMvABCYwgQlMYEqC6TQw',
+  'gQlMYAITmJJgGgYTmMAEJjCBKQmmz4EJTGACE5jAlATTqWACE5jABCYwJcG0FExgAhOYwASmJJhOAROYwAQmMIEpCaYlYAITmMAEJjAlwTQEJjCBCUxg',
+  'AlMSTIvBBCYwgQlMYEqC6bNgAhOYwAQmMCXBtAhMYAITmMAEpiSYPgMmMIEJTGACUxJMnwYTmMAEJjCBKQmmhWACE5jABCYwJcF0MpjABCYwgQlMSTCd',
+  'BCYwgQlMYAJTEkyfAhOYwAQmMIEpCaZPgglMYAITmMCUBNMnwAQmMIEJTGBKgulEMIEJTGACE5iSYFoAJjCBCUxgAlMSTB8HE5jABCYwgSkJpo+BCUxg',
+  'AhOYwJQE0wlgAhOYwAQmMCXB9FEwgQlMYAITmJJgmg8mMIEJTGACUxJM88AEJjCBCUxgSoJpLpjABCYwgQlMQTCVB7nEJS5xiUtcCnJpgEtc4hKXuMSl',
+  'IJeO5xKXuMQlLnEpyKUWl7jEJS5xiUtBLjW5xCUucYlLXApyqcElLnGJS1ziUpBLdS5xiUtc4hKXglzq5xKXuMQlLnEpyKU5XOISl7jEJS4FuVTjEpe4',
+  'xCUucSnIpT4ucYlLXOISl4Jc+giXuMQlLnGJS0EuHcclLnGJS1ziUpBLH+YSl7jEJS5xKcilD3GJS1ziEpe4FOTSsVziEpe4xCUuBbl0DJe4xCUucYlL',
+  'QS7N5hKXuMQlLnEpyKWjucQlLnGJS1wKcmkWl7jEJS5xiUtBLs3kEpe4xCUucSnIpQ9yiUtc4hKXuBTk0lFc4hKXuMQlLgW5NINLXOISl7jEpSCXjuQS',
+  'l7jEJS5xKcilI7jEJS5xiUtcCnLpcC5xiUtc4hKXglz6AJe4xCUucYlLQS5N5xKXuMQlLnEpyKXDuMQlLnGJS1wKcun9XOISl7jEJS4FuTSNS1ziEpe4',
+  'xKUglw7lEpe4xCUucSnIpalc4hKXuMQlLgW5dAiXuMQlLnGJS0EuTeESl7jEJS5xKcilyVziEpe4xCUuBbl0MJe4xCUucYlLQS5N4hKXuMQlLnEpyKVe',
+  'LnGJS1ziEpeCXOrhEpe4xCUucSnIpW4ucYlLXOISl4Jc6uISl7jEJS5xKcilKpe4xCUucYlLQS5VuMQlLnGJS1wKcqmTS1ziEpe4xKUglzq4xCUucYlL',
+  'XApy6X1c4hKXuMQlLgW5dBCXuMQlLnGJS0EuvZdLXOISl7jEpSCX3sMlLnGJS1ziUpBL7+YSl7jEJS5xKcilA7nEJS5xiUtcCnLpXVziEpe4xCUuBbn0',
+  'Ti5xiUtc4hKXglw6gEtc4hKXuMSlIJfewSUucYlLXOJSkEv7c4lLXOISl7gU5NJ+XOISl7jEJS4FufR2LnGJS1ziEpeCXHobl7jEJS5xiUtBLu3LJS5x',
+  'iUtc4lKQSxO5xCUucYlLXApyaQKXuMQlLnGJS0EuvZVLXOISl7jEpSCX9uESl7jEJS5xKcilt3CJS1ziEpe4FOTS3lziEpe4xCUuBbm0F5e4xCUucYlL',
+  'QS7tySUucYlLXOJSkEt7cIlLXOISl7gU5NKbucQlLnGJS1wKcml3LnGJS1ziEpeCXNqNS1ziEpe4xKUgl3blEpe4xCUucSnIpTdxiUtc4hKXuBTk0i5c',
+  '4hKXuMQlLgW59EYucYlLXOISl4Jc2plLXOISl7jEpSCXduISl7jEJS5xKcilN3CJS1ziEpe4FOTS67nEJS5xiUtcCnJpRy5xiUtc4hKXglzagUtc4hKX',
+  'uMSlIJdexyUucYlLXOJSkEuv5RKXuMQlLnEpyKXtucQlLnGJS1wKcuk1XOISl7jEJS4FufRqLnGJS1ziEpeCXHoVl7jEJS5xiUtBLm3HJS5xiUtc4lKQ',
+  'S6/kEpe4xCUucSnIpW25xCUucYlLXApy6RVc4hKXuMQlLgW51M4lLnGJS1ziUpBLbVziEpe4xCUuBbn0ci5xiUtc4hKXglx6GZe4xCUucYlLQS5twyUu',
+  'cYlLXOJSkEsv5RKXuMQlLnEpyKWtucQlLnGJS1wKcuklXOISl7jEJS4FufRiLnGJS1ziEpeCXHoRl7jEJS5xiUtBLo3nEpe4xCUucSnIpa24xCUucYlL',
+  'XApy6YVc4hKXuMQlLgW5tCWXuMQlLnGJS0EuvYBLXOISl7jEpSCXns8lLnGJS1ziUpBLz+MSl7jEJS5xKcelaVjCEpawhCUs5bB0KJawhCUsYQlLOSxN',
+  'xRKWsIQlLGEph6VDsIQlLGEJS1jKYWkKlrCEJSxhCUs5LE3GEpawhCUsYSmHpYOxhCUsYQlLWMphaRKWsIQlLGEJSzks9WIJS1jCEpawlMNSD5awhCUs',
+  'YQlLOSx1YwlLWMISlrCUw1IXlrCEJSxhCUs5LFWxhCUsYQlLWMphqYIlLGEJS1jCUg5LnVjCEpawhCUs5bC0kEpUohKVqESlnB+Wlk4fuQCbtt56d723',
+  '3lPvHU2cphS6QycXw2lSIZx6i6Rnj5yfrnr3aPLUXSjdNcJTb30Snv7uJI4WT12Feao2FlUbi4ZHXKs0ujd9AQtYwPqnwWo2m9317pGfEors9IU2yNbi',
+  'Intw1yiupVpoLdVGdRTXUim0lmLfl/cX2TH06tWrV69evXr16n2GemVlZWVl7dWysrKysrKysrKysrKysrKyfmeuV69evXr16tWrV69evXr16tWrV69e',
+  'vXr16tWrV69evXr16n2m1tDqqxWblFJrFpqhV2ikUbPYML9NM0H6WuX2ueW2wb5Sq2Ow2WwNPHufxtKhDswqtw2OgeMslwbmtcbKcTZd02fdcVbqnfVl',
+  'm/7obw23+ocWdda76oVGR/UUifcUmi9WZHJZpdAqioywqhca0tVVH7WxTJ3FVlItNO6uyEKMh9KrV69evXr16tVrPJSsrKysrL1aVlZWVlZWVlZWVlZW',
+  'VlbW7zX06tWrV69evXr16tWrV69evXr16tWrV69evXr16tWrV69evcZDbfZ4qCKLKDZJqrvYmJChIs39Q0UmVywpMp2jyDoafV2Nvv8aVNXqrC9pNZf0',
+  'tXdsN/2RNdeu2nDC8vErL3h4/eonNj3p1bNmNZsLho/sOL12zpalf/A48fwZ/wk8uGjfkKQOAA=='
+].join('')
+
+/** Length of the raw (post-gunzip) template -- equal to R1K1_LOCK_LEN in
+ * services/vault/r1k1.ts. Recorded here too so templateCodec.ts can
+ * sanity-check the inflated size without importing r1k1.ts just for this one
+ * constant. */
+export const VAULT_TEMPLATE_RAW_LENGTH = 959_632


### PR DESCRIPTION
Replaces the vault-backup streaming rethink. The cap was never the problem, and neither was the transport — the representation was.

## The insight

An R1-K1 vault locking script is 959,632 bytes of which **40 vary**. Verified against the mined mainnet transaction `6c947ae3825b7a7ea1c61a27b64b39c5b8b424d460677addb896285222982697`:

```
built length                          : 959,632  (= R1K1_LOCK_LEN)
bytes differing between two instances : 40
variable runs                         : 17-36 (20B), 959609-959628 (20B)
real vs freshly built                 : 40 bytes differ
diffs OUTSIDE the known-variable runs : 0        <-- template identical
```

- offsets 17..36 — `r1Commitment` = `hash160(r1PublicKey || salt)`
- offsets 959,609..959,628 — `k1PublicKeyHash`
- the other 959,592 bytes are byte-identical template

The spend side matters as much. `R1K1Wallet.unlockR1` commits `lockingBytes.subarray(60)`, so the preimage `scriptCode` is the locking script minus its first 60 bytes — 959,572. **One pinned template reconstructs both regions.**

## Measured savings

| | verbatim | compressed |
|---|---|---|
| deposit `rawTx` | 959,836 B | **255 B** (3,764x) |
| deposit as a backup record (base64) | 1,279,784 B | 340 B |
| `outputs.lockingScript` | 959,632 B | 51 B |
| R1 preimage | 959,733 B | 192 B |
| R1 unlocking script | 959,871 B | 327 B |
| withdrawal tx, 1 vault input | 960,075 B | 531 B (1,808x) |
| withdrawal tx, 2 vault inputs | 1,919,946 B | 858 B |
| backup per user per year (1 vault tx/month) | 15.4 MB | ~4.0 KB |
| wallet DB per vault tx (stored twice) | 1,919,468 B | 306 B |

For context: one vault transaction currently occupies **26.6% of a real 7.2 MB wallet database**.

## Why 0xff and not OP_NOP7

`OP_NOP7` (0xb6) is a **valid** opcode that evaluates as a no-op, so a script left in compressed form could pass evaluation and reach the chain. `0xff` is undefined and invalid everywhere, so a compressed script fails closed and can never be **spent**.

Precisely: output scripts are not executed at creation, so a compressed script *can* be mined into an output — it simply becomes unspendable, i.e. burnt. `0xff` guarantees it cannot be spent; preventing such an output from being created is procedural, not cryptographic.

## Wire format (v2)

```
0xff              1 byte   marker (OP_INVALIDOPCODE)
version           1 byte   monotonic, never reused
region            1 byte   0x01 = locking script, 0x02 = preimage scriptCode
originalLength    4 bytes  big-endian, validated on expand
checksum          4 bytes  first 4 bytes of SHA-256 of the ORIGINAL bytes
payload           N bytes
```

Region 0x01 payload is `commitment(20) || k1PublicKeyHash(20)` — 51 bytes total. Region 0x02 carries `k1PublicKeyHash(20)` only (31 bytes), because `subarray(60)` drops the commitment window; the commitment is recoverable since the unlocking script pushes `publicKey` and `salt` verbatim.

The checksum is verified **after** reconstruction — reconstruct, hash, compare, then return — so a corrupted payload throws instead of yielding a structurally perfect but wrong script. It detects accidental corruption only; it is **not a MAC**, since anyone able to rewrite a stored blob can recompute it.

v1 (a 7-byte header, no checksum) existed only during development on this branch, was never persisted, and is rejected as an unknown version. There is no migration gap.

## Durability: the template is vendored

Reconstruction keys off a **vendored 8,059-byte gzipped copy** of the template, not off the installed `@bsv/templates`. `package.json` pins `^1.10.0`, so a routine `npm i` could otherwise have made every stored record unreadable — and the tempting fix, re-pinning the hash, would have silently expanded old records against the *new* template.

A reviewer proved this holds by patching the installed library to differ, then confirming compress/expand still round-trip byte-exactly from the vendored bytes **while the drift-detection tests failed loudly**. Drift is detected; reconstruction no longer depends on it.

## Memory

References are `Uint8Array`, inflated on first use, cached for a batch, released via `releaseTemplateCache()`. Measured with `--expose-gc`: **+0.96 MB** retained while a batch is open, back to baseline after release; cold `describeVaultTemplate` **6.5 ms**, warm 0.025 ms. Previously ~15.5-16.4 MB retained as `number[]` at 114-200 ms cold.

## What is verified, and by whom

Independent reviewers on the strongest model, each checking rather than trusting:

- **Byte-exactness on real on-chain data.** Reviewers fetched the transaction from WhatsOnChain, re-derived the txid, and confirmed the digests. One spliced compress -> expand output back into the real 959,836-byte `rawTx` and recomputed the txid bit-identically.
- **The vendored artifact alone reproduces the chain.** Decoded outside Jest and outside `@bsv/templates`, spliced in the real commitment and `k1PublicKeyHash`, and got `f5f78dcf…` — the mainnet digest.
- **The variable runs are structurally guaranteed**, traced to `substituteConstructorSlots` as a pure byte splice and cross-checked against the library's own `validateLockingScript`.
- **`subarray(60)` is pinned.** `unlockR1(...).estimateLength(...) === 959871`; patching the vendored offset 60 -> 61 makes it fail, confirmed independently twice.
- **Corruption throws.** Flipping any payload or checksum byte throws `template-invalid`; near misses are declined, including a 16-position fencepost audit around every run boundary in both regions.
- **No secret leakage**: no logging in the module; errors carry only lengths and integers.

**1028 tests / 85 suites** green (990 at branch point). `tsc --noEmit` clean apart from two pre-existing `funding-app/` errors.

## Scope: this is the codec only

**Nothing calls it yet.** The `StorageExpoSQLite` wiring that realises these savings is deliberately a separate change: the codec is provable in isolation, whereas the wiring touches every read path and a missed expansion silently corrupts money data.

Decisions already taken for that change: skip-and-log on expansion failure (with a visible indicator so an understated balance cannot pass as correct), and a wire-boundary guard enforcing that compressed bytes never reach broadcast, BEEF, or txid computation.

One measured constraint to carry into it: per-record compress ~57 ms and expand ~55 ms on desktop Node, so a 12-record batch is ~567 ms of unyielding synchronous work over `number[]`. Not a regression — it is the pre-existing array shape plus one SHA-256 pass — but it needs sizing against this project's "no >100 ms JS block" goal on Hermes.

## Deliberately deferred

`isCompressed`'s 0xff invariant beyond the compress-side refusal; a region-0x02 same-length corruption test (shares its path with 0x01); repetitive `try/catch` blocks in the test file.

Spec: `docs/superpowers/specs/2026-08-18-vault-script-template-compression-design.md`
Docs: `docs/vault-script-compression.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)