### PR TITLE
fix(wallet): one wallet screen, one balance read

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -147,11 +147,29 @@ export default function RootLayout() {
                               contentStyle: { backgroundColor }
                             }}
                           >
-                            <Stack.Screen name="index" />
+                            {/* One Browser, ever — and one wallet screen, ever
+                                (below). Both routes take no params, so there is
+                                only ever one identity to collapse, which is what
+                                makes `dangerouslySingular` safe here.
+
+                                Without it, every navigation to a route already in
+                                the stack APPENDS another live instance rather than
+                                returning to the existing one: this expo-router
+                                emits a bare NAVIGATE, and react-navigation's stack
+                                router only reuses a route when it is already on
+                                top, is addressed with `pop`, or — as here — has an
+                                id to match on. A default browser navigates to '/'
+                                on every external link tap (see +native-intent and
+                                useDeepLinking), so a day of link taps while the
+                                wallet screen was open stacked six live wallet
+                                screens and as many Browsers, each re-running its
+                                own multi-second listOutputs balance read whenever
+                                the wallet context rebuilt. */}
+                            <Stack.Screen name="index" dangerouslySingular />
                             <Stack.Screen name="config" />
                             <Stack.Screen name="auth/mnemonic" />
                             <Stack.Screen name="transactions" />
-                            <Stack.Screen name="wallet" />
+                            <Stack.Screen name="wallet" dangerouslySingular />
                             <Stack.Screen name="wallet-config" />
                             <Stack.Screen name="vault" />
                             <Stack.Screen name="vault-recover" />

--- a/app/wallet.tsx
+++ b/app/wallet.tsx
@@ -134,64 +134,81 @@ export default function WalletScreen() {
   const inFlightRef = useRef(false)
 
   // ── balance ─────────────────────────────────────────────────────────
-  // TEMPORARY DIAGNOSTICS (remove once the stale-balance cause is confirmed).
-  // Deliberately outside render — a per-render log flood has starved the JS
-  // thread in this app before.
-  const refreshBalance = useCallback(
-    async (source = 'unknown') => {
-      if (!managers.permissionsManager) {
-        console.log('[balance] skipped, no permissionsManager · source=%s', source)
-        return
-      }
-      const startedAt = Date.now()
+  /**
+   * One balance read at a time, shared by every caller.
+   *
+   * `listOutputs({ basket: specOpWalletBalance })` is a serialised SQL scan —
+   * seconds on a real wallet — so two overlapping reads do not merely duplicate
+   * work, they QUEUE, and the second returns the figure the first already had.
+   * Mount, invalidation and pull-to-refresh all funnel through this latch, so a
+   * caller arriving mid-read awaits that read instead of starting another.
+   */
+  const inFlightBalanceRef = useRef<Promise<void> | null>(null)
+  const refreshBalance = useCallback(async () => {
+    const pm = managers.permissionsManager
+    if (!pm) return
+    if (inFlightBalanceRef.current) return await inFlightBalanceRef.current
+    const read = (async () => {
       try {
-        const { totalOutputs } = await managers.permissionsManager.listOutputs(
+        const { totalOutputs } = await pm.listOutputs(
           { basket: sdk.specOpWalletBalance },
           adminOriginator
         )
         const total = totalOutputs ?? 0
-        console.log(
-          '[balance] read ok · source=%s · total=%s · rawTotalOutputs=%s · ms=%d',
-          source,
-          total,
-          String(totalOutputs),
-          Date.now() - startedAt
-        )
         setBalance(total)
         await AsyncStorage.setItem(balanceCacheKey, String(total))
-      } catch (e) {
-        // Keep the last known balance on screen rather than blanking it. The
-        // error was silently swallowed before, which is indistinguishable from
-        // a successful read that returned the same figure.
-        console.log(
-          '[balance] read FAILED · source=%s · ms=%d · %s',
-          source,
-          Date.now() - startedAt,
-          (e as Error)?.message ?? String(e)
-        )
+      } catch {
+        // Keep the last known balance on screen rather than blanking it: a
+        // failed read is not "zero satoshis".
       }
-    },
-    [managers.permissionsManager, adminOriginator, balanceCacheKey]
-  )
+    })()
+    inFlightBalanceRef.current = read
+    // Cleared here rather than in a `finally` inside the body: a synchronous
+    // throw from listOutputs would run that finally BEFORE the assignment
+    // above, leaving a settled promise latched forever.
+    void read.finally(() => {
+      if (inFlightBalanceRef.current === read) inFlightBalanceRef.current = null
+    })
+    return await read
+  }, [managers.permissionsManager, adminOriginator, balanceCacheKey])
+
+  /**
+   * The effects below key off DATA changes, never off `refreshBalance`'s
+   * identity.
+   *
+   * `refreshBalance` is rebuilt whenever the wallet context rebuilds, because
+   * `managers.permissionsManager` is one of its deps. With that callback in an
+   * effect's dependency list, a mid-session rebuild made every live instance of
+   * this screen fire a fresh multi-second balance read — the "mount" effect was
+   * never mount-only. What the effects actually need is *whether* a wallet
+   * exists, so they depend on that instead.
+   */
+  const refreshBalanceRef = useRef(refreshBalance)
+  useEffect(() => {
+    refreshBalanceRef.current = refreshBalance
+  }, [refreshBalance])
+  const hasWallet = managers.permissionsManager != null
 
   useEffect(() => {
     let cancelled = false
     ;(async () => {
       // Show the cached figure immediately so the screen never opens empty.
       const cached = await AsyncStorage.getItem(balanceCacheKey)
-      if (!cancelled && cached != null) setBalance(Number(cached))
-      console.log('[balance] mount effect · cached=%s', String(cached))
-      await refreshBalance('mount')
+      if (cancelled) return
+      if (cached != null) setBalance(Number(cached))
+      await refreshBalanceRef.current()
     })()
     return () => {
       cancelled = true
     }
-  }, [refreshBalance, balanceCacheKey])
+    // `hasWallet` covers the cold start where this screen mounts before the
+    // wallet finishes building; `balanceCacheKey` covers a network switch.
+  }, [balanceCacheKey, hasWallet])
 
   /**
    * Returning to this screen refetches the balance and the activity list once.
    *
-   * This screen stays mounted while /pay and /get-paid sit on top of it in the
+   * This screen stays mounted while /pay and /vault sit on top of it in the
    * stack, so neither the mount effect above nor the activity effect below runs
    * again on the way back. `txStatusVersion` covers writes that go through the
    * wallet, but relying on it alone leaves the user's own money looking stale
@@ -208,7 +225,6 @@ export default function WalletScreen() {
   const firstFocusRef = useRef(true)
   useFocusEffect(
     useCallback(() => {
-      console.log('[balance] FOCUS fired · first=%s', String(firstFocusRef.current))
       if (firstFocusRef.current) {
         firstFocusRef.current = false
         return
@@ -222,18 +238,12 @@ export default function WalletScreen() {
   // which the mount effect above already covers.
   const balanceMountedRef = useRef(false)
   useEffect(() => {
-    console.log(
-      '[balance] invalidation effect · txStatusVersion=%d · focusVersion=%d · firstRun=%s',
-      txStatusVersion,
-      focusVersion,
-      String(!balanceMountedRef.current)
-    )
     if (!balanceMountedRef.current) {
       balanceMountedRef.current = true
       return
     }
-    void refreshBalance('invalidation')
-  }, [txStatusVersion, focusVersion, refreshBalance])
+    void refreshBalanceRef.current()
+  }, [txStatusVersion, focusVersion])
 
   // ── activity ────────────────────────────────────────────────────────
   const fetchActions = useCallback(
@@ -313,7 +323,7 @@ export default function WalletScreen() {
   const onRefresh = useCallback(async () => {
     setRefreshing(true)
     try {
-      const [result] = await Promise.all([fetchActions(0), refreshBalance('pull-to-refresh'), fetchOfflineRows()])
+      const [result] = await Promise.all([fetchActions(0), refreshBalance(), fetchOfflineRows()])
       if (result) {
         setActions(result.actions as ActivityAction[])
         offsetRef.current = result.actions.length
@@ -511,7 +521,7 @@ export default function WalletScreen() {
     () => (
       <View>
         <TouchableOpacity
-          onPress={() => void refreshBalance('tap')}
+          onPress={() => void refreshBalance()}
           activeOpacity={0.7}
           style={styles.balanceBlock}
           accessibilityLabel={t('wallet_balance_refresh')}

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -359,16 +359,10 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
    * a short trailing timer instead of per call.
    */
   const ledgerBumpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const noteLedgerChanged = useCallback((source = 'unknown') => {
-    // TEMPORARY DIAGNOSTICS (remove once the stale-balance cause is confirmed).
-    if (ledgerBumpTimerRef.current) {
-      console.log('[ledger] write coalesced into pending bump · source=%s', source)
-      return
-    }
-    console.log('[ledger] write · source=%s · bump in 120ms', source)
+  const noteLedgerChanged = useCallback(() => {
+    if (ledgerBumpTimerRef.current) return
     ledgerBumpTimerRef.current = setTimeout(() => {
       ledgerBumpTimerRef.current = null
-      console.log('[ledger] BUMP txStatusVersion')
       setTxStatusVersion(v => v + 1)
     }, 120)
   }, [])
@@ -829,7 +823,7 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
           const bound = original.bind(wallet)
           ;(wallet as any)[method] = async (...callArgs: any[]) => {
             const result = await bound(...callArgs)
-            noteLedgerChanged(method)
+            noteLedgerChanged()
             return result
           }
         }
@@ -1755,8 +1749,11 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
         console.warn('[backupAttestation.clearAll]', err)
       })
 
+      // dismissAll() leaves exactly one screen on the stack, so this has to
+      // REPLACE it: push() would add a second /index on top of the one already
+      // there and leave two Browsers mounted.
       router.dismissAll()
-      router.push('/')
+      router.replace('/')
     })()
   }, [deleteAllWalletKeys])
 

--- a/hooks/useDeepLinking.ts
+++ b/hooks/useDeepLinking.ts
@@ -44,10 +44,13 @@ export function useDeepLinking() {
         }
       }
 
-      // Navigate to browser if not already there. Use navigate() (reuses the
-      // existing /index route) NOT push() — +native-intent already routes http
-      // launches to '/', so push() here mounts a SECOND Browser on top (duplicate
-      // that re-renders forever on every WalletContext/SSE tick = the storm).
+      // Navigate to browser if not already there. navigate() NOT push():
+      // +native-intent already routes http launches to '/', so push() here would
+      // mount a SECOND Browser on top (a duplicate that re-renders forever on
+      // every WalletContext/SSE tick = the storm). navigate() alone is not
+      // enough either — a bare NAVIGATE appends a route it cannot see as "the
+      // same one", so /index is declared `dangerouslySingular` in app/_layout to
+      // make this reuse the Browser that is already mounted.
       if (pathnameRef.current !== '/') {
         router.navigate('/')
       }

--- a/services/vault/ceremony.ts
+++ b/services/vault/ceremony.ts
@@ -312,12 +312,6 @@ export class CeremonyController {
 
   private async run(): Promise<void> {
     const driver = this.deps.getDriver()
-    // TEMPORARY DIAGNOSTICS (remove with the others in this file).
-    console.log(
-      '[vault] ceremony run · driver=%s · sessionBased=%s',
-      driver ? 'present' : 'NULL',
-      String(driver?.sessionBased)
-    )
     if (!driver) {
       this.failAll(new VaultError('driver-unavailable'))
       this.running = false
@@ -335,18 +329,6 @@ export class CeremonyController {
     let armed = false
     try {
       const meta = await this.deps.store.getMeta()
-      // TEMPORARY DIAGNOSTICS (remove with the others in this file). The v3
-      // fields are what the R1-K1 signer needs; a pre-v3 enrollment would show
-      // r1PublicKey=undefined here.
-      console.log(
-        '[vault] meta · present=%s · v=%s · slot=%s · serial=%s · hasR1PublicKey=%s · hasXpub=%s',
-        String(!!meta),
-        String((meta as any)?.v),
-        String(meta?.slot),
-        String(meta?.yubiSerial),
-        String(!!(meta as any)?.r1PublicKey),
-        String(!!(meta as any)?.xpub)
-      )
       if (!meta) throw new VaultError('not-enrolled')
 
       // NFC (session-based) collects the PIN BEFORE the tap and verifies it in
@@ -369,21 +351,11 @@ export class CeremonyController {
       // Session-based transports keep listening: see the method doc above.
       if (!driver.sessionBased) this.unsubscribeKeyEvents(session)
     } catch (e) {
-      // TEMPORARY DIAGNOSTICS (remove once the arm failure is identified).
-      // Everything that is not a VaultError is relabelled 'driver-unavailable'
-      // below, which renders as "YubiKey support is unavailable on this
-      // device" — so a completely unrelated failure is indistinguishable from
-      // a genuinely absent driver. Log the real thing before it is masked.
-      if (!(e instanceof VaultError)) {
-        console.log(
-          '[vault] arm failed with a NON-VaultError, masking as driver-unavailable · name=%s · message=%s',
-          (e as Error)?.name ?? typeof e,
-          (e as Error)?.message ?? String(e)
-        )
-        console.log('[vault] stack:', (e as Error)?.stack ?? '(none)')
-      } else {
-        console.log('[vault] arm failed · code=%s · %s', e.code, e.message ?? '')
-      }
+      // Anything that is not a VaultError gets relabelled 'driver-unavailable',
+      // which renders as "YubiKey support is unavailable on this device" — so
+      // the original message is carried across as the detail rather than being
+      // dropped, otherwise an unrelated failure is indistinguishable from a
+      // genuinely absent driver.
       const err = e instanceof VaultError ? e : new VaultError('driver-unavailable', String(e))
       if (err.code === 'user-cancelled') {
         this.set({ phase: 'idle' })
@@ -486,20 +458,11 @@ export class CeremonyController {
     this.subscribeKeyEvents(driver, session)
     this.set({ phase: 'waiting-for-key' })
     const waiter = (this.attachWaiter = defer<void>())
-    // TEMPORARY DIAGNOSTICS (remove with the others in this file).
-    console.log('[vault] openTapSession · driver.start(), waiting for attach')
     driver.start()
     await waiter.promise
     this.throwIfCancelled()
-    console.log('[vault] key attached · calling getKeyInfo')
     this.set({ phase: 'connecting' })
     const info = await driver.getKeyInfo()
-    console.log(
-      '[vault] getKeyInfo ok · serial=%s · expected=%s · fw=%s',
-      info.serial,
-      meta.yubiSerial,
-      info.firmwareVersion
-    )
     if (info.serial !== meta.yubiSerial) {
       throw new VaultError('serial-mismatch', `Expected key ${meta.yubiSerial}`)
     }


### PR DESCRIPTION
Device logs showed **six live instances of the wallet screen**, each running its own `listOutputs({ basket: specOpWalletBalance })`:

```
[balance] mount effect · cached=5804605      x6
[balance] read ok · source=mount · ms=5334
[balance] read ok · source=mount · ms=5753
... (six reads, ~5.7s each)
```

~34s of serialised SQL for one screen, on the thread the whole app shares. In the same log a balance read took 54,498ms and header sync fell 94s behind. It grew through the day — pairs in the morning, six by evening.

## Why instances accumulated

Navigating to a route already in the stack **appends another live copy of it**. This expo-router emits a bare `NAVIGATE`, and react-navigation's stack router only reuses an existing route when it is already on top, is addressed with `pop`, or has an id to match on (`StackRouter.tsx`, `PUSH`/`NAVIGATE` case).

This app is a default browser: every external link tap routes to `/` (`app/+native-intent.ts`, then `hooks/useDeepLinking.ts`). So a tap taken while the wallet screen was open left that screen mounted and pushed a fresh Browser above it — which also explains the `[render] Browser #13 … #20` storm in the same log. The next trip to the wallet added another wallet.

`/index` and `/wallet` take no params, so there is only one identity to collapse: both are now declared `dangerouslySingular`. That is what the comment in `useDeepLinking` already claimed `navigate()` did.

## Why each instance read more than once

The "mount" effect and the invalidation effect both had `refreshBalance` in their deps, and that callback is rebuilt whenever the wallet context rebuilds (`managers.permissionsManager` is a dep) — so a mid-session rebuild fired **two** reads per live instance, and `firstRun=true` per instance was never the whole story.

- both effects now key off what they need (`hasWallet`, `balanceCacheKey`, `txStatusVersion`, `focusVersion`) and reach the callback through a ref
- `refreshBalance` single-flights: overlapping callers await the read in progress rather than queueing an identical one behind it

## Also

- `logout()` ran `dismissAll()` then `push('/')`, leaving two Browsers mounted — `dismissAll()` already leaves `/index` as the only screen, so it replaces now.
- **Removed the `TEMPORARY DIAGNOSTICS` that reached master**: the per-read `[balance]` logs, the `[ledger]` bump logs in `WalletContext`, and the `[vault]` arm-path logs in `services/vault/ceremony.ts`. The vault catch block's note about non-`VaultError`s being masked as `driver-unavailable` is kept as a comment — the original message was already carried through as the `VaultError` detail.

## Verification

- `npx jest` — 990 passed, 83 suites
- `npx tsc --noEmit` — clean apart from the two pre-existing `funding-app/vite.config.ts` errors
- `npx eslint` on the touched files — no new warnings

Not device-verified: the fix is navigation-stack behaviour, so the confirmation to look for on device is a single `[balance]`-free wallet screen with one read per invalidation. Worth watching the next real session for it.

## Not fixed here

The read itself is ~5.7s over 145 outputs. That is a wallet-toolbox `specOpWalletBalance` scan, not a screen bug, and it is the next thing worth attacking — six of them was the emergency, one of them is still slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)