### PR TITLE
perf(balance): stop the balance read queueing behind the network

### DIFF
--- a/__tests__/__mocks__/expo-sqlite.js
+++ b/__tests__/__mocks__/expo-sqlite.js
@@ -1,0 +1,12 @@
+// expo-sqlite ships untransformed ESM and is a native module, so it cannot load
+// under jest. Tests that exercise StorageExpoSQLite inject their own database
+// handle (see __tests__/walletBalanceSql.test.ts, which injects one backed by
+// node:sqlite) — nothing should ever reach these.
+const native = () => {
+  throw new Error('expo-sqlite is native: inject a database handle in tests')
+}
+module.exports = {
+  openDatabaseAsync: native,
+  openDatabaseSync: native,
+  deleteDatabaseAsync: native
+}

--- a/__tests__/walletBalanceSql.test.ts
+++ b/__tests__/walletBalanceSql.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The wallet balance query, run against the REAL schema.
+ *
+ * node:sqlite gives us the actual SQLite engine in jest, so these tests execute
+ * `createTables()` and then the same SQL the app runs on device — a filter that
+ * silently stopped matching, or a column that a migration renamed, fails here
+ * rather than showing the user the wrong money.
+ */
+import { DatabaseSync } from 'node:sqlite'
+import { createTables } from '@/storage/schema/createTables'
+import { readWalletBalance, BALANCE_BASKET } from '@/storage/methods/walletBalanceSql'
+import { StorageExpoSQLite } from '@/storage/StorageExpoSQLite'
+import { listOutputsSql } from '@/storage/methods/listOutputsSql'
+import { sdk } from '@bsv/wallet-toolbox-mobile'
+
+/** expo-sqlite's async surface over node:sqlite's sync one — only the handful of
+ * methods the code under test calls. */
+function adapt(db: DatabaseSync) {
+  return {
+    execAsync: async (sql: string) => {
+      db.exec(sql)
+    },
+    getAllAsync: async (sql: string, params: unknown[] = []) => db.prepare(sql).all(...(params as never[])),
+    getFirstAsync: async (sql: string, params: unknown[] = []) =>
+      db.prepare(sql).get(...(params as never[])) ?? null,
+    runAsync: async (sql: string, params: unknown[] = []) => db.prepare(sql).run(...(params as never[]))
+  }
+}
+
+type Db = ReturnType<typeof adapt>
+
+const NOW = '2026-08-18T00:00:00.000Z'
+let raw: DatabaseSync
+let db: Db
+let storage: StorageExpoSQLite
+
+/** Insert a transaction in `status` and one output in `basketId` against it. */
+async function seedOutput(opts: {
+  status: string
+  basketId: number
+  satoshis: number
+  spendable?: boolean
+  userId?: number
+  vout?: number
+}): Promise<void> {
+  const userId = opts.userId ?? 1
+  await db.runAsync(
+    `INSERT INTO transactions (created_at, updated_at, userId, status, reference, isOutgoing, satoshis, txid)
+     VALUES (?, ?, ?, ?, ?, 0, ?, ?)`,
+    [NOW, NOW, userId, opts.status, `ref-${Math.random()}`, opts.satoshis, 'a'.repeat(64)]
+  )
+  const { transactionId } = (await db.getFirstAsync(
+    'SELECT MAX(transactionId) as transactionId FROM transactions',
+    []
+  )) as { transactionId: number }
+  await db.runAsync(
+    `INSERT INTO outputs (created_at, updated_at, userId, transactionId, basketId, spendable, change,
+       vout, satoshis, providedBy, txid, lockingScript)
+     VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 'you', ?, ?)`,
+    [
+      NOW,
+      NOW,
+      userId,
+      transactionId,
+      opts.basketId,
+      opts.spendable === false ? 0 : 1,
+      opts.vout ?? 0,
+      opts.satoshis,
+      'b'.repeat(64),
+      new Uint8Array(25)
+    ]
+  )
+}
+
+async function seedBasket(name: string, userId = 1): Promise<number> {
+  await db.runAsync(
+    `INSERT INTO output_baskets (created_at, updated_at, userId, name, numberOfDesiredUTXOs, minimumDesiredUTXOValue)
+     VALUES (?, ?, ?, ?, 6, 1000)`,
+    [NOW, NOW, userId, name]
+  )
+  const { basketId } = (await db.getFirstAsync('SELECT MAX(basketId) as basketId FROM output_baskets', [])) as {
+    basketId: number
+  }
+  return basketId
+}
+
+beforeEach(async () => {
+  raw = new DatabaseSync(':memory:')
+  db = adapt(raw)
+  await createTables(db as never)
+  // The real provider, over the real engine: only the native handle is swapped
+  // out, so these tests run the SQL StorageExpoSQLite actually builds.
+  storage = new StorageExpoSQLite({ chain: 'test' } as never)
+  ;(storage as unknown as { db: unknown }).db = db
+  // node:sqlite enforces foreign keys, so the two users these tests reference
+  // have to exist.
+  for (const identityKey of ['02' + 'a'.repeat(62), '02' + 'b'.repeat(62)]) {
+    await db.runAsync('INSERT INTO users (created_at, updated_at, identityKey) VALUES (?, ?, ?)', [
+      NOW,
+      NOW,
+      identityKey
+    ])
+  }
+})
+
+afterEach(() => {
+  raw.close()
+})
+
+describe('readWalletBalance', () => {
+  it('sums only spendable default-basket outputs in a counted transaction state', async () => {
+    const dflt = await seedBasket(BALANCE_BASKET)
+    const vault = await seedBasket('admin vault')
+
+    await seedOutput({ status: 'completed', basketId: dflt, satoshis: 1000 })
+    await seedOutput({ status: 'unproven', basketId: dflt, satoshis: 200, vout: 1 })
+    await seedOutput({ status: 'nosend', basketId: dflt, satoshis: 30, vout: 2 })
+    // Excluded, each for its own reason.
+    await seedOutput({ status: 'completed', basketId: dflt, satoshis: 9_000, spendable: false, vout: 3 })
+    await seedOutput({ status: 'failed', basketId: dflt, satoshis: 9_000, vout: 4 })
+    await seedOutput({ status: 'unprocessed', basketId: dflt, satoshis: 9_000, vout: 5 })
+    await seedOutput({ status: 'completed', basketId: vault, satoshis: 9_000, vout: 6 })
+    await seedOutput({ status: 'completed', basketId: dflt, satoshis: 9_000, userId: 2, vout: 7 })
+
+    expect(await readWalletBalance(storage, 1)).toBe(1230)
+  })
+
+  it('is zero, not null, for a wallet whose basket exists but holds nothing spendable', async () => {
+    const dflt = await seedBasket(BALANCE_BASKET)
+    await seedOutput({ status: 'completed', basketId: dflt, satoshis: 500, spendable: false })
+
+    expect(await readWalletBalance(storage, 1)).toBe(0)
+  })
+
+  it('returns null — not 0 — when the default basket does not exist yet', async () => {
+    // A wallet still building. 0 here would flash over the cached figure.
+    expect(await readWalletBalance(storage, 1)).toBeNull()
+  })
+
+  it('scopes to the asking user', async () => {
+    await seedBasket(BALANCE_BASKET, 1)
+    const theirs = await seedBasket(BALANCE_BASKET, 2)
+    await seedOutput({ status: 'completed', basketId: theirs, satoshis: 7777, userId: 2 })
+
+    expect(await readWalletBalance(storage, 1)).toBe(0)
+    expect(await readWalletBalance(storage, 2)).toBe(7777)
+  })
+})
+
+describe('the queries behind the balance', () => {
+  /** Every SQL string the provider sent, in order. */
+  function recordSql(): string[] {
+    const seen: string[] = []
+    const getAll = db.getAllAsync
+    db.getAllAsync = async (sql: string, params: unknown[] = []) => {
+      seen.push(sql)
+      return await getAll(sql, params)
+    }
+    const getFirst = db.getFirstAsync
+    db.getFirstAsync = async (sql: string, params: unknown[] = []) => {
+      seen.push(sql)
+      return await getFirst(sql, params)
+    }
+    return seen
+  }
+
+  it('never fetches lockingScript for a noScript caller', async () => {
+    const dflt = await seedBasket(BALANCE_BASKET)
+    await seedOutput({ status: 'completed', basketId: dflt, satoshis: 1000 })
+
+    const seen = recordSql()
+    const outputs = await storage.findOutputs({ partial: { userId: 1 }, noScript: true } as never)
+
+    expect(outputs).toHaveLength(1)
+    expect(outputs[0].lockingScript).toBeUndefined()
+    // The blob is 959,632 bytes for a vault output — this is the whole point:
+    // it must not cross the bridge only to be dropped.
+    const rowQuery = seen.find(q => q.includes('FROM "outputs"'))!
+    expect(rowQuery).not.toContain('lockingScript')
+    expect(rowQuery).toContain('"satoshis"')
+    // Projected from the live schema, so a migration's new column still arrives.
+    expect(rowQuery).toContain('"customInstructions"')
+  })
+
+  it('still returns the script when the caller wants it', async () => {
+    const dflt = await seedBasket(BALANCE_BASKET)
+    await seedOutput({ status: 'completed', basketId: dflt, satoshis: 1000 })
+
+    const outputs = await storage.findOutputs({ partial: { userId: 1 } } as never)
+    expect(outputs[0].lockingScript).toBeDefined()
+  })
+
+  it('answers the wallet-balance specOp with an aggregate, not a row scan', async () => {
+    const dflt = await seedBasket(BALANCE_BASKET)
+    await seedOutput({ status: 'completed', basketId: dflt, satoshis: 1000 })
+    await seedOutput({ status: 'unproven', basketId: dflt, satoshis: 234, vout: 1 })
+
+    const seen = recordSql()
+    const r = await listOutputsSql(storage, { userId: 1, identityKey: 'k' } as never, {
+      basket: sdk.specOpWalletBalance,
+      tags: [],
+      tagQueryMode: 'any',
+      limit: 10,
+      offset: 0
+    } as never)
+
+    expect(r).toEqual({ totalOutputs: 1234, outputs: [] })
+    expect(seen.some(q => q.includes('SUM("satoshis")'))).toBe(true)
+    // No query that would pull the rows themselves back into JS.
+    expect(seen.some(q => q.startsWith('SELECT *') && q.includes('"outputs"'))).toBe(false)
+  })
+})

--- a/app/wallet.tsx
+++ b/app/wallet.tsx
@@ -50,6 +50,7 @@ import ActivityRow, { type ActivityAction } from '@/components/wallet/ActivityRo
 import { showToast } from '@/components/ui/Toast'
 import { exportTransactionsAsCsv } from '@/utils/exportTransactions'
 import { findOfflineActions, type OfflineActionRow } from '@/storage/methods/offlineActions'
+import { readWalletBalance } from '@/storage/methods/walletBalanceSql'
 import tabStore from '@/stores/TabStore'
 import WalletLockNotice from '@/components/security/WalletLockNotice'
 
@@ -137,24 +138,34 @@ export default function WalletScreen() {
   /**
    * One balance read at a time, shared by every caller.
    *
-   * `listOutputs({ basket: specOpWalletBalance })` is a serialised SQL scan —
-   * seconds on a real wallet — so two overlapping reads do not merely duplicate
-   * work, they QUEUE, and the second returns the figure the first already had.
    * Mount, invalidation and pull-to-refresh all funnel through this latch, so a
    * caller arriving mid-read awaits that read instead of starting another.
    */
   const inFlightBalanceRef = useRef<Promise<void> | null>(null)
   const refreshBalance = useCallback(async () => {
-    const pm = managers.permissionsManager
-    if (!pm) return
     if (inFlightBalanceRef.current) return await inFlightBalanceRef.current
     const read = (async () => {
       try {
-        const { totalOutputs } = await pm.listOutputs(
-          { basket: sdk.specOpWalletBalance },
-          adminOriginator
-        )
-        const total = totalOutputs ?? 0
+        // Straight to our own SQLite, deliberately NOT through the wallet's
+        // listOutputs: every call through WalletStorageManager queues on one
+        // FIFO reader lock, and the monitor holds that lock across network
+        // broadcasts — so this read used to wait on whatever the monitor was
+        // doing rather than on the database. See storage/methods/walletBalanceSql.
+        // The wallet's own path stays as the fallback for the window before
+        // storage and the user id are known.
+        let total: number | null = null
+        if (storage && walletUserId != null) {
+          total = await readWalletBalance(storage, walletUserId)
+        }
+        if (total == null) {
+          const pm = managers.permissionsManager
+          if (!pm) return
+          const { totalOutputs } = await pm.listOutputs(
+            { basket: sdk.specOpWalletBalance },
+            adminOriginator
+          )
+          total = totalOutputs ?? 0
+        }
         setBalance(total)
         await AsyncStorage.setItem(balanceCacheKey, String(total))
       } catch {
@@ -164,13 +175,13 @@ export default function WalletScreen() {
     })()
     inFlightBalanceRef.current = read
     // Cleared here rather than in a `finally` inside the body: a synchronous
-    // throw from listOutputs would run that finally BEFORE the assignment
-    // above, leaving a settled promise latched forever.
+    // throw from the read would run that finally BEFORE the assignment above,
+    // leaving a settled promise latched forever.
     void read.finally(() => {
       if (inFlightBalanceRef.current === read) inFlightBalanceRef.current = null
     })
     return await read
-  }, [managers.permissionsManager, adminOriginator, balanceCacheKey])
+  }, [storage, walletUserId, managers.permissionsManager, adminOriginator, balanceCacheKey])
 
   /**
    * The effects below key off DATA changes, never off `refreshBalance`'s
@@ -187,7 +198,9 @@ export default function WalletScreen() {
   useEffect(() => {
     refreshBalanceRef.current = refreshBalance
   }, [refreshBalance])
-  const hasWallet = managers.permissionsManager != null
+  // Either route to a figure counts: the direct read needs storage and the user
+  // id, the fallback needs the permissions manager.
+  const hasWallet = (storage != null && walletUserId != null) || managers.permissionsManager != null
 
   useEffect(() => {
     let cancelled = false

--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
     "moduleNameMapper": {
       "^react-native-reanimated$": "<rootDir>/__tests__/__mocks__/reanimated.js",
       "^react-native-worklets$": "<rootDir>/node_modules/react-native-worklets/lib/module/mock.js",
-      "^expo-audio$": "<rootDir>/__tests__/__mocks__/expo-audio.js"
+      "^expo-audio$": "<rootDir>/__tests__/__mocks__/expo-audio.js",
+      "^expo-sqlite$": "<rootDir>/__tests__/__mocks__/expo-sqlite.js"
     },
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|react-native-reanimated|react-native-gesture-handler|react-native-worklets|expo-modules-core|@noble/secp256k1|@noble/curves|@noble/hashes)/)",

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -329,11 +329,13 @@ export class StorageExpoSQLite extends StorageProvider {
       trx?: TrxToken
     },
     pkCol: string,
-    extraClauses?: { conditions: string[]; params: any[] }
+    extraClauses?: { conditions: string[]; params: any[] },
+    columns?: string[]
   ): Promise<T[]> {
     const db = this.getDB()
     const { sql: whereSql, params } = this.buildWhere(args.partial)
-    let query = `SELECT * FROM "${table}" ${whereSql}`
+    const projection = columns ? columns.map(c => `"${c}"`).join(', ') : '*'
+    let query = `SELECT ${projection} FROM "${table}" ${whereSql}`
 
     if (args.since) {
       query += `${whereSql ? ' AND' : ' WHERE'} updated_at >= ?`
@@ -376,6 +378,52 @@ export class StorageExpoSQLite extends StorageProvider {
     }
     const result = (await db.getFirstAsync(query, params)) as any
     return result?.count || 0
+  }
+
+  /**
+   * The same shape as sqlCount, for a SUM over one column — so a total can be
+   * computed by SQLite instead of by marshalling every row into JS to add it up.
+   * `column` is never caller-supplied; it names a schema column literally.
+   */
+  private async sqlSum(
+    table: string,
+    column: string,
+    args: { partial: Record<string, any>; since?: Date; trx?: TrxToken },
+    extraClauses?: { conditions: string[]; params: any[] }
+  ): Promise<{ count: number; total: number }> {
+    const db = this.getDB()
+    const { sql: whereSql, params } = this.buildWhere(args.partial)
+    let query = `SELECT COUNT(*) as count, COALESCE(SUM("${column}"), 0) as total FROM "${table}" ${whereSql}`
+
+    if (args.since) {
+      query += `${whereSql ? ' AND' : ' WHERE'} updated_at >= ?`
+      params.push(this.validateDateForWhere(args.since))
+    }
+    if (extraClauses) {
+      for (const c of extraClauses.conditions) {
+        query += `${whereSql || args.since ? ' AND' : ' WHERE'} ${c}`
+      }
+      params.push(...extraClauses.params)
+    }
+    const result = (await db.getFirstAsync(query, params)) as any
+    return { count: result?.count || 0, total: result?.total || 0 }
+  }
+
+  /**
+   * Column names of a table, cached for the life of this connection.
+   *
+   * Read from the database rather than hardcoded so that a column added by a
+   * later migration cannot silently disappear from reads that project columns
+   * explicitly (see findOutputs' noScript path).
+   */
+  private tableColumnsCache = new Map<string, string[]>()
+  private async tableColumns(table: string): Promise<string[]> {
+    const cached = this.tableColumnsCache.get(table)
+    if (cached) return cached
+    const rows = (await this.getDB().getAllAsync(`PRAGMA table_info("${table}")`, [])) as { name: string }[]
+    const names = rows.map(r => r.name)
+    this.tableColumnsCache.set(table, names)
+    return names
   }
 
   private async sqlInsert(table: string, entity: Record<string, any>, pkCol: string): Promise<number> {
@@ -733,13 +781,13 @@ export class StorageExpoSQLite extends StorageProvider {
     return this.validateEntities(rows, undefined, ['isDeleted'])
   }
 
-  async findOutputs(args: FindOutputsArgs, tagIds?: number[], isQueryModeAll?: boolean): Promise<TableOutput[]> {
-    if ((args.partial as any).lockingScript) {
-      throw new Error('Outputs may not be found by lockingScript value.')
-    }
-    const partial = { ...args.partial } as any
-
-    // Build base query
+  /** The txStatus and tag filters shared by every outputs query — one
+   * definition so a find, a count and a sum can never drift apart. */
+  private outputExtraClauses(
+    args: FindOutputsArgs,
+    tagIds?: number[],
+    isQueryModeAll?: boolean
+  ): { conditions: string[]; params: any[] } | undefined {
     const extraConditions: string[] = []
     const extraParams: any[] = []
 
@@ -772,11 +820,29 @@ export class StorageExpoSQLite extends StorageProvider {
       extraParams.push(...tagIds)
     }
 
+    return extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined
+  }
+
+  async findOutputs(args: FindOutputsArgs, tagIds?: number[], isQueryModeAll?: boolean): Promise<TableOutput[]> {
+    if ((args.partial as any).lockingScript) {
+      throw new Error('Outputs may not be found by lockingScript value.')
+    }
+    const partial = { ...args.partial } as any
+
+    // `noScript` callers throw the script away the moment it arrives, so do not
+    // fetch it at all: an R1-K1 vault output's lockingScript is 959,632 bytes,
+    // and `SELECT *` copies every one of them out of SQLite and across the
+    // bridge into JS — on the JS thread — only to be discarded below.
+    const columns = args.noScript
+      ? (await this.tableColumns('outputs')).filter(c => c !== 'lockingScript')
+      : undefined
+
     const rows = await this.sqlFind<any>(
       'outputs',
       { ...args, partial },
       'outputId',
-      extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined
+      this.outputExtraClauses(args, tagIds, isQueryModeAll),
+      columns
     )
 
     const results = this.validateEntities(rows, undefined, ['spendable', 'change'])
@@ -789,6 +855,27 @@ export class StorageExpoSQLite extends StorageProvider {
       }
     }
     return results
+  }
+
+  /**
+   * Count and total the satoshis of the outputs a findOutputs with these same
+   * args would return, without materialising a single row.
+   *
+   * This is the wallet balance: summing it in SQLite rather than pulling every
+   * output into JS is the difference between one number crossing the bridge and
+   * a few hundred full rows crossing it.
+   */
+  async sumOutputSatoshis(
+    args: FindOutputsArgs,
+    tagIds?: number[],
+    isQueryModeAll?: boolean
+  ): Promise<{ count: number; total: number }> {
+    return await this.sqlSum(
+      'outputs',
+      'satoshis',
+      args as any,
+      this.outputExtraClauses(args, tagIds, isQueryModeAll)
+    )
   }
 
   async findOutputTags(args: FindOutputTagsArgs): Promise<TableOutputTag[]> {
@@ -979,34 +1066,7 @@ export class StorageExpoSQLite extends StorageProvider {
   }
 
   async countOutputs(args: FindOutputsArgs, tagIds?: number[], isQueryModeAll?: boolean): Promise<number> {
-    const extraConditions: string[] = []
-    const extraParams: any[] = []
-    if (args.txStatus && args.txStatus.length > 0) {
-      const placeholders = args.txStatus.map(() => '?').join(',')
-      extraConditions.push(
-        `transactionId IN (SELECT transactionId FROM transactions WHERE status IN (${placeholders}))`
-      )
-      extraParams.push(...args.txStatus)
-    }
-    if (tagIds && tagIds.length > 0) {
-      const tagPlaceholders = tagIds.map(() => '?').join(',')
-      if (isQueryModeAll) {
-        extraConditions.push(`outputId IN (
-          SELECT outputId FROM output_tags_map WHERE outputTagId IN (${tagPlaceholders}) AND isDeleted = 0
-          GROUP BY outputId HAVING COUNT(DISTINCT outputTagId) = ${tagIds.length}
-        )`)
-      } else {
-        extraConditions.push(`outputId IN (
-          SELECT outputId FROM output_tags_map WHERE outputTagId IN (${tagPlaceholders}) AND isDeleted = 0
-        )`)
-      }
-      extraParams.push(...tagIds)
-    }
-    return this.sqlCount(
-      'outputs',
-      args,
-      extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined
-    )
+    return this.sqlCount('outputs', args, this.outputExtraClauses(args, tagIds, isQueryModeAll))
   }
 
   async countOutputTags(args: FindOutputTagsArgs): Promise<number> {

--- a/storage/methods/listOutputsSql.ts
+++ b/storage/methods/listOutputsSql.ts
@@ -7,7 +7,7 @@ import type { ListOutputsResult, Validation } from '@bsv/sdk'
 import type { AuthId } from '@bsv/wallet-toolbox-mobile/out/src/sdk/WalletStorage.interfaces'
 import type { StorageExpoSQLite } from '../StorageExpoSQLite'
 import { getListOutputsSpecOp } from '@bsv/wallet-toolbox-mobile/out/src/storage/methods/ListOutputsSpecOp'
-import { devLog } from '../../utils/logging'
+import { devLog, isLoggingEnabled } from '../../utils/logging'
 
 export async function listOutputsSql(
   storage: StorageExpoSQLite,
@@ -90,13 +90,30 @@ export async function listOutputsSql(
     findArgs.paged = { limit, offset }
   }
 
+  // The wallet-balance specOp wants ONE NUMBER: the sum of the satoshis of the
+  // outputs this query would return. Let SQLite add them up rather than reading
+  // every row into JS to do it here — for a wallet with a few hundred change
+  // outputs that is a few hundred full rows crossing the bridge, on the JS
+  // thread, to produce a single integer. Same filter, same answer; the row path
+  // below still serves every other specOp.
+  if (specOp?.totalOutputsIsSumOfSatoshis && !specOp.filterOutputs) {
+    const { total } = await storage.sumOutputSatoshis(
+      findArgs,
+      tagIds.length > 0 ? tagIds : undefined,
+      isQueryModeAll
+    )
+    return { totalOutputs: total, outputs: [] }
+  }
+
   let outputs = await storage.findOutputs(
     findArgs,
     tagIds.length > 0 ? tagIds : undefined,
     isQueryModeAll
   )
-  if (outputs.length === 0 && basketId !== undefined) {
-    // Debug: check what's in the basket without filters
+  if (outputs.length === 0 && basketId !== undefined && isLoggingEnabled()) {
+    // Debug aid for an empty basket: what IS in there, before the filters. The
+    // query is gated with the log — running it unconditionally cost a second
+    // full-basket read on every empty result, in production too.
     const db = (storage as any).getDB()
     const raw = await db.getAllAsync(
       `SELECT o.outputId, o.spendable, o.satoshis, t.status as txStatus

--- a/storage/methods/walletBalanceSql.ts
+++ b/storage/methods/walletBalanceSql.ts
@@ -1,0 +1,55 @@
+/**
+ * The wallet balance, as one SQL aggregate — and ONE definition of what the
+ * balance is, used from both ends:
+ *
+ *  - `listOutputsSql`, when the toolbox asks for the `specOpWalletBalance` basket
+ *  - the wallet screen, which calls this directly
+ *
+ * Calling it directly matters. Every read through `WalletStorageManager` queues
+ * on a single FIFO reader lock, and the monitor's tasks hold that lock — along
+ * with the writer and sync locks — across NETWORK calls: `attemptToPostReqsToNetwork`
+ * broadcasts from inside `runAsStorageProvider`. A balance read issued while a
+ * transaction is being broadcast therefore waits for the broadcast, not for the
+ * database. That is where the multi-second balance reads on device came from,
+ * not from the ~145 rows the query actually touches.
+ *
+ * This is a side-effect-free read of our own SQLite file, so it does not need
+ * the lock the writes need.
+ */
+
+/** The basket the toolbox counts as the wallet balance, and the transaction
+ * states in which an output's satoshis are really yours. Mirrors what
+ * `listOutputsSql` builds for every other outputs query. */
+export const BALANCE_BASKET = 'default'
+export const BALANCE_TX_STATUS = ['completed', 'unproven', 'nosend']
+
+/** The slice of StorageExpoSQLite this needs. Structural, so a caller can pass
+ * the real provider and a test can pass one backed by any SQLite handle. */
+export interface BalanceStorage {
+  findOutputBaskets(args: { partial: { userId: number; name: string } }): Promise<{ basketId: number }[]>
+  sumOutputSatoshis(
+    args: { partial: Record<string, unknown>; txStatus?: string[]; noScript?: boolean },
+    tagIds?: number[],
+    isQueryModeAll?: boolean
+  ): Promise<{ count: number; total: number }>
+}
+
+/**
+ * Sum the spendable satoshis in the default basket for one user.
+ *
+ * Returns `null` when the basket does not exist yet — a wallet that has never
+ * held anything. Callers should treat that as "no figure available" rather than
+ * as a balance of zero, so a wallet still building does not flash 0 over a
+ * cached figure.
+ */
+export async function readWalletBalance(storage: BalanceStorage, userId: number): Promise<number | null> {
+  const baskets = await storage.findOutputBaskets({ partial: { userId, name: BALANCE_BASKET } })
+  if (baskets.length !== 1) return null
+
+  const { total } = await storage.sumOutputSatoshis({
+    partial: { userId, basketId: baskets[0].basketId, spendable: true },
+    txStatus: BALANCE_TX_STATUS,
+    noScript: true
+  })
+  return total
+}


### PR DESCRIPTION
Stacked on #126 — review that first; this PR's own diff is the storage layer plus one change to `refreshBalance`.

## The 5.7s was not the query

I benchmarked the actual SQL against the real schema (node:sqlite, 600 transactions, 145 spendable default-basket outputs, plus vault rows carrying 959,632-byte scripts and 1 MB `rawTx` blobs):

```
current: SELECT * (145 rows, then sum in JS)     0.5 ms
columns without lockingScript                    0.4 ms
SELECT SUM(satoshis) in SQL                      0.2 ms
```

Sub-millisecond. The query plan is index-driven (`SEARCH outputs USING INDEX idx_outputs_basketId`, covering index on `transactions.status`). So the multi-second reads had to be coming from somewhere else.

**They were lock waits.** Every read through `WalletStorageManager` queues on a single FIFO `readerLocks` array — readers are fully serialised, not shared. The monitor's tasks take that lock *plus* the writer and sync locks for the whole of `runAsStorageProvider`, and `attemptToPostReqsToNetwork` does `services.postBeef(...)` — a network broadcast — from inside it. A balance read issued while a transaction is broadcasting waits for the broadcast.

That also re-reads the original log correctly: six reads reporting 5334/5753/5760/5766/5771/5776 ms are not six slow queries. They are six callers that queued at the same moment and were released together when one holder finally let go — which is why they finish within 450ms of each other after a ~5.3s wait. The 54,498ms one is the same thing behind a longer holder.

## What this changes

**The wallet screen reads the balance directly** (`storage/methods/walletBalanceSql.ts`). It is a side-effect-free read of our own SQLite, so it does not need the lock the writes need. The same function backs the toolbox's `specOpWalletBalance` path, so there is one definition of what the balance is. The wallet's own `listOutputs` remains the fallback for the window before `storage`/`walletUserId` exist.

**`SELECT *` no longer drags blobs across the bridge to drop them.** Every `noScript` caller — which is all of `listOutputsSql` — assigned `lockingScript = undefined` right after SQLite had already read it and marshalled it into JS, on the JS thread. For a vault output that is 959,632 bytes each. The projection now omits the column, built from `PRAGMA table_info` rather than hardcoded so a later migration's column still arrives. Behaviour when scripts *are* wanted is untouched (`validateOutputScript` refills from `rawTx`, exactly as it already did).

**The balance specOp sums in SQL.** It was fetching every matching row to add `satoshis` up in a JS loop; now one integer crosses the bridge. `findOutputs`, `countOutputs` and the new `sumOutputSatoshis` share one clause builder, so they cannot drift apart on what they filter.

**The empty-basket debug query is gated** behind the logging switch — only the log was gated before, so the extra full-basket read ran on every empty result in production too.

## Tests

`__tests__/walletBalanceSql.test.ts` runs the **real** `createTables()` schema and the **real** `StorageExpoSQLite` against node:sqlite — only the native handle is swapped, so the SQL the app builds is what executes:

- what the balance counts and excludes (spendable, basket, `completed`/`unproven`/`nosend`, user scoping)
- `null` not `0` before the default basket exists, so a building wallet cannot flash zero over the cached figure
- a `noScript` projection that contains `satoshis` and `customInstructions` but **not** `lockingScript`
- scripts still returned when the caller wants them
- the balance specOp answering from `SUM("satoshis")` with no row query issued at all

Adds an `expo-sqlite` jest mock beside the existing `expo-audio` one — that is what makes storage-layer tests possible at all, and it should be reusable well beyond this PR.

`npx jest` 997 passed / 84 suites. `npx tsc --noEmit` clean bar the two known `funding-app/vite.config.ts` errors. eslint no new warnings.

## What I did NOT do

- **The lock itself.** The monitor holding all four storage locks across a network broadcast blocks every other storage read app-wide, not just the balance — `listActions` on this screen, `/pay`, everything. Fixing that means either narrowing the toolbox's lock scope or moving broadcasts outside it, which is a change to `@bsv/wallet-toolbox-mobile`, not to us. Worth raising upstream; say the word and I will write it up with the line references.
- **The vault basket**, per your call — though it gets the `SELECT *` fix for free, and that is the basket where it matters most: `getVaultBalance` lists up to 1000 vault outputs, each of which was dragging its ~960 KB script through JS just to have `satoshis` read off it.
- Anything touching huge-tx parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)