### PR TITLE
perf(storage): stop reading blobs nobody wants, and bound the two columns that grow forever

### DIFF
--- a/__tests__/storage/findSql.test.ts
+++ b/__tests__/storage/findSql.test.ts
@@ -5,6 +5,7 @@
  * needs a hardcoded column list, and a list that falls behind the schema would
  * silently drop a column from every read that projects.
  */
+import { DatabaseSync } from 'node:sqlite'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
@@ -13,7 +14,9 @@ import {
   TABLE_COLUMNS,
   buildFindSql,
   columnsExcluding,
-  rangeReadSql
+  rangeReadSql,
+  spendingReferencesSql,
+  splitOutpoint
 } from '@/storage/methods/findSql'
 
 describe('columnsExcluding', () => {
@@ -162,4 +165,62 @@ describe('column lists match the schema', () => {
       }
     })
   }
+})
+
+describe('spendingReferencesSql against real SQLite', () => {
+  const seeded = () => {
+    const d = new DatabaseSync(':memory:')
+    d.exec('CREATE TABLE outputs (txid TEXT, vout INTEGER, spentBy INTEGER)')
+    d.exec('CREATE TABLE transactions (transactionId INTEGER, reference TEXT, status TEXT)')
+    d.prepare('INSERT INTO transactions VALUES (?,?,?)').run(1, 'ref-orphan', 'unsigned')
+    d.prepare('INSERT INTO transactions VALUES (?,?,?)').run(2, 'ref-done', 'completed')
+    d.prepare('INSERT INTO outputs VALUES (?,?,?)').run('aa'.repeat(32), 0, 1)
+    d.prepare('INSERT INTO outputs VALUES (?,?,?)').run('bb'.repeat(32), 1, 2)
+    // Unspent: must never be reported.
+    d.prepare('INSERT INTO outputs VALUES (?,?,?)').run('cc'.repeat(32), 0, null)
+    return d
+  }
+
+  it('finds the reserving transaction by outpoint', () => {
+    const rows = seeded()
+      .prepare(spendingReferencesSql(1))
+      .all('aa'.repeat(32), 0) as { reference: string; status: string }[]
+    expect(rows).toEqual([{ reference: 'ref-orphan', status: 'unsigned' }])
+  })
+
+  it('matches on the vout as well as the txid', () => {
+    // vout 1 of that txid is spent by ref-done; vout 0 is not present.
+    const rows = seeded().prepare(spendingReferencesSql(1)).all('bb'.repeat(32), 0) as unknown[]
+    expect(rows).toEqual([])
+  })
+
+  it('takes several outpoints in one query', () => {
+    const rows = seeded()
+      .prepare(spendingReferencesSql(2))
+      .all('aa'.repeat(32), 0, 'bb'.repeat(32), 1) as { reference: string }[]
+    expect(rows.map(r => r.reference).sort()).toEqual(['ref-done', 'ref-orphan'])
+  })
+
+  it('ignores unspent outputs', () => {
+    const rows = seeded().prepare(spendingReferencesSql(1)).all('cc'.repeat(32), 0) as unknown[]
+    expect(rows).toEqual([])
+  })
+})
+
+describe('splitOutpoint', () => {
+  it('accepts both spellings the toolbox uses', () => {
+    const txid = 'ab'.repeat(32)
+    expect(splitOutpoint(`${txid}.3`)).toEqual({ txid, vout: 3 })
+    expect(splitOutpoint(`${txid}:3`)).toEqual({ txid, vout: 3 })
+  })
+
+  it('lowercases the txid so a mixed-case outpoint still matches storage', () => {
+    expect(splitOutpoint(`${'AB'.repeat(32)}.0`)!.txid).toBe('ab'.repeat(32))
+  })
+
+  it('rejects anything that is not an outpoint', () => {
+    expect(splitOutpoint('nonsense')).toBeNull()
+    expect(splitOutpoint('ab.0')).toBeNull()
+    expect(splitOutpoint(`${'ab'.repeat(32)}.`)).toBeNull()
+  })
 })

--- a/__tests__/storage/findSql.test.ts
+++ b/__tests__/storage/findSql.test.ts
@@ -1,0 +1,165 @@
+/**
+ * SQL construction for the storage read paths.
+ *
+ * The drift test at the bottom is the load-bearing one: an explicit projection
+ * needs a hardcoded column list, and a list that falls behind the schema would
+ * silently drop a column from every read that projects.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  BLOB_COLUMNS,
+  PROVEN_HEIGHTS_SQL,
+  TABLE_COLUMNS,
+  buildFindSql,
+  columnsExcluding,
+  rangeReadSql
+} from '@/storage/methods/findSql'
+
+describe('columnsExcluding', () => {
+  it('returns undefined when nothing is excluded, meaning SELECT *', () => {
+    // Callers with no reason to project must generate byte-identical SQL to
+    // before this change, or the projection could alter their result rows.
+    expect(columnsExcluding('outputs', [])).toBeUndefined()
+  })
+
+  it('names every non-excluded column so the blob is never read', () => {
+    const cols = columnsExcluding('outputs', ['lockingScript'])!
+    expect(cols).not.toContain('lockingScript')
+    // The two columns that make the range-read path work must survive: with
+    // maxOutputScript = 1024 a vault output stores offsets, not the script.
+    expect(cols).toContain('scriptOffset')
+    expect(cols).toContain('scriptLength')
+    expect(cols).toContain('outputId')
+  })
+
+  it('returns undefined for a table it has no column list for', () => {
+    expect(columnsExcluding('users', ['nope'])).toBeUndefined()
+  })
+})
+
+describe('buildFindSql', () => {
+  it('emits SELECT * when no column list is given', () => {
+    const sql = buildFindSql({ table: 'outputs', whereSql: '', hasSince: false, pkCol: 'outputId' })
+    expect(sql).toContain('SELECT * FROM "outputs"')
+  })
+
+  it('emits an explicit projection that does not name the blob column', () => {
+    const sql = buildFindSql({
+      table: 'outputs',
+      whereSql: 'WHERE "spendable" = ?',
+      hasSince: false,
+      pkCol: 'outputId',
+      columns: columnsExcluding('outputs', ['lockingScript'])
+    })
+    expect(sql).not.toMatch(/lockingScript/)
+    expect(sql.startsWith('SELECT "outputId"')).toBe(true)
+    expect(sql).toContain('WHERE "spendable" = ?')
+    expect(sql).toContain('ORDER BY "outputId" ASC')
+  })
+
+  it('quotes identifiers, because proven_txs has a column named index', () => {
+    const sql = buildFindSql({
+      table: 'proven_txs',
+      whereSql: '',
+      hasSince: false,
+      pkCol: 'provenTxId',
+      columns: columnsExcluding('proven_txs', ['rawTx', 'merklePath'])
+    })
+    expect(sql).toContain('"index"')
+    expect(sql).not.toMatch(/[^"]index/)
+  })
+
+  it('introduces WHERE for since when there is no where clause', () => {
+    const sql = buildFindSql({ table: 'transactions', whereSql: '', hasSince: true, pkCol: 'transactionId' })
+    expect(sql).toContain('WHERE updated_at >= ?')
+  })
+
+  it('preserves since, extra conditions, order and paging exactly as before', () => {
+    const sql = buildFindSql({
+      table: 'transactions',
+      whereSql: 'WHERE "userId" = ?',
+      hasSince: true,
+      extraConditions: ['status IN (?,?)'],
+      pkCol: 'transactionId',
+      orderDescending: true,
+      limit: 10,
+      offset: 5
+    })
+    expect(sql).toContain('AND updated_at >= ?')
+    expect(sql).toContain('AND status IN (?,?)')
+    expect(sql).toContain('ORDER BY "transactionId" DESC')
+    expect(sql).toContain('LIMIT 10')
+    expect(sql).toContain('OFFSET 5')
+  })
+
+  it('omits OFFSET when there is no LIMIT, matching the original', () => {
+    const sql = buildFindSql({
+      table: 'outputs',
+      whereSql: '',
+      hasSince: false,
+      pkCol: 'outputId',
+      offset: 20
+    })
+    expect(sql).not.toContain('OFFSET')
+  })
+})
+
+describe('rangeReadSql', () => {
+  it('filters proven_tx_reqs by the same statuses getProvenOrRawTx accepts', () => {
+    // A divergence here would make a range read see a row the full read
+    // refuses, or vice versa.
+    const sql = rangeReadSql('proven_tx_reqs')
+    for (const status of ['unsent', 'unmined', 'unconfirmed', 'sending', 'nosend', 'completed']) {
+      expect(sql).toContain(`'${status}'`)
+    }
+  })
+
+  it('applies no status filter to proven_txs', () => {
+    expect(rangeReadSql('proven_txs')).not.toContain('status')
+  })
+})
+
+describe('PROVEN_HEIGHTS_SQL', () => {
+  it('selects only the two columns the height map needs', () => {
+    expect(PROVEN_HEIGHTS_SQL).toBe('SELECT txid, height FROM proven_txs')
+    expect(PROVEN_HEIGHTS_SQL).not.toMatch(/rawTx|merklePath|\*/)
+  })
+})
+
+describe('column lists match the schema', () => {
+  // Parses createTables.ts rather than trusting the hardcoded lists. A column
+  // added to the schema but not here would be silently dropped from every
+  // projected read — invisible in any test that does not compare the two.
+  const ddl = readFileSync(join(__dirname, '../../storage/schema/createTables.ts'), 'utf8')
+
+  const columnsFromDdl = (table: string): string[] => {
+    const create = new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n {4}\\);`).exec(ddl)
+    if (!create) throw new Error(`no CREATE TABLE found for ${table}`)
+    const cols: string[] = []
+    for (const rawLine of create[1].split('\n')) {
+      const line = rawLine.trim()
+      if (!line || /^(FOREIGN KEY|PRIMARY KEY|UNIQUE|CONSTRAINT|CHECK)\b/i.test(line)) continue
+      const m = /^"?([A-Za-z_][A-Za-z0-9_]*)"?\s/.exec(line)
+      if (m) cols.push(m[1])
+    }
+    for (const alter of ddl.matchAll(
+      new RegExp(`ALTER TABLE ${table} ADD COLUMN "?([A-Za-z_][A-Za-z0-9_]*)"?`, 'g')
+    )) {
+      if (!cols.includes(alter[1])) cols.push(alter[1])
+    }
+    return cols
+  }
+
+  for (const table of Object.keys(TABLE_COLUMNS)) {
+    it(`${table} has exactly the columns the schema declares`, () => {
+      expect(TABLE_COLUMNS[table]).toEqual(columnsFromDdl(table))
+    })
+
+    it(`${table} blob columns are all real columns`, () => {
+      for (const blob of BLOB_COLUMNS[table]) {
+        expect(TABLE_COLUMNS[table]).toContain(blob)
+      }
+    })
+  }
+})

--- a/__tests__/storage/historyNotes.test.ts
+++ b/__tests__/storage/historyNotes.test.ts
@@ -1,0 +1,80 @@
+import { NOTE_VALUE_MAX, scrubHistoryJson, scrubNoteValues } from '@/storage/methods/historyNotes'
+
+describe('scrubNoteValues', () => {
+  it('truncates a megabyte of broadcast hex to the cap', () => {
+    // The real shape: a provider note carrying the whole Extended Format payload.
+    const note = { when: '2026-08-19T00:00:00Z', what: 'ArcadePostEF', rawTx: 'ab'.repeat(500_000) }
+    const out = scrubNoteValues(note)
+    expect(out.rawTx.length).toBe(NOTE_VALUE_MAX)
+    expect(out.rawTx.endsWith('…')).toBe(true)
+    expect(out.what).toBe('ArcadePostEF')
+    expect(out.when).toBe('2026-08-19T00:00:00Z')
+  })
+
+  it('leaves short values untouched and does not mutate the input', () => {
+    const note = { what: 'wocPostRawTx', httpStatus: 200 }
+    const out = scrubNoteValues(note)
+    expect(out).toEqual(note)
+    expect(out).not.toBe(note)
+  })
+
+  it('scrubs nested objects and arrays', () => {
+    const out = scrubNoteValues({
+      what: 'x',
+      nested: { hex: 'c'.repeat(9999) },
+      list: ['d'.repeat(9999), 'short']
+    })
+    expect((out.nested as any).hex.length).toBe(NOTE_VALUE_MAX)
+    expect((out.list as any)[0].length).toBe(NOTE_VALUE_MAX)
+    expect((out.list as any)[1]).toBe('short')
+  })
+
+  it('keeps a string exactly at the cap intact', () => {
+    const exact = 'e'.repeat(NOTE_VALUE_MAX)
+    expect(scrubNoteValues({ v: exact }).v).toBe(exact)
+  })
+
+  it('preserves non-string values, including null', () => {
+    const out = scrubNoteValues({ what: 'x', code: 429, ok: false, when: null })
+    expect(out).toEqual({ what: 'x', code: 429, ok: false, when: null })
+  })
+})
+
+describe('scrubHistoryJson', () => {
+  it('scrubs the values inside stored history JSON', () => {
+    const history = JSON.stringify({
+      notes: [{ what: 'ArcadePostEF', rawTx: 'ab'.repeat(500_000) }]
+    })
+    expect(history.length).toBeGreaterThan(1_000_000)
+
+    const out = scrubHistoryJson(history) as string
+    expect(out.length).toBeLessThan(600)
+    const parsed = JSON.parse(out)
+    expect(parsed.notes[0].what).toBe('ArcadePostEF')
+    expect(parsed.notes[0].rawTx.length).toBe(NOTE_VALUE_MAX)
+  })
+
+  it('passes short history through byte-identically', () => {
+    const history = JSON.stringify({ notes: [{ what: 'ok' }] })
+    expect(scrubHistoryJson(history)).toBe(history)
+  })
+
+  it('truncates unparseable history rather than letting it through', () => {
+    // Malformed history is already a bug; letting a megabyte past because it
+    // failed to parse would defeat the purpose of the cap.
+    const junk = 'f'.repeat(900_000)
+    const out = scrubHistoryJson(junk) as string
+    expect(out.length).toBe(NOTE_VALUE_MAX)
+  })
+
+  it('leaves undefined alone so an update that omits history stays an omission', () => {
+    // sqlUpdate skips undefined values; turning one into a string here would
+    // write a column the caller never asked to touch.
+    expect(scrubHistoryJson(undefined)).toBeUndefined()
+  })
+
+  it('handles an already-parsed object', () => {
+    const out = scrubHistoryJson({ notes: [{ hex: 'a'.repeat(9999) }] }) as any
+    expect(out.notes[0].hex.length).toBe(NOTE_VALUE_MAX)
+  })
+})

--- a/__tests__/storage/provenHeights.test.ts
+++ b/__tests__/storage/provenHeights.test.ts
@@ -1,0 +1,37 @@
+/**
+ * The CSV export's txid -> height map, verified against real SQLite.
+ *
+ * The point of the change is what is NOT read: the previous implementation used
+ * findProvenTxs({ partial: {} }), an unbounded SELECT * that pulled every rawTx
+ * and merklePath in the wallet through Array.from to build a map of two small
+ * columns.
+ */
+import { DatabaseSync } from 'node:sqlite'
+import { PROVEN_HEIGHTS_SQL } from '@/storage/methods/findSql'
+
+function seeded(): DatabaseSync {
+  const d = new DatabaseSync(':memory:')
+  d.exec('CREATE TABLE proven_txs (txid TEXT, height INTEGER, rawTx BLOB, merklePath BLOB)')
+  const insert = d.prepare('INSERT INTO proven_txs (txid, height, rawTx, merklePath) VALUES (?, ?, ?, ?)')
+  // A vault-sized row, so a SELECT * would be visibly expensive.
+  insert.run('aa', 42, new Uint8Array(960_000), new Uint8Array(1_000))
+  insert.run('bb', 43, new Uint8Array(250), new Uint8Array(1_000))
+  return d
+}
+
+describe('PROVEN_HEIGHTS_SQL', () => {
+  it('returns the rows the height map needs', () => {
+    const rows = seeded().prepare(PROVEN_HEIGHTS_SQL).all() as { txid: string; height: number }[]
+    expect(rows).toEqual([
+      { txid: 'aa', height: 42 },
+      { txid: 'bb', height: 43 }
+    ])
+  })
+
+  it('does not return the blob columns at all', () => {
+    const rows = seeded().prepare(PROVEN_HEIGHTS_SQL).all() as Record<string, unknown>[]
+    expect(Object.keys(rows[0])).toEqual(['txid', 'height'])
+    expect(Object.keys(rows[0])).not.toContain('rawTx')
+    expect(Object.keys(rows[0])).not.toContain('merklePath')
+  })
+})

--- a/__tests__/storage/rangeRead.test.ts
+++ b/__tests__/storage/rangeRead.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Byte-range reads of a stored rawTx, run against real SQLite.
+ *
+ * This is the path spec §2.2 identifies as the silent-fund-eviction route: a
+ * wrong or truncated slice here is hashed by Services.hashOutputScript, the
+ * chain answers "not a UTXO", and three separate writers persist
+ * spendable = false with nothing in the logs. So the byte-exactness of the
+ * offset arithmetic is asserted against the equivalent JS slice rather than
+ * assumed — substr on a BLOB is 1-indexed, JS slice is 0-indexed, and an
+ * off-by-one produces plausible bytes of the right length.
+ */
+import { DatabaseSync } from 'node:sqlite'
+import { rangeReadSql } from '@/storage/methods/findSql'
+
+/** 300 bytes with a recognisable pattern, so a shifted read is visible. */
+const RAW = Array.from({ length: 300 }, (_, i) => (i * 7) % 256)
+
+/** JS offset → the 1-indexed start substr wants. */
+const start = (offset: number): number => offset + 1
+
+function seeded(): DatabaseSync {
+  const d = new DatabaseSync(':memory:')
+  d.exec('CREATE TABLE proven_txs (txid TEXT, rawTx BLOB NOT NULL)')
+  d.exec('CREATE TABLE proven_tx_reqs (txid TEXT, status TEXT, rawTx BLOB)')
+  d.prepare('INSERT INTO proven_txs (txid, rawTx) VALUES (?, ?)').run('aa', new Uint8Array(RAW))
+  d.prepare('INSERT INTO proven_tx_reqs (txid, status, rawTx) VALUES (?, ?, ?)').run(
+    'bb',
+    'completed',
+    new Uint8Array(RAW)
+  )
+  d.prepare('INSERT INTO proven_tx_reqs (txid, status, rawTx) VALUES (?, ?, ?)').run(
+    'cc',
+    'invalid',
+    new Uint8Array(RAW)
+  )
+  return d
+}
+
+const read = (d: DatabaseSync, table: 'proven_txs' | 'proven_tx_reqs', offset: number, length: number, txid: string) =>
+  d.prepare(rangeReadSql(table)).get(start(offset), length, txid) as { chunk?: Uint8Array } | undefined
+
+describe('rangeReadSql against real SQLite', () => {
+  it('reads an exact byte range from proven_txs', () => {
+    const row = read(seeded(), 'proven_txs', 40, 10, 'aa')
+    expect(Array.from(row!.chunk!)).toEqual(RAW.slice(40, 50))
+  })
+
+  it('matches a full-array slice at every boundary that could be off by one', () => {
+    const d = seeded()
+    for (const [offset, length] of [
+      [0, 1],
+      [0, 300],
+      [1, 1],
+      [149, 2],
+      [250, 49],
+      [299, 1]
+    ]) {
+      const row = read(d, 'proven_txs', offset, length, 'aa')
+      expect(Array.from(row!.chunk!)).toEqual(RAW.slice(offset, offset + length))
+    }
+  })
+
+  it('clamps a range that runs past the end, exactly as slice does', () => {
+    const row = read(seeded(), 'proven_txs', 290, 100, 'aa')
+    expect(Array.from(row!.chunk!)).toEqual(RAW.slice(290, 390))
+  })
+
+  it('reads from proven_tx_reqs for a usable status', () => {
+    const row = read(seeded(), 'proven_tx_reqs', 0, 4, 'bb')
+    expect(Array.from(row!.chunk!)).toEqual(RAW.slice(0, 4))
+  })
+
+  it('refuses a proven_tx_reqs row whose status is not usable', () => {
+    // getProvenOrRawTx ignores such rows; a range read that returned bytes here
+    // would make the two paths disagree about which rows exist.
+    expect(read(seeded(), 'proven_tx_reqs', 0, 4, 'cc')).toBeUndefined()
+  })
+
+  it('returns no row for an unknown txid', () => {
+    expect(read(seeded(), 'proven_txs', 0, 4, 'zz')).toBeUndefined()
+  })
+
+  it('reads only the requested bytes, not the whole blob', () => {
+    // The entire point: a 1 MB row must not be materialised to answer a
+    // 20-byte question.
+    const d = new DatabaseSync(':memory:')
+    d.exec('CREATE TABLE proven_txs (txid TEXT, rawTx BLOB NOT NULL)')
+    const big = new Uint8Array(1_000_000)
+    big[999_990] = 42
+    d.prepare('INSERT INTO proven_txs (txid, rawTx) VALUES (?, ?)').run('big', big)
+
+    const row = read(d, 'proven_txs', 999_990, 1, 'big')
+    expect(row!.chunk!.length).toBe(1)
+    expect(row!.chunk![0]).toBe(42)
+  })
+})

--- a/__tests__/vault/transfers.test.ts
+++ b/__tests__/vault/transfers.test.ts
@@ -716,6 +716,61 @@ describe('withdraw self-heals a double-spend from stuck reservations', () => {
     expect(aborted).toEqual(['ref-orphan'])
   })
 
+  test('with a storage lookup, heals from one query and never pages actions', async () => {
+    const fx = await seedVaultOutputs(1)
+    let createCalls = 0
+    const asked: string[][] = []
+    const findSpendingReferences = jest.fn(async (outpoints: string[]) => {
+      asked.push(outpoints)
+      return [
+        { reference: 'ref-orphan', status: 'unsigned' },
+        // Terminal, so not abortable — the status filter must still apply on
+        // this path exactly as it does on the scan.
+        { reference: 'ref-done', status: 'completed' }
+      ]
+    })
+    const realCreateAction = wallet.createAction.getMockImplementation()!
+    wallet.createAction.mockImplementation(async (...args: any[]) => {
+      if (++createCalls === 1) throw unspendableError(fx[0].outpoint)
+      return realCreateAction(...args)
+    })
+
+    const { txid } = await withdrawFromVault(wallet, ADMIN, 'all', 'Withdraw all', findSpendingReferences)
+
+    expect(txid).toBeDefined()
+    expect(createCalls).toBe(2)
+    expect(asked).toEqual([[fx[0].outpoint]])
+    expect(wallet.abortAction).toHaveBeenCalledWith({ reference: 'ref-orphan' }, ADMIN)
+    expect(wallet.abortAction).not.toHaveBeenCalledWith({ reference: 'ref-done' }, ADMIN)
+    // The whole point: no paged scan, so no per-action rawTx load and parse.
+    expect(wallet.listActions).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the scan when the storage lookup throws', async () => {
+    // A storage failure must not cost the retry.
+    const fx = await seedVaultOutputs(1)
+    let createCalls = 0
+    const findSpendingReferences = jest.fn(async () => {
+      throw new Error('database is locked')
+    })
+    wallet.listActions.mockResolvedValue({
+      actions: [{ status: 'unsigned', reference: 'ref-orphan', inputs: [{ sourceOutpoint: fx[0].outpoint }] }]
+    })
+    const realCreateAction = wallet.createAction.getMockImplementation()!
+    wallet.createAction.mockImplementation(async (...args: any[]) => {
+      if (++createCalls === 1) throw unspendableError(fx[0].outpoint)
+      return realCreateAction(...args)
+    })
+
+    await expect(
+      withdrawFromVault(wallet, ADMIN, 'all', 'Withdraw all', findSpendingReferences)
+    ).resolves.toMatchObject({ txid: expect.any(String) })
+
+    expect(findSpendingReferences).toHaveBeenCalled()
+    expect(wallet.listActions).toHaveBeenCalled()
+    expect(wallet.abortAction).toHaveBeenCalledWith({ reference: 'ref-orphan' }, ADMIN)
+  })
+
   test('matches the outpoint spelling the toolbox uses in error text (txid:vout)', async () => {
     const fx = await seedVaultOutputs(1)
     const [txid] = fx[0].outpoint.split('.')

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1149,8 +1149,17 @@ const Browser = observer(function Browser() {
     [domainForUrl, permissionRouterConfig]
   )
 
+  /**
+   * The async worker takes the two values it needs, never the event.
+   *
+   * A WebViewMessageEvent captured in an async closure is retained for the whole
+   * duration of the call, and nativeEvent.data is the entire message JSON — a
+   * measured 3.6-4.0x the payload size in Hermes string memory, held across
+   * every await in a wallet operation. onWebViewMessage below destructures it in
+   * a synchronous wrapper so the event becomes collectable immediately.
+   */
   const handleMessage = useCallback(
-    async (tabId: number, event: WebViewMessageEvent) => {
+    async (tabId: number, eventData: string, eventUrl: string) => {
       if (!activeTab) return
       // Warm background tabs stay mounted and their pages keep running; ignore
       // their messages so only the visible tab can drive wallet/CWI calls and
@@ -1159,7 +1168,7 @@ const Browser = observer(function Browser() {
       // user returns to it.
       if (tabId !== activeTab.id) return
 
-      const frameIdentity = walletFrameIdentityFromUrl(event.nativeEvent.url)
+      const frameIdentity = walletFrameIdentityFromUrl(eventUrl)
 
       const sendResponseToWebView = (id: string, result: any) => {
         if (!activeTab?.webviewRef?.current) return
@@ -1189,7 +1198,7 @@ const Browser = observer(function Browser() {
       let msg
       const endParse = perf.mark('webview.message.parse')
       try {
-        msg = JSON.parse(event.nativeEvent.data)
+        msg = JSON.parse(eventData)
       } catch {
         endParse()
         return
@@ -1364,6 +1373,19 @@ const Browser = observer(function Browser() {
     [activeTab, wallet, routeWebViewMessage, isWeb2Mode, walletBuilding]
   )
 
+  /**
+   * Synchronous adapter: pulls the two values off the event and hands them on,
+   * so the event object (and the whole message JSON it holds) is not reachable
+   * from the async handler's closure. See handleMessage's doc comment.
+   */
+  const onWebViewMessage = useCallback(
+    (tabId: number, event: WebViewMessageEvent) => {
+      const { data, url } = event.nativeEvent
+      void handleMessage(tabId, data, url)
+    },
+    [handleMessage]
+  )
+
   // Reload the active tab as soon as the wallet becomes available so any
   // page that loaded before the wallet was ready gets a fresh start with
   // the CWI provider backed by a ready wallet.
@@ -1536,7 +1558,7 @@ const Browser = observer(function Browser() {
       isWeb2Mode={isWeb2Mode}
       injectedJavaScript={injectedJavaScript}
       injectedJSBefore={injectedJSBefore}
-      onMessage={handleMessage}
+      onMessage={onWebViewMessage}
       onNavStateChange={handleNavStateChange}
       paymentHandlerRef={paymentHandlerRef}
       paymentInFlightUrl={paymentInFlightUrl}

--- a/app/vault-transfer.tsx
+++ b/app/vault-transfer.tsx
@@ -54,7 +54,7 @@ export default function VaultTransferScreen() {
   const { colors } = useTheme()
   const insets = useSafeAreaInsets()
   const { direction } = useLocalSearchParams<{ direction?: string }>()
-  const { managers, adminOriginator } = useWallet()
+  const { managers, adminOriginator, storage } = useWallet()
   const { balance, refresh } = useVaultBalance()
   const [amount, setAmount] = useState('')
   const [busy, setBusy] = useState(false)
@@ -87,7 +87,10 @@ export default function VaultTransferScreen() {
           w,
           adminOriginator,
           isMax ? 'all' : sats,
-          t('vault_withdraw_reason', { amount: isMax ? (balance ?? 0) : sats })
+          t('vault_withdraw_reason', { amount: isMax ? (balance ?? 0) : sats }),
+          // Lets the reservation heal find the reserving transaction with one
+          // indexed query instead of paging every action in the wallet.
+          storage ? outpoints => storage.findSpendingReferences(outpoints) : undefined
         )
         // vaultOpen/haptic already fired by the ceremony's onArmed
         showToast(t('vault_withdraw_done'), { type: 'success' })

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -2103,7 +2103,9 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
             })
             // Match by looking up which of our change outputs belong to the spending tx
             // via the transactions table (our tx with this on-chain txid)
-            const txRows = await storage.findTransactions({ partial: { txid: spendingTxid } })
+            // Only transactionId is used below; noRawTx keeps the ~960 KB blob
+            // (and its JS-array expansion) out of the read entirely.
+            const txRows = await storage.findTransactions({ partial: { txid: spendingTxid }, noRawTx: true })
             const matchingTxId = txRows.length > 0 ? txRows[0].transactionId : undefined
 
             const outputsToInternalize: any[] = []

--- a/docs/superpowers/plans/2026-08-19-storage-read-path-and-growth-fixes.md
+++ b/docs/superpowers/plans/2026-08-19-storage-read-path-and-growth-fixes.md
@@ -1,0 +1,415 @@
+# Storage Read Path and Unbounded Growth Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the wallet reading and expanding megabyte BLOBs it immediately discards, serve byte-range reads in SQL, and bound the two columns that grow without limit.
+
+**Architecture:** All changes are local to `storage/`, `utils/` and `services/vault/`. No codec, no schema change, no toolbox patch. Each task extracts a pure, testable helper and wires it into an existing method, so behaviour is verified without a device.
+
+**Tech Stack:** TypeScript, expo-sqlite, `@bsv/wallet-toolbox-mobile`, Jest, `node:sqlite` (test-only, verified available on Node v24.15.0).
+
+**Spec:** [docs/superpowers/specs/2026-08-19-tx-size-limits-and-blob-compression-design.md](../specs/2026-08-19-tx-size-limits-and-blob-compression-design.md) §7 and §4.5 B0.
+
+## Global Constraints
+
+- No schema migration. No change to any column type or nullability.
+- No behavioural change visible to the toolbox: every method keeps its existing signature and return type (`number[]`, not `Uint8Array`, at the storage boundary).
+- `maxOutputScript = 1024` — vault outputs store `scriptOffset`/`scriptLength` and NOT the script, so the range-read path is live and vault-only.
+- SQLite `substr` on a BLOB is byte-based and **1-indexed**: a JS offset `n` maps to `substr(col, n + 1, len)`.
+- Commit after every task.
+
+---
+
+### Task 1: Column projection in `sqlFind`, making `noRawTx`/`noScript` real
+
+**Files:**
+- Create: `storage/methods/findSql.ts`
+- Create: `__tests__/storage/findSql.test.ts`
+- Modify: `storage/StorageExpoSQLite.ts` (`sqlFind` :322-355, `findOutputs` :736, `findTransactions` :807, `findProvenTxs` :919, `findProvenTxReqs` :896)
+
+**Interfaces:**
+- Produces: `buildFindSql(opts: { table: string; whereSql: string; hasSince: boolean; extraConditions?: string[]; pkCol: string; orderDescending?: boolean; limit?: number; offset?: number; columns?: string[] }): string`
+- Produces: `BLOB_COLUMNS: Record<string, string[]>` mapping table name → blob column names.
+- Produces: `columnsExcluding(table: string, exclude: string[]): string[] | undefined` — `undefined` means "all columns" (`SELECT *`).
+
+**Why:** `sqlFind` always emits `SELECT *`, so `validateEntity` `Array.from`s every BLOB (~8× heap under Hermes) and `findOutputs`/`findTransactions` then throw the value away. Five callers already ask for the cheap path and pay full price.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { BLOB_COLUMNS, buildFindSql, columnsExcluding } from '@/storage/methods/findSql'
+
+describe('columnsExcluding', () => {
+  it('returns undefined when nothing is excluded, meaning SELECT *', () => {
+    expect(columnsExcluding('outputs', [])).toBeUndefined()
+  })
+
+  it('names every non-excluded column so the blob is never read', () => {
+    const cols = columnsExcluding('outputs', ['lockingScript'])!
+    expect(cols).not.toContain('lockingScript')
+    expect(cols).toContain('outputId')
+    expect(cols).toContain('scriptOffset')
+    expect(cols).toContain('scriptLength')
+  })
+
+  it('knows the blob columns of every table it projects', () => {
+    expect(BLOB_COLUMNS.outputs).toEqual(['lockingScript'])
+    expect(BLOB_COLUMNS.transactions).toEqual(['rawTx', 'inputBEEF'])
+    expect(BLOB_COLUMNS.proven_txs).toEqual(['rawTx', 'merklePath'])
+    expect(BLOB_COLUMNS.proven_tx_reqs).toEqual(['rawTx', 'inputBEEF'])
+  })
+})
+
+describe('buildFindSql', () => {
+  it('emits SELECT * when no column list is given', () => {
+    const sql = buildFindSql({ table: 'outputs', whereSql: '', hasSince: false, pkCol: 'outputId' })
+    expect(sql).toContain('SELECT * FROM "outputs"')
+  })
+
+  it('emits an explicit projection that does not name the blob column', () => {
+    const sql = buildFindSql({
+      table: 'outputs',
+      whereSql: 'WHERE "spendable" = ?',
+      hasSince: false,
+      pkCol: 'outputId',
+      columns: columnsExcluding('outputs', ['lockingScript'])
+    })
+    expect(sql).not.toMatch(/lockingScript/)
+    expect(sql).toMatch(/^SELECT "outputId"/)
+    expect(sql).toContain('WHERE "spendable" = ?')
+    expect(sql).toContain('ORDER BY "outputId" ASC')
+  })
+
+  it('preserves since, extra conditions, order and paging exactly as before', () => {
+    const sql = buildFindSql({
+      table: 'transactions',
+      whereSql: 'WHERE "userId" = ?',
+      hasSince: true,
+      extraConditions: ['status IN (?,?)'],
+      pkCol: 'transactionId',
+      orderDescending: true,
+      limit: 10,
+      offset: 5
+    })
+    expect(sql).toContain('AND updated_at >= ?')
+    expect(sql).toContain('AND status IN (?,?)')
+    expect(sql).toContain('ORDER BY "transactionId" DESC')
+    expect(sql).toContain('LIMIT 10')
+    expect(sql).toContain('OFFSET 5')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest __tests__/storage/findSql.test.ts`
+Expected: FAIL — cannot find module `@/storage/methods/findSql`.
+
+- [ ] **Step 3: Implement `storage/methods/findSql.ts`**
+
+Copy the clause order from `sqlFind` verbatim (`WHERE` → `since` → extra conditions → `ORDER BY` → `LIMIT`/`OFFSET`), because the `AND`/`WHERE` choice depends on what came before. Column names come from `storage/schema/createTables.ts` — read them from the file, do not invent them.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx jest __tests__/storage/findSql.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into `sqlFind` and the four finders**
+
+`sqlFind` takes an optional `columns?: string[]` and delegates its query building to `buildFindSql`. `findOutputs` passes `columnsExcluding('outputs', ['lockingScript'])` when `args.noScript`; `findTransactions` passes `columnsExcluding('transactions', ['rawTx', 'inputBEEF'])` when `args.noRawTx`. Keep the existing post-hoc `o.lockingScript = undefined` / `t.rawTx = undefined` assignments — with the projection they are no-ops, and leaving them means a future caller that forgets the projection still gets the documented shape.
+
+- [ ] **Step 6: Verify nothing regressed**
+
+Run: `npx tsc --noEmit` (expect only the two pre-existing `funding-app/vite.config.ts` errors) then `npx jest`.
+Expected: all suites pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add storage/methods/findSql.ts __tests__/storage/findSql.test.ts storage/StorageExpoSQLite.ts
+git commit -m "perf(storage): project columns so noRawTx/noScript stop reading blobs"
+```
+
+---
+
+### Task 2: Serve byte-range reads in SQL
+
+**Files:**
+- Modify: `storage/StorageExpoSQLite.ts` (`getRawTxOfKnownValidTransaction` :1235-1250)
+- Create: `__tests__/storage/rangeRead.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: no new exports; `getRawTxOfKnownValidTransaction(txid, offset, length, trx)` keeps its signature and `number[] | undefined` return.
+
+**Why:** today the method loads the entire rawTx (a whole vault transaction, ~960 KB, `Array.from`-ed to a 960 K-element array) and then `.slice()`s ~960 KB out of it. `substr` in SQLite reads only the requested bytes. This is also the path the spec's §2.2 silent-fund-eviction failure runs through, so it needs a byte-exactness test of its own.
+
+The existing semantics must be preserved exactly: `proven_txs` is consulted first; only if there is no proven row is `proven_tx_reqs` used, and then **only** when `status` is one of `unsent`, `unmined`, `unconfirmed`, `sending`, `nosend`, `completed`.
+
+- [ ] **Step 1: Write the failing test** (uses `node:sqlite` directly against the real schema)
+
+```ts
+import { DatabaseSync } from 'node:sqlite'
+import { rangeReadSql } from '@/storage/methods/findSql'
+
+const RAW = Array.from({ length: 300 }, (_, i) => i % 256)
+
+function db (): DatabaseSync {
+  const d = new DatabaseSync(':memory:')
+  d.exec('CREATE TABLE proven_txs (txid TEXT, rawTx BLOB NOT NULL)')
+  d.exec("CREATE TABLE proven_tx_reqs (txid TEXT, status TEXT, rawTx BLOB)")
+  d.prepare('INSERT INTO proven_txs (txid, rawTx) VALUES (?, ?)').run('aa', Buffer.from(RAW))
+  d.prepare('INSERT INTO proven_tx_reqs (txid, status, rawTx) VALUES (?, ?, ?)')
+    .run('bb', 'completed', Buffer.from(RAW))
+  d.prepare('INSERT INTO proven_tx_reqs (txid, status, rawTx) VALUES (?, ?, ?)')
+    .run('cc', 'invalid', Buffer.from(RAW))
+  return d
+}
+
+describe('rangeReadSql', () => {
+  it('reads an exact byte range from proven_txs, 1-indexed conversion included', () => {
+    const row: any = db().prepare(rangeReadSql('proven_txs')).get(41, 10, 'aa')
+    expect(Array.from(row.chunk as Uint8Array)).toEqual(RAW.slice(40, 50))
+  })
+
+  it('matches a full-array slice byte for byte at a large offset', () => {
+    const row: any = db().prepare(rangeReadSql('proven_txs')).get(251, 49, 'aa')
+    expect(Array.from(row.chunk as Uint8Array)).toEqual(RAW.slice(250, 299))
+  })
+
+  it('reads from proven_tx_reqs only for usable statuses', () => {
+    const d = db()
+    const ok: any = d.prepare(rangeReadSql('proven_tx_reqs')).get(1, 4, 'bb')
+    expect(Array.from(ok.chunk as Uint8Array)).toEqual(RAW.slice(0, 4))
+    const bad = d.prepare(rangeReadSql('proven_tx_reqs')).get(1, 4, 'cc')
+    expect(bad).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest __tests__/storage/rangeRead.test.ts`
+Expected: FAIL — `rangeReadSql` is not exported.
+
+- [ ] **Step 3: Add `rangeReadSql` and use it**
+
+```ts
+/** Byte-range read. substr() on a BLOB is byte-based and 1-indexed, so a JS
+ * offset n is passed as n + 1. Reading the range in SQL avoids materialising a
+ * whole ~960 KB vault transaction to slice a script out of it. */
+export function rangeReadSql (table: 'proven_txs' | 'proven_tx_reqs'): string {
+  const usable = "AND status IN ('unsent','unmined','unconfirmed','sending','nosend','completed')"
+  return `SELECT substr(rawTx, ?, ?) AS chunk FROM "${table}" WHERE txid = ? ${
+    table === 'proven_tx_reqs' ? usable : ''
+  }`
+}
+```
+
+In `getRawTxOfKnownValidTransaction`, when `offset` and `length` are both integers, query `proven_txs` first and fall through to `proven_tx_reqs`; otherwise keep the existing `getProvenOrRawTx` path untouched. Return `Array.from(chunk)` to preserve the `number[]` contract.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx jest __tests__/storage/rangeRead.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Full verification**
+
+Run: `npx tsc --noEmit && npx jest`
+Expected: clean; all suites pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add storage/StorageExpoSQLite.ts storage/methods/findSql.ts __tests__/storage/rangeRead.test.ts
+git commit -m "perf(storage): read byte ranges with substr instead of loading whole rawTx"
+```
+
+---
+
+### Task 3: Cap `proven_tx_reqs.history` note values
+
+**Files:**
+- Create: `storage/methods/historyNotes.ts`
+- Create: `__tests__/storage/historyNotes.test.ts`
+- Modify: `services/arcadeBroadcastProvider.ts` (the note-producing result objects)
+- Modify: `storage/StorageExpoSQLite.ts` (override `updateProvenTxReqDynamics`)
+
+**Interfaces:**
+- Produces: `NOTE_VALUE_MAX = 256`
+- Produces: `scrubNoteValues<T>(note: T): T` — returns a copy with every string property longer than `NOTE_VALUE_MAX` truncated to `NOTE_VALUE_MAX - 1` characters plus `…`.
+
+**Why:** provider error notes capture full EF/rawTx hex, `transferNotesToReqHistories` copies them verbatim into a TEXT column with no truncation, and `addHistoryNote`'s dedup does full string equality against every existing note. One failing vault broadcast writes multi-megabyte hex; the second failure compares megabyte strings. Quadratic, and triggered exactly when things go wrong — a direct violation of "stored compressed everywhere" that no rawTx codec touches.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { NOTE_VALUE_MAX, scrubNoteValues } from '@/storage/methods/historyNotes'
+
+describe('scrubNoteValues', () => {
+  it('truncates a megabyte of hex to the cap', () => {
+    const note = { what: 'postBeef', rawTx: 'ab'.repeat(500_000) }
+    const out = scrubNoteValues(note)
+    expect(out.rawTx.length).toBe(NOTE_VALUE_MAX)
+    expect(out.rawTx.endsWith('…')).toBe(true)
+    expect(out.what).toBe('postBeef')
+  })
+
+  it('leaves short values untouched and does not mutate the input', () => {
+    const note = { what: 'ok', detail: 'short' }
+    const out = scrubNoteValues(note)
+    expect(out).toEqual(note)
+    expect(out).not.toBe(note)
+  })
+
+  it('scrubs nested objects and arrays of strings', () => {
+    const out = scrubNoteValues({ what: 'x', nested: { hex: 'c'.repeat(9999) }, list: ['d'.repeat(9999)] })
+    expect((out.nested as any).hex.length).toBe(NOTE_VALUE_MAX)
+    expect((out.list as any)[0].length).toBe(NOTE_VALUE_MAX)
+  })
+
+  it('preserves non-string values', () => {
+    const out = scrubNoteValues({ what: 'x', code: 429, ok: false, when: null })
+    expect(out).toEqual({ what: 'x', code: 429, ok: false, when: null })
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest __tests__/storage/historyNotes.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement, then apply at both ends**
+
+Implement `scrubNoteValues` as a recursive copy. Then apply it in `services/arcadeBroadcastProvider.ts` wherever a note/detail object is built, and override `updateProvenTxReqDynamics` in `StorageExpoSQLite` to scrub `history` before it is written — the override is the backstop that also covers notes produced inside the toolbox's own providers.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx jest __tests__/storage/historyNotes.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Full verification and commit**
+
+```bash
+npx tsc --noEmit && npx jest
+git add storage/methods/historyNotes.ts __tests__/storage/historyNotes.test.ts services/arcadeBroadcastProvider.ts storage/StorageExpoSQLite.ts
+git commit -m "fix(storage): cap history note values so a failed broadcast cannot write megabytes"
+```
+
+---
+
+### Task 4: `exportTransactionsAsCsv` height map via direct SQL
+
+**Files:**
+- Modify: `utils/exportTransactions.ts:48-54`
+- Modify: `storage/StorageExpoSQLite.ts` (add `getProvenTxHeights`)
+- Create: `__tests__/exportTransactionsHeights.test.ts`
+
+**Interfaces:**
+- Produces: `getProvenTxHeights(): Promise<Map<string, number>>` on `StorageExpoSQLite`.
+
+**Why:** `findProvenTxs({ partial: {} })` is an unbounded `SELECT * FROM proven_txs` that reads and `Array.from`-expands **every rawTx and merklePath in the wallet** purely to build a `txid → height` map. On a wallet with vault history that is hundreds of megabytes of transient heap for two columns.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { DatabaseSync } from 'node:sqlite'
+import { PROVEN_HEIGHTS_SQL } from '@/storage/methods/findSql'
+
+it('selects only txid and height', () => {
+  expect(PROVEN_HEIGHTS_SQL).toBe('SELECT txid, height FROM proven_txs')
+  const d = new DatabaseSync(':memory:')
+  d.exec('CREATE TABLE proven_txs (txid TEXT, height INTEGER, rawTx BLOB)')
+  d.prepare('INSERT INTO proven_txs VALUES (?,?,?)').run('aa', 42, Buffer.alloc(1024))
+  const rows = d.prepare(PROVEN_HEIGHTS_SQL).all() as any[]
+  expect(rows).toEqual([{ txid: 'aa', height: 42 }])
+  expect(Object.keys(rows[0])).not.toContain('rawTx')
+})
+```
+
+- [ ] **Step 2: Run to verify it fails, implement, verify it passes**
+
+Run: `npx jest __tests__/exportTransactionsHeights.test.ts`
+
+- [ ] **Step 3: Use it in `exportTransactions.ts`**
+
+Replace the `findProvenTxs` loop with `await storage.getProvenTxHeights()`, keeping the existing `heightMap` variable name and shape so the rest of the function is untouched.
+
+- [ ] **Step 4: Full verification and commit**
+
+```bash
+npx tsc --noEmit && npx jest
+git add utils/exportTransactions.ts storage/StorageExpoSQLite.ts storage/methods/findSql.ts __tests__/exportTransactionsHeights.test.ts
+git commit -m "perf(export): read txid/height directly instead of every rawTx in the wallet"
+```
+
+---
+
+### Task 5: Two call-site hygiene fixes
+
+**Files:**
+- Modify: `context/WalletContext.tsx:2106` (add `noRawTx: true`)
+- Modify: `app/index.tsx:1185-1195` (destructure `nativeEvent` before the async handler)
+
+**Interfaces:** none.
+
+**Why:** the WalletContext call needs only `transactionId` and reads the full rawTx for nothing — free win now that Task 1 makes `noRawTx` real. The `app/index.tsx` handler captures the whole `WebViewMessageEvent` in its async closure, retaining the JSON string (3.6-4.0 N measured) for the entire duration of every wallet call.
+
+- [ ] **Step 1: Apply both edits**
+
+For `app/index.tsx`, keep `handleMessage` async but extract `const { data, url } = event.nativeEvent` in a thin non-async wrapper and pass those two values in, so the event object is not reachable from the coroutine environment.
+
+- [ ] **Step 2: Verify**
+
+Run: `npx tsc --noEmit && npx jest`
+Expected: clean; all suites pass (`__tests__/iframeWalletRoundTrip.test.ts` and `__tests__/documentStartScript.test.ts` exercise the message path).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add context/WalletContext.tsx app/index.tsx
+git commit -m "perf(wallet): stop retaining webview message strings and reading unused rawTx"
+```
+
+---
+
+### Task 6: `abortReservingOutpoints` via `outputs.spentBy`
+
+**Files:**
+- Modify: `services/vault/transfers.ts:214-266`
+- Modify: `storage/StorageExpoSQLite.ts` (add `findSpendingTxidsForOutpoints`)
+- Modify: `__tests__/vault/transfers.test.ts`
+
+**Interfaces:**
+- Produces: `findSpendingTxidsForOutpoints(outpoints: string[]): Promise<string[]>` — the txids of transactions whose `outputs.spentBy` marks them as spending any of the given outpoints.
+
+**Why:** the current heal pages up to 25 × 200 actions with `includeInputs: true` and `stopAfter: Infinity`, purely to string-match `sourceOutpoint`. `listActionsSql` answers each page by fetching full rawTx and calling `Transaction.fromBinary` per action to read `input?.sequence` — so a vault withdrawal retry parses thousands of transactions to find one outpoint.
+
+- [ ] **Step 1: Write the failing test in the existing vault suite**
+
+Add a case asserting that a wedged outpoint is healed with a single query rather than a paged scan: seed the mock wallet so `listActions` would need to be called, assert `listActions` is **not** called, and assert `abortAction` is called with the reserving reference.
+
+- [ ] **Step 2: Run to verify it fails, implement, verify it passes**
+
+Run: `npx jest __tests__/vault/transfers.test.ts`
+
+- [ ] **Step 3: Full verification and commit**
+
+```bash
+npx tsc --noEmit && npx jest
+git add services/vault/transfers.ts storage/StorageExpoSQLite.ts __tests__/vault/transfers.test.ts
+git commit -m "perf(vault): find the reserving transaction by outpoint instead of paging every action"
+```
+
+---
+
+## Self-review
+
+**Spec coverage (§7 + B0):** column projection → Task 1; SQL `substr` range reads → Task 2; `history` cap → Task 3; `exportTransactions` → Task 4; `noRawTx` at WalletContext and the retained event string → Task 5; `abortReservingOutpoints` → Task 6.
+
+**Deferred from §7 with reason:** "stop `Array.from`-ing large BLOBs" is **not** in this plan. `validateEntity` converts every `Uint8Array` to `number[]` because the toolbox's entity classes and `TableOutput`/`TableTransaction` types are declared `number[]`; changing that at the storage boundary is a cross-cutting type change that belongs with spec step B1 (codec to `Uint8Array` end to end), not here. Tasks 1, 2 and 4 remove the three worst *instances* of it without touching the contract. `releaseTemplateCache` guidance is a comment-only change deferred to the codec plan, where it is testable.
+
+**Type consistency:** `buildFindSql`, `columnsExcluding`, `BLOB_COLUMNS`, `rangeReadSql`, `PROVEN_HEIGHTS_SQL` all live in `storage/methods/findSql.ts` and are referenced by those exact names in Tasks 1, 2 and 4. `scrubNoteValues`/`NOTE_VALUE_MAX` live in `storage/methods/historyNotes.ts`. `getProvenTxHeights` and `findSpendingTxidsForOutpoints` are both methods on `StorageExpoSQLite`.
+
+**Follow-on plans (this spec, in order):** (2) WalletInterface size caps + vault input cap + offline gate; (3) disk-space guard, typed storage errors, reclaim report; (4) the compressed-at-rest codec programme B1-B6.

--- a/docs/superpowers/specs/2026-08-19-tx-size-limits-and-blob-compression-design.md
+++ b/docs/superpowers/specs/2026-08-19-tx-size-limits-and-blob-compression-design.md
@@ -1,0 +1,220 @@
+# Compressed-at-rest R1-K1 transactions, size caps, and storage pressure
+
+**Date:** 2026-08-19
+**Status:** design, awaiting review
+**Research:** two multi-agent sweeps (16 agents, ~2.8 M tokens) over the codec, storage, backup, disk/SQLite, GC schema, wallet boundary, toolbox byte consumers, broadcast boundaries and codec feasibility, plus five adversarial critics. Claims carry `file:line`; the ones the design rests on were spot-verified by hand.
+
+## 1. Constraints (product owner, fixed)
+
+- The R1-K1 script is stored **compressed everywhere it is stored**, including inside transaction `rawTx` and including the rows that feed broadcast. Full bytes exist only at the moment of handing a transaction to an external service.
+- Compression/decompression ships everywhere. **Older builds are not a consideration.**
+- **No migration or backfill** — no R1-K1 output exists in any production database, and no device is wedged.
+- Expansion is a **generic wire-serialiser concern**, not a vault-task concern: expand-and-verify at the outbound boundary, assert everywhere else.
+- **Vault transactions are refused while offline.** The offline queue is for small casual default-basket payments only.
+- 100 MB is the network's transaction ceiling; nothing larger should be attempted.
+- Low disk surfaces a typed error whose remedy is clearing old transaction data.
+
+## 2. Three corrections to earlier assumptions in this design
+
+**2.1 "Keep the stored transaction structurally normal, with compressed scripts in place" must be rejected.** I argued for it because a parseable blob lets structure-only consumers work without expanding. That property is exactly the hazard: in-place substitution with a rewritten length varint produces a **syntactically valid transaction with a wrong txid**, and nothing in the stack hashes stored bytes to notice. `processOfflineActions.ts:110-127` exists to prevent orphan cascades and cannot catch this, because nothing throws. Unexpanded bytes must be **unparseable**: the envelope's first byte is `0xfe`, a value no rawTx (`01|02 00 00 00`), BEEF (`01|02 00 be ef`) or AtomicBEEF (`01 01 01 01`) can begin with, and distinct from the compressed-*script* marker `0xff`.
+
+**2.2 Vault outputs do have `scriptOffset`/`scriptLength`, and the slice path is live.** I claimed they would be null so the toolbox's re-slice never engages. The opposite is true: `maxOutputScript = 1024` ([StorageExpoSQLite.ts:98-102](../../../storage/StorageExpoSQLite.ts)), so a 959,632-byte script is *not* stored inline — the offsets are recorded instead, and `getRawTxOfKnownValidTransaction(txid, offset, length)` slices rawTx at them. Slicing an envelope returns wrong bytes **with no exception**, `Services.hashOutputScript` hashes them, the chain says "not a UTXO", and three writers persist `spendable = false` (`attemptToPostReqsToNetwork.js:472`, `StorageProvider.js:779`, `StorageProvider.js:856-861`). The vault balance vanishes from the wallet's own view with nothing in the logs. **The envelope must therefore serve `readRange(offset, length)` from its span list**, and the byte-compare test at the recorded offset is the single most important test in the programme.
+
+**2.3 "Expand only at the broadcast boundary" is not implementable as one seam.** `mergeReqToBeefToShareExternally` reads bytes off the `findProvenTxReqs` row its caller already loaded (`StorageProvider.js:301-307`, `attemptToPostReqsToNetwork.js:82`) — and that same row read also feeds the monitor's destructive txid tripwire and `getSyncChunk`, both of which must keep seeing compressed bytes. There is no single choke point. The design is safe only as an **explicitly enumerated multi-seam boundary** (§4.3) with a runtime assert at the parse primitives.
+
+## 3. What the toolbox actually does with stored bytes
+
+| Site | Behaviour | Consequence for compressed storage |
+|---|---|---|
+| `TaskCheckForProofs.getProofs` (`monitor/tasks/TaskCheckForProofs.js:116-127`) | Re-hashes `proven_tx_reqs.rawTx`, compares to the stored `txid`, sets `status='invalid'` on mismatch and fails every notified transaction | **A live tripwire on a schedule.** Compressed reqs are invalidated minutes after a foreground test passes. `invalid` is not reversible by the app |
+| `Beef.verifyBumpIndexLeaves` (`@bsv/sdk/.../Beef.js:974-985`, `BeefTx.js:83-87`) | Requires `hash256(rawTx)` to equal a level-0 BUMP leaf | **Un-patchable by subclassing.** Once mined, the chain commits to the real bytes, so a compressed `proven_txs.rawTx` fails `Beef.verify()` permanently — breaking `createAction` inputBEEF validation for every later vault spend |
+| `Beef.verify(chainTracker)` at four entry points (`processAction.js:71-79`, `createAction.js:495-498`, signer + storage `internalizeAction`) | Transitively hashes rawTx | Four independent hard gates |
+| `Services.applyRawTxResult` (`services/Services.js:471-483`) | Verifies **network-sourced** bytes against the requested txid, discards on mismatch | The natural **inbound** compress point |
+| `getProvenOrRawTx`, `getRawTxOfKnownValidTransaction`, `mergeReqToBeefToShareExternally`, `getValidBeefForTxid`, `verifyKnownValidTransaction` | Return or merge stored bytes with **no hashing** | The whole read side is unguarded — which is why compression "works" in unit tests and fails in the monitor and the broadcaster |
+| `EntityProvenTx.fromTxid` | Docstring claims it verifies `hash(rawTx) === txid`; **the body never hashes** | Compressed bytes propagate from `proven_tx_reqs` into `proven_txs` unchallenged, reaching the un-patchable gate above |
+| `attemptToPostReqsToNetwork` → `mergeReqToBeefToShareExternally` → `services.postBeef` | The one path where stored bytes become network payload | `mergeReqToBeefToShareExternally` is **abstract** (`StorageProvider.d.ts:39-40`) and implemented in *our* [StorageExpoSQLite.ts:1220-1251](../../../storage/StorageExpoSQLite.ts) — so this seam needs an override, not a patch |
+| `Arcade` provider (`services/providers/Arcade.js:229-237`) | Rebuilds Extended Format per txid | Worst case on the wire: EF re-embeds each input's **source** locking script, so spending one R1-K1 output puts ~960 KB into the HTTP body even when the spending transaction is small |
+
+## 4. Part 1 — the compressed-at-rest programme
+
+### 4.1 Envelope format (`services/vault/txEnvelope.ts`)
+
+```
+magic(1)=0xfe ‖ version(1)=0x01 ‖ flags(1) ‖ txid(32, internal order)
+  ‖ origLength(4 BE) ‖ spanCount(1)
+  ‖ spanCount × { offset(4 BE) ‖ recLen(2 BE) ‖ record }
+  ‖ literalLen(4 BE) ‖ literal
+```
+
+A **span list**, not in-place substitution (§2.1). Expansion is a pure splice, so byte-exactness does not depend on reasoning about varint canonicality — and a rawTx carrying a deliberately non-canonical script-length varint must round-trip to the *original* txid rather than being normalised. That is a required test case.
+
+**Self-verifying expansion:** expand → `hash256` → compare to the recorded `txid`. At ~960 KB saved per span, 32 bytes of txid is free, and it converts every silent corruption into a loud, attributable failure.
+
+**Refuse to expand** when spans overlap, are out of ascending order, or `Σ(span lengths) + literalLen ≠ origLength`.
+
+### 4.2 Span discovery must be structural, never a byte search
+
+Region `0x02` (the preimage scriptCode) is a **byte-for-byte suffix** of region `0x01` (the locking script) — `PREIMAGE_SCRIPT_CODE_OFFSET = 60` ([templateCodec.ts:114](../../../services/vault/templateCodec.ts)) — so any sliding-window matcher yields overlapping ambiguous spans. Walk the transaction instead:
+
+`version(4)` → varint `nIn` → per input `{ skip 36, read varint L; candidate iff L === 959,871 with the framing canary 0x40@0 / 0x21@65 / 0x20@99 / 0x4e@132 / f5 a4 0e 00@133-136 / 0x00@959,870 and inner scriptCode varint fe 54 a4 0e 00@241-245, then take the span at inner offset 246, length 959,572; skip L+4 }` → varint `nOut` → per output `{ skip 8, read varint L; candidate iff L === 959,632; skip L }` → skip 4 and assert the cursor lands exactly on the buffer end.
+
+Use **one** varint reader for discovery and validation: `Transaction.fromReaderInternal` uses `readVarIntNum()` while `BeefTx.scanRawTransaction` uses `readVarIntNum(false)`, and they disagree on `0xff`-prefixed high-bit counts.
+
+The canary rejects a non-match in ~20 byte reads; a genuine candidate pays the full 959 K-byte compare (~5.85 ms on V8, extrapolating to 0.4-1.0 s of blocked JS thread for a 21-instance transaction on Hermes). **Set a size ceiling above which compression is skipped rather than attempted, and yield between candidates.**
+
+### 4.3 The boundary, enumerated
+
+**Compression (write) — five hooks plus three assertions:** `insertProvenTxReq` (:476), `updateProvenTxReq` (:594), `insertTransaction` (:559), `updateTransaction` (:654), `insertOutput`/`updateOutput` (:522/:624, step B6); write-side envelope assertions in `sqlInsert` (:381), `sqlUpdate` (:403), `sqlUpdateComposite` (:429).
+
+**Expansion (read) — seven functions, and only these:**
+
+| # | Site | Why |
+|---|---|---|
+| E1 | `getProvenOrRawTx` ([:1220](../../../storage/StorageExpoSQLite.ts)) | Feeds BEEF assembly and signing |
+| E2 | `getRawTxOfKnownValidTransaction` ([:1235](../../../storage/StorageExpoSQLite.ts)) | Range reads → served by `readRange`, never by slicing the envelope |
+| E3 | `findOutputs` script loop ([:785-789](../../../storage/StorageExpoSQLite.ts)) | Before `validateOutputScript`, never after |
+| E4 | `findTransactions` ([:864-868](../../../storage/StorageExpoSQLite.ts)) | |
+| E5 | `mergeReqToBeefToShareExternally` (new override) | The single convergence point for every broadcaster, including the toolbox's own `ArcadeBeef` |
+| E6 | `getBeefForTransaction.js:121,129` (patch) | Reached from `createAction.js:251` and `:783` with a fan-out of 8 — the site the first census missed |
+| E7 | `TaskCheckForProofs.js:117` (patch) | Expand **before** `doubleSha256BE`, and split the outcome: an *unexpandable* blob must **not** become `status='invalid'` (irreversible, cascades) — only successfully-expanded bytes that hash wrong are genuinely invalid |
+
+Plus `StorageProvider.js:513,533` and `createAction.js:558`.
+
+**Type-level enforcement is impossible** — a branded type is erased the moment bytes cross into `node_modules` (`StorageProvider.d.ts:39-40` declares `Promise<number[] | undefined>`). So: an `assertExpanded` guard at the top of `Transaction.fromBinary`, `fromBinaryView`, `Beef.mergeRawTx` and `BeefTx.scanRawTransaction` (**both** `dist/cjs` and `dist/esm`) that throws naming the txid when it sees `0xfe`. One patch covers eight-plus parse sites and turns any missed seam into a loud failure. Add a test asserting the guard is *present*, not merely that the patch applied — and make CI fail hard when any patch in `patches/` does not apply, because `patch-package` failures in `postinstall` are easy to miss and a dropped patch degrades to silent wrong behaviour.
+
+### 4.4 Template version registry — required, not optional
+
+`describeVaultTemplate()` returns descriptors for exactly one `TEMPLATE_VERSION` and `referenceBytesFor` refuses every other ([templateCodec.ts:331-378](../../../services/vault/templateCodec.ts)). So **the first change to the vendored artifact makes every stored envelope permanently unexpandable** — in `proven_tx_reqs`, `transactions`, `proven_txs` and every backup at once. "No migration needed" silently converts into "migration impossible", and the victim is the current build's own data written by yesterday's binary.
+
+Replace the single artifact with an **append-only version-keyed registry**, return a descriptor per entry, and add a CI test hashing the serialised entry list against a committed golden digest so no historical entry can be removed or mutated.
+
+### 4.5 Sequencing
+
+**B0 — make `noRawTx`/`noScript` real (ship first, no codec).** `sqlFind` always emits `SELECT *` ([:334](../../../storage/StorageExpoSQLite.ts)), so every BLOB is read and `Array.from`-expanded (~8× heap under Hermes) then discarded post-hoc. Add a column list and emit a projection. Five callers already ask for the cheap path and pay full price ([:1499](../../../storage/StorageExpoSQLite.ts), [listActionsSql.ts:89](../../../storage/methods/listActionsSql.ts), [processOfflineActions.ts:342](../../../storage/methods/processOfflineActions.ts), [payerHold.ts:80](../../../utils/offline/payerHold.ts), [WalletContext.tsx:1937](../../../context/WalletContext.tsx)). This shrinks the number of sites that ever see bytes, de-risking everything after it.
+
+**B1 — codec to `Uint8Array` end to end**, with `number[]` adapters at the edge; replace `Array.from(reference)` with `reference.slice()`. Must land whole: a partial migration costs 24 ms per `Array.from` and 2× hash cost at every crossing.
+
+**B2 — the envelope** (§4.1-4.2), with `readRange`.
+
+**B3 — install the expansion boundary while still writing uncompressed.** E1-E7 plus the patches, all dispatching through `classify(blob)` with a fall-through raw path. Ships as a behavioural no-op. Also remove `ArcadeBeef` from `postBeefServices`: `Services` registers it first (`Services.js:86-88`) and [WalletContext.tsx:800-803](../../../context/WalletContext.tsx) removes four other providers but not that one, so the toolbox's hex-in-JSON poster is still the primary broadcaster.
+
+**B4 — compress `proven_tx_reqs.{rawTx,inputBEEF}` and `transactions.inputBEEF`.** This alone fixes the backup wedge, `TaskSendWaiting`'s 8-second full-BLOB re-read of up to 100 rows, and the offline drain's merge loop. **Primary success criterion for the whole programme:** after a real deposit and withdrawal on device, `estimateEncodedBytes` clears `MAX_BLOB_BYTES` and the backup cursor *advances*.
+
+**B5 — compress `proven_txs.rawTx` last, behind its own flag.** That row *is* the merkle evidence (`BLOB NOT NULL`, [createTables.ts:31](../../../storage/schema/createTables.ts)) and `Beef.verifyBumpIndexLeaves` is the un-patchable gate. Verification: spend a vault output whose source is a compressed `proven_txs` row and assert `beef.verify()` at `createAction.js:495` passes.
+
+**B6 — sync-chunk `outputs.lockingScript`, gated on a capability flag.** `getSyncChunk` calls `findOutputs` without `noScript`, so `validateOutputScript` puts a full ~960 KB script into the chunk for a column the origin device stores as NULL. Separately, `storage/portable/index.js:58-63` base64s byte columns verbatim and neither `getSyncChunk` nor `processSyncChunk` inspects them, so envelopes replicate to peer storage with no signal — and byte-for-byte entity diffs mean a mixed fleet sees every record as changed and re-pushes forever. **Sync must be gated on a declared capability, not assumed.**
+
+### 4.6 Backup envelope versioning
+
+`utils/backup/codec.ts` has no version field of any kind. Put the codec version **plus the registry digest** in the backup envelope, check it before `processSyncChunk` ([restore.ts:80](../../../utils/backup/restore.ts)), and refuse the **whole** restore — never partially apply — on an unknown version. Binary magic inside the plaintext, before encryption; never a JSON envelope (an old build parses it, `isEmptyChunk` reads it as the completion sentinel, and `restoreOnImport` returns `restored: true, chunks: 0` — a healthy-looking wallet with no history), and never a marker outside the ciphertext (fails inside `wallet.decrypt` indistinguishably from the wrong-seed case).
+
+Generic gzip of the serialised chunk (1.28 MB → ~12.6 KB measured) is now **optional**: B4 fixes the wedge at the source. Keep it as a later independent win, and either way retire `estimateEncodedBytes` as the cap gate — its contract is to *underestimate*, so it refuses exactly the chunks compression makes fit.
+
+## 5. Part 2 — WalletInterface size caps
+
+Measured on shipped Hermes v0.14.1: peak RSS ≈ **20× N** central, **30× N** planning (native intake 7-16 N + JSON string 3.6-4.0 N retained for the whole call + `number[]` 4.0 N + GC slack + `Uint8Array` 1.0 N + SQLite copies 2.0 N).
+
+**100 MB cannot be a memory cap.** At 20-30× that is a 2-3 GB peak — above the jetsam limit of every iPhone with ≤4 GB — and the failure is an uncatchable `LLVM ERROR: OOM`, so there is no degrade path. 100 MB stays the *network* ceiling; the *memory* ceiling is separate. Under the stated 800 MB transient budget the arithmetic supports ~27 MB per call; under 300 MB, ~10 MB.
+
+**Recommended page-facing aggregate: 4 MB per call** (2 MB on `low` tier via [getDeviceTier()](../../../utils/deviceTier.ts)). The largest legitimate page payload today is a 65,536-byte localpay AtomicBEEF and a ~25-byte P2PKH script, so 4 MB is ~60× observed traffic.
+
+| Field | Cap | Warn |
+|---|---|---|
+| aggregate per call | 4 MB (2 MB low) | 1 MB |
+| single output `lockingScript` | 100 KB | 25 KB |
+| sum of output `lockingScript` | 500 KB | — |
+| `outputs` / `inputs` array length | 1,000 | — |
+| declared `inputs[i].unlockingScriptLength` | 100,000 | — |
+| sum of declared `unlockingScriptLength` | 500,000 | — |
+| `signAction` spend `unlockingScript` | 100 KB | — |
+| `inputBEEF` | 2 MB | 256 KB |
+| `internalizeAction` `args.tx` | 1 MB | 64 KB |
+| `customInstructions` per output | 4 KB | — |
+
+The declared `unlockingScriptLength` cap cannot be substituted by a byte cap: the SDK only cross-checks it against a *supplied* script (`validationHelpers.js:372-375`), so a page can declare 959,871 per input with a near-empty payload and make the wallet fund a ~1 MB-per-input transaction. Also refuse a page-supplied `lockingScript` whose first byte is `0xff` — provably unspendable, and it closes the decoder-poisoning path.
+
+**Placement:** a `capWalletArgs` Proxy shaped like [guardVaultAccess](../../../services/vault/guard.ts), composed at each external call site — [app/index.tsx:729](../../../app/index.tsx), [pair.tsx:92](../../../app/pair.tsx), [connections.tsx:123,137,175](../../../app/connections.tsx). Exempt the vault **by call site**, not by originator string: the vault calls `permissionsManager` directly and never enters the dispatcher. A cap in `guardVaultAccess`, `SimpleWalletManager`, `WalletPermissionsManager` or the toolbox breaks the vault outright. Refuse as `sendErrorToWebView(msg.id, '<field> exceeds the <N>-byte limit', 6)` to match `WERR_INVALID_PARAMETER`.
+
+**Pre-parse ceiling** before [app/index.tsx:1192](../../../app/index.tsx): 32,000,000 chars when `data.startsWith('{"type":"FILE_DOWNLOAD_BLOB"')`, else 8,000,000. Comment it as a damage limiter — 7-16 N is already spent natively by then, and closing it fully needs a `react-native-webview` patch.
+
+### 5.1 The app's own payload is the bigger risk
+
+`spendVaultOutputs` spends **every** vault output with no input cap ([transfers.ts:402-412](../../../services/vault/transfers.ts)), and `toEF()` re-embeds each input's source locking script, so even the leanest binary path is ~188 MB at 20 inputs *regardless of storage encoding*. Compression at rest does not bound what leaves the device.
+
+**Add an input cap of 6 per withdrawal (hard ceiling 8)**, re-vaulting the remainder, with a legible "consolidate the vault first" refusal **before** `signAction` ([:577](../../../services/vault/transfers.ts)) — today the only bound is a 30 s AbortSignal, and the failure lands *after* the point-of-no-abort comment at `:563`, where an OOM strands a signed transaction whose inputs nothing releases. The cap sits inside all three constraints: measured memory (~110-150 MB at 6 vs ~350 MB at 20), Arcade's 10 MB `MaxTxSizePolicy` (~10 inputs), and its 32 MiB single-tx endpoint (~18 inputs).
+
+### 5.2 Vault refused while offline
+
+Gate `depositToVault` and `withdrawFromVault` on the app's online signal with a typed `VaultError`. This is also what makes the offline-queue assertion exhaustive: no vault row can reach `offline_actions`, so the drain's in-memory `Beef` ([processOfflineActions.ts:129-132](../../../storage/methods/processOfflineActions.ts)) and the localpay serialisers only ever see default-basket traffic, and "a `0xfe` blob here is a bug" becomes a testable invariant rather than a hope.
+
+### 5.3 Boundaries compression does not help
+
+- **402 paid-GET** puts the whole AtomicBEEF into an HTTP *header* as base64 ([bsvPaymentHandler.ts:232-250](../../../utils/webview/bsvPaymentHandler.ts)), where intermediaries cap headers at 8-16 KiB.
+- **peerpay/MessageBox** hands a token to a third-party wallet with no R1-K1 codec, and persists `transaction: number[]` indefinitely.
+- **localpay radio** send at [NearbyFlow.tsx:1105](../../../components/pay/NearbyFlow.tsx) has **no size gate** while both QR branches do, and `socket.ts:15-19` base64s one byte at a time. Today vault-funded frames are refused as `local_pay_too_large`; anything that makes them fit will send them, and `verify.ts:86-93` compares locking-script hex for equality so a codec mismatch declines as `not_mine`. Gate the radio send and fix the encoder before B4.
+
+Because vault change lands in the **default basket** and BEEF/EF require every input's source transaction in full, an ordinary payment can drag a full withdrawal ancestor across any of these with no vault operation in the session. Scoping this work to `services/vault/*` would leave live paths uncovered.
+
+## 6. Part 3 — disk pressure and reclaiming space
+
+**Free space:** `import { Paths } from 'expo-file-system'` then `Paths.availableDiskSpace` — a synchronous getter. `getFreeDiskStorageAsync` from the bare specifier **throws at runtime** (verified, [legacyWarnings.ts:105-109](../../../node_modules/expo-file-system/src/legacyWarnings.ts)); the only valid async form is the `expo-file-system/legacy` subpath. Guard the read — the native getter is `Int64?` and returns nil on failure while TypeScript claims `number`, so an unguarded comparison fails *open*.
+
+**Absolute thresholds only** — `Paths.totalDiskSpace` returns free space on iOS, so any percentage never fires. Warn under 200 MB; block non-essential writes under 50 MB.
+
+**Classify by message text, not code.** Every SQLite failure carries `code === 'ERR_INTERNAL_SQLITE_ERROR'`. Match unanchored on the sqlite text (`/database or disk is full/i`, `/disk I\/O error/i`) and **exclude** `/database is locked/i`. Do not parse a numeric code — Android appends it as a raw control character (`NativeDatabaseBinding.cpp:196`). New `storage/errors.ts` modelled on [services/vault/types.ts:6-82](../../../services/vault/types.ts). Hook both the pre-write gate and the classifier into `transaction()` ([:147-170](../../../storage/StorageExpoSQLite.ts)); pre-emptive checking is required because `withExclusiveTransactionAsync` awaits ROLLBACK inside its catch *before* recording the error, so a rollback failing under disk pressure destroys the diagnosis. Surface with `showAlert`, not `showToast`. **WAL is not enabled**; the companion is a transient `-journal`.
+
+**Reclaiming: the requested rule must not ship as stated.** "Drop the oldest transactions whose outputs are all spent" fails on three verified grounds: spent-ness is **reversible** (`releaseInputsAllocatedToFailedTransaction` restores `spendable = 1`, so pruning inside that window strands the coin with `ignoreServices: true` and no network recovery); proven-ness does not close the transitively-required ancestry (`storageProviderHelpers.js:49-66`); and the backup delta protocol has **no deletes**, so pruning looks harmless in testing and then the next generation rotation snapshots the pruned database — the loss surfaces weeks later on another device during a recovery.
+
+- **E1 (ship): a read-only report.** Rows and reclaimable bytes per table per rule, plus which guard excluded each near-miss. Predicted answer: nearly all of it is `transactions.inputBEEF` plus duplicated vault blobs, in which case E2 plus Part 1 is the whole feature.
+- **E2 (ship): null exactly one column** — `transactions.inputBEEF`. Nothing reads it for BEEF (`getProvenOrRawTx` reads `proven_txs` then `proven_tx_reqs`), which is why it is the safe target. Predicate: `status='completed' AND provenTxId IS NOT NULL AND proven height ≤ tip-100 AND no non-completed proven_tx_req for the txid AND no queued/posting offline_action AND updated_at < cutoff`. Deliberately **no spent-ness term**. Needs raw `db.runAsync` — `updateTransaction` cannot write NULL until `sqlUpdate`'s undefined-skip is fixed (verified, [:412-417](../../../storage/StorageExpoSQLite.ts)).
+- **E3 (defer): `proven_txs.rawTx` nulling** — only behind all eight exclusion clauses, and I would still argue against it.
+- **Never triggered by low disk.** On a nearly full volume the rollback journal for a large UPDATE can itself fail with `SQLITE_FULL`, and with no WAL and no `auto_vacuum` the file does not shrink, so the user sees zero benefit. Manual action, gated on a verified recent backup, refused outright on a wallet wedged by the oversize bail.
+- **Bound the offline queue** regardless: `processOfflineActions.ts:128-138` turns any failure into `blocked` and requeues forever with no attempt cap, no expiry and no local terminal state — reservations are never released. Give rows an attempt/age budget with a user-visible terminal state that **releases** the reservation.
+
+## 7. Independent wins to ship before any codec wiring
+
+Each shrinks the blast radius and stands alone:
+
+- Push offset/length into SQL (`SELECT substr(rawTx, ?, ?)`) at [:1235-1250](../../../storage/StorageExpoSQLite.ts).
+- Stop `Array.from`-ing large BLOBs to `number[]` at [:206-213](../../../storage/StorageExpoSQLite.ts) — ~8× Hermes heap reduction on every row read.
+- **Cap the `history` column.** Provider error notes capture full EF/rawTx hex (`Arcade.js:110,137,149,195`; `WhatsOnChain.js:161,206`), `transferNotesToReqHistories` copies them verbatim into `proven_tx_reqs.history` untruncated, and `addHistoryNote`'s dedup does full string equality against every existing note. One failing vault broadcast writes multi-megabyte hex into a TEXT column and the second failure compares megabyte strings — quadratic, and triggered exactly when things go wrong. Cap note values at ~256 chars. This is a direct violation of "stored compressed everywhere" that no rawTx codec touches.
+- Replace `abortReservingOutpoints`' 25-page × 200-action `includeInputs` scan ([transfers.ts:255-266](../../../services/vault/transfers.ts)) with a direct query over `outputs.spentBy`, and populate the declared-but-never-written `outputs.sequenceNumber` so `listActionsSql`'s per-action `Transaction.fromBinary` disappears.
+- `exportTransactionsAsCsv` does an unbounded `findProvenTxs({ partial: {} })` reading every rawTx and merklePath in the wallet to build a txid→height map ([exportTransactions.ts:48-54](../../../utils/exportTransactions.ts)). Make it `SELECT txid, height`.
+- Destructure `const { data, url } = event.nativeEvent` in a thin wrapper so the event is not captured across every await — releases 3.6-4.0 N for the whole call.
+- Retune `releaseTemplateCache` guidance: `ensureTemplateCache` is ~40 ms on desktop V8 without `node:crypto` and plausibly 120-330 ms on Hermes, not the "sub-frame" the comment claims. With the codec wired, cache-warm state becomes a latency precondition for broadcast and for every vault-basket `listOutputs`, so release only on a real memory-pressure signal.
+
+## 8. Testing — the suite must mine
+
+Every representation-agnostic site (`classifyReqStatus`, `verifyKnownValidTransaction`, `arraysEqual` entity diffs, `getSyncChunk`, the portable round trip) **passes green on compressed bytes**. A test that does not drive `mockchain/MockMiner.js` far enough to mine proves nothing.
+
+Required:
+
+1. `hash256(expand(compress(rawTx))) === recorded txid` for the real mined mainnet fixture, a synthetic 1-in/2-out withdrawal with a re-vault output, and a rawTx with a **non-canonical** script-length varint.
+2. `readRange` at a vault output's exact recorded `scriptOffset`/`scriptLength`, byte-compared against the original — plus a variant with `maxOutputScript` set below 51 so the slice path runs for a compressed row (today vault outputs are the only consumers of that path).
+3. Mine, then re-run `TaskCheckForProofs` and `Beef.verify` against the stored row.
+4. Spend a vault output whose source is a compressed `proven_txs` row; assert `beef.verify()` at `createAction.js:495` passes.
+5. An end-to-end signing test against a compressed-at-rest source validated through the **Spend VM**, not a mocked wallet — `transfers.ts:512-517` rebuilds the prevout script independently, and the R1K1 template prefers supplied `lockingScript` over `input.sourceTransaction`, so a compressed script reaching inputBEEF produces an invalid signature with **nothing thrown**.
+6. `0xfe` cannot begin a valid rawTx, BEEF or AtomicBEEF; `0xfe` and `0xff` never conflated.
+7. `assertExpanded` guards present in the patched SDK; CI fails hard on any `patches/` mis-apply.
+8. `matchesTemplate` is **not** an ownership oracle: a counterparty can mint a genuine R1-K1-shaped output committing to their own key and hand it in via `internalizeAction` from an arbitrary web origin. Basket membership plus `customInstructions` must remain the only authority — as a test, not a comment.
+9. Per-output `try/catch` in `findOutputs` so one corrupt envelope cannot take down `listOutputs`, the vault screen and backup wallet-wide; `getRawTxOfKnownValidTransaction` must distinguish "no such transaction" from "stored but unexpandable".
+
+Storage has no test harness today (`StorageExpoSQLite` is validated only on device). Extract the envelope, the predicate and the write plan into pure modules behind thin interfaces (the [offlineActions.ts:40-44](../../../storage/methods/offlineActions.ts) pattern) and test against `node:sqlite` with a schema built by `createTables`.
+
+## 9. Order of work
+
+1. **§7 independent wins** + B0 (`noRawTx`/`noScript`) + `history` cap. No codec, all upside.
+2. **Part 2 caps** including the vault input cap and the offline gate — highest severity, self-contained.
+3. **B1-B3** codec to `Uint8Array`, the envelope, the boundary installed as a no-op.
+4. **B4** compress `proven_tx_reqs` + `transactions.inputBEEF` → the backup cursor advances. Primary success criterion.
+5. **Part 3** disk guard, typed errors, E1 report.
+6. **B5** `proven_txs.rawTx`, then **B6** sync chunks with the capability flag.
+7. **E2** `inputBEEF` nuller, if the report justifies it.
+
+## 10. Open items needing device measurement
+
+- The 7-16 N native-intake term is reasoned from RN/RNW source, **not measured on device**. An RSS sampler around one 1 MB `internalizeAction` on both platforms settles it.
+- Baseline RSS with 1-3 warm tabs and a built wallet on a low-tier device — every transient budget is meaningless without it, and [deviceTier.ts:56-70](../../../utils/deviceTier.ts) already records this app being process-terminated for memory it considered normal.
+- Hermes cost of `ensureTemplateCache` and of the full 959 K-byte compare (the 0.4-1.0 s figure is extrapolated from V8).
+- `new File(dbPath).size` on Android.
+- Whether the 4 bytes-per-element `number[]` figure survives an RN/Hermes bump.

--- a/services/vault/transfers.ts
+++ b/services/vault/transfers.ts
@@ -49,6 +49,17 @@ import {
 export const VAULT_BASKET = 'admin vault'
 
 /**
+ * Storage-backed lookup of the transactions reserving a set of outpoints.
+ *
+ * Injected rather than imported so this module stays testable without a database
+ * — and optional, so a caller that has no storage handle keeps the original
+ * paged-scan heal. See findSpendingReferences in StorageExpoSQLite.
+ */
+export type SpendingReferenceLookup = (
+  outpoints: string[]
+) => Promise<{ reference: string; status: string }[]>
+
+/**
  * Economic-dust floor for a vault output — a hard minimum, not a caution.
  *
  * An R1 spend pays the ~960 KB script twice — once to create the output, once
@@ -253,8 +264,38 @@ async function abortReservingTxids(w: VaultWallet, adminOriginator: string, txid
 /** Abort the orphaned transactions holding these outpoints, matched on each
  * action's own input list — the only handle available when the reservation has
  * no txid to blame. */
-async function abortReservingOutpoints(w: VaultWallet, adminOriginator: string, outpoints: string[]): Promise<number> {
+async function abortReservingOutpoints(
+  w: VaultWallet,
+  adminOriginator: string,
+  outpoints: string[],
+  findSpendingReferences?: SpendingReferenceLookup
+): Promise<number> {
   if (outpoints.length === 0) return 0
+
+  // One indexed query when storage is reachable. The scan below answers the
+  // same question by paging up to 5,000 actions with includeInputs, and
+  // listActionsSql answers each page by loading every action's full rawTx and
+  // running Transaction.fromBinary on it to read a sequence number — so a vault
+  // retry parsed thousands of transactions to find one outpoint.
+  if (findSpendingReferences) {
+    try {
+      const rows = await findSpendingReferences(outpoints)
+      const aborted = new Set<string>()
+      for (const r of rows) {
+        if (!ABORTABLE.has(r.status) || aborted.has(r.reference)) continue
+        aborted.add(r.reference)
+        await w.abortAction({ reference: r.reference }, adminOriginator).catch(err =>
+          console.log('[vault] abortAction rejected:', (err as Error)?.message)
+        )
+      }
+      console.log('[vault] abort by outpoint · matched=%d · aborted=%d', rows.length, aborted.size)
+      return aborted.size
+    } catch (e) {
+      // A storage failure must not cost the retry: fall through to the scan.
+      console.log('[vault] spending-reference lookup failed, falling back to scan:', (e as Error)?.message)
+    }
+  }
+
   const want = new Set(outpoints.map(sameOutpoint))
   return await abortActions(
     w,
@@ -279,14 +320,15 @@ async function freeReservedInputs(
   w: VaultWallet,
   adminOriginator: string,
   e: unknown,
-  ours: string[]
+  ours: string[],
+  findSpendingReferences?: SpendingReferenceLookup
 ): Promise<number> {
   if (isReviewActionsError(e)) {
     return await abortReservingTxids(w, adminOriginator, competingTxids(e))
   }
   const mine = new Set(ours.map(sameOutpoint))
   const wedged = unspendableInputOutpoints(e).filter(o => mine.has(o))
-  return await abortReservingOutpoints(w, adminOriginator, wedged)
+  return await abortReservingOutpoints(w, adminOriginator, wedged, findSpendingReferences)
 }
 
 // ── balance ─────────────────────────────────────────────────────────────
@@ -356,7 +398,7 @@ async function spendVaultOutputs(
   amount: number | 'all',
   reason: string,
   spend: SpendPath,
-  opts: { revaultRemainder: boolean }
+  opts: { revaultRemainder: boolean; findSpendingReferences?: SpendingReferenceLookup }
 ): Promise<{ txid: string }> {
   // Announce work BEFORE starting it, then hand the JS thread back once so
   // React can actually paint the sheet. Everything below — a ~1.83 MB
@@ -458,7 +500,13 @@ async function spendVaultOutputs(
     // outright. Two error shapes, depending on whether the orphan ever got a
     // txid — see freeReservedInputs. Abort it and retry ONCE; anything else
     // frees nothing and rethrows untouched.
-    const freed = await freeReservedInputs(w, adminOriginator, e, selected.map(o => o.outpoint))
+    const freed = await freeReservedInputs(
+      w,
+      adminOriginator,
+      e,
+      selected.map(o => o.outpoint),
+      opts.findSpendingReferences
+    )
     if (freed === 0) throw e
     created = await w.createAction(caArgs, adminOriginator)
   }
@@ -591,12 +639,14 @@ export async function withdrawFromVault(
   w: VaultWallet,
   adminOriginator: string,
   amount: number | 'all',
-  reason: string
+  reason: string,
+  findSpendingReferences?: SpendingReferenceLookup
 ): Promise<{ txid: string }> {
   const signer = await requestVaultSigner(reason)
   try {
     return await spendVaultOutputs(w, adminOriginator, amount, reason, { path: 'r1', signer }, {
-      revaultRemainder: true
+      revaultRemainder: true,
+      findSpendingReferences
     })
   } finally {
     signer.release()
@@ -612,11 +662,13 @@ export async function sweepVaultWithHD(
   w: VaultWallet,
   adminOriginator: string,
   hd: HD,
-  reason: string
+  reason: string,
+  findSpendingReferences?: SpendingReferenceLookup
 ): Promise<{ txid: string } | null> {
   try {
     return await spendVaultOutputs(w, adminOriginator, 'all', reason, { path: 'k1', hd }, {
-      revaultRemainder: false
+      revaultRemainder: false,
+      findSpendingReferences
     })
   } catch (e) {
     if (e instanceof VaultError && e.code === 'vault-empty') return null

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -2,6 +2,7 @@ import * as SQLite from 'expo-sqlite'
 import type { SQLiteDatabase } from 'expo-sqlite'
 import { createTables, ensureOfflineActionsColumns } from './schema/createTables'
 import { PROVEN_HEIGHTS_SQL, buildFindSql, columnsExcluding, rangeReadSql } from './methods/findSql'
+import { scrubHistoryJson } from './methods/historyNotes'
 import { devLog } from '../utils/logging'
 import { StorageProvider } from '@bsv/wallet-toolbox-mobile'
 import type { StorageProviderOptions } from '@bsv/wallet-toolbox-mobile'
@@ -482,6 +483,9 @@ export class StorageExpoSQLite extends StorageProvider {
   async insertProvenTxReq(tx: TableProvenTxReq, trx?: TrxToken): Promise<number> {
     const e = await this.validateEntityForInsert(tx, trx)
     if (e.provenTxReqId === 0) delete e.provenTxReqId
+    // See methods/historyNotes.ts: provider error notes carry the full EF/rawTx
+    // hex and reach this column untruncated.
+    e.history = scrubHistoryJson(e.history)
     const id = await this.sqlInsert('proven_tx_reqs', e, 'provenTxReqId')
     tx.provenTxReqId = id
     return id
@@ -597,9 +601,15 @@ export class StorageExpoSQLite extends StorageProvider {
     return await this.sqlUpdate('proven_txs', id, u as any, 'provenTxId')
   }
 
+  /**
+   * The single write path for proven_tx_reqs, and therefore the backstop for the
+   * history column: every note the toolbox's own broadcast providers produce
+   * arrives here, and they capture whole Extended Format payloads as hex.
+   */
   async updateProvenTxReq(id: number | number[], update: Partial<TableProvenTxReq>, trx?: TrxToken): Promise<number> {
-    const u = this.validatePartialForUpdate(update)
-    return await this.sqlUpdate('proven_tx_reqs', id, u as any, 'provenTxReqId')
+    const u = this.validatePartialForUpdate(update) as any
+    if ('history' in u) u.history = scrubHistoryJson(u.history)
+    return await this.sqlUpdate('proven_tx_reqs', id, u, 'provenTxReqId')
   }
 
   async updateCertificate(id: number, update: Partial<TableCertificate>, trx?: TrxToken): Promise<number> {

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -1,6 +1,7 @@
 import * as SQLite from 'expo-sqlite'
 import type { SQLiteDatabase } from 'expo-sqlite'
 import { createTables, ensureOfflineActionsColumns } from './schema/createTables'
+import { PROVEN_HEIGHTS_SQL, buildFindSql, columnsExcluding, rangeReadSql } from './methods/findSql'
 import { devLog } from '../utils/logging'
 import { StorageProvider } from '@bsv/wallet-toolbox-mobile'
 import type { StorageProviderOptions } from '@bsv/wallet-toolbox-mobile'
@@ -319,6 +320,12 @@ export class StorageExpoSQLite extends StorageProvider {
     return { sql, params }
   }
 
+  /**
+   * @param columns explicit projection. Omit for `SELECT *`. Passing the
+   * non-blob columns is what makes `noRawTx`/`noScript` actually cheap: without
+   * it every BLOB is read off disk and `Array.from`-expanded by validateEntity
+   * before being discarded. See storage/methods/findSql.ts.
+   */
   private async sqlFind<T>(
     table: string,
     args: {
@@ -329,29 +336,28 @@ export class StorageExpoSQLite extends StorageProvider {
       trx?: TrxToken
     },
     pkCol: string,
-    extraClauses?: { conditions: string[]; params: any[] }
+    extraClauses?: { conditions: string[]; params: any[] },
+    columns?: string[]
   ): Promise<T[]> {
     const db = this.getDB()
     const { sql: whereSql, params } = this.buildWhere(args.partial)
-    let query = `SELECT * FROM "${table}" ${whereSql}`
 
-    if (args.since) {
-      query += `${whereSql ? ' AND' : ' WHERE'} updated_at >= ?`
-      params.push(this.validateDateForWhere(args.since))
-    }
-    if (extraClauses) {
-      for (const c of extraClauses.conditions) {
-        query += `${whereSql || args.since ? ' AND' : ' WHERE'} ${c}`
-      }
-      params.push(...extraClauses.params)
-    }
-    query += ` ORDER BY "${pkCol}" ${args.orderDescending ? 'DESC' : 'ASC'}`
-    if (args.paged?.limit) {
-      query += ` LIMIT ${args.paged.limit}`
-      if (args.paged?.offset) {
-        query += ` OFFSET ${args.paged.offset}`
-      }
-    }
+    // Params must be pushed in the same order buildFindSql emits their
+    // placeholders: where, then since, then the extra conditions.
+    if (args.since) params.push(this.validateDateForWhere(args.since))
+    if (extraClauses) params.push(...extraClauses.params)
+
+    const query = buildFindSql({
+      table,
+      whereSql,
+      hasSince: args.since !== undefined,
+      extraConditions: extraClauses?.conditions,
+      pkCol,
+      orderDescending: args.orderDescending,
+      limit: args.paged?.limit,
+      offset: args.paged?.offset,
+      columns
+    })
     return (await db.getAllAsync(query, params)) as T[]
   }
 
@@ -776,7 +782,11 @@ export class StorageExpoSQLite extends StorageProvider {
       'outputs',
       { ...args, partial },
       'outputId',
-      extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined
+      extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined,
+      // noScript callers get a projection that never reads the column. The
+      // post-hoc `o.lockingScript = undefined` below stays as the contract for
+      // any future caller that reaches here without the projection.
+      args.noScript ? columnsExcluding('outputs', ['lockingScript']) : undefined
     )
 
     const results = this.validateEntities(rows, undefined, ['spendable', 'change'])
@@ -855,7 +865,8 @@ export class StorageExpoSQLite extends StorageProvider {
       'transactions',
       args,
       'transactionId',
-      extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined
+      extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined,
+      args.noRawTx ? columnsExcluding('transactions', ['rawTx', 'inputBEEF']) : undefined
     )
 
     const results = this.validateEntities(rows, undefined, ['isOutgoing'])

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -1251,14 +1251,29 @@ export class StorageExpoSQLite extends StorageProvider {
   ): Promise<number[] | undefined> {
     if (!txid) return undefined
     if (!this.isAvailable()) await this.makeAvailable()
-    let rawTx: number[] | undefined
-    const r = await this.getProvenOrRawTx(txid, trx)
-    if (r.proven) rawTx = r.proven.rawTx
-    else rawTx = r.rawTx
-    if (rawTx && offset !== undefined && length !== undefined && Number.isInteger(offset) && Number.isInteger(length)) {
-      rawTx = rawTx.slice(offset, offset + length)
+
+    // Range reads are served in SQL. The caller here is almost always
+    // validateOutputScript re-slicing one output's locking script out of its
+    // source transaction, and with maxOutputScript = 1024 the outputs that take
+    // that path are exactly the ~960 KB vault scripts. Loading the whole rawTx
+    // to slice it meant reading ~960 KB off disk and Array.from-ing it into an
+    // ~960 K-element JS array to keep a few hundred bytes.
+    //
+    // Table order and the status filter mirror getProvenOrRawTx exactly (see
+    // rangeReadSql), so a range read can never see a row the full read refuses.
+    if (offset !== undefined && length !== undefined && Number.isInteger(offset) && Number.isInteger(length)) {
+      const db = this.getDB()
+      // substr is 1-indexed over bytes; a JS offset of n starts at n + 1.
+      const args = [offset + 1, length, txid]
+      const proven = (await db.getFirstAsync(rangeReadSql('proven_txs'), args)) as { chunk?: Uint8Array } | null
+      const row =
+        proven ?? ((await db.getFirstAsync(rangeReadSql('proven_tx_reqs'), args)) as { chunk?: Uint8Array } | null)
+      if (!row?.chunk) return undefined
+      return Array.from(row.chunk)
     }
-    return rawTx
+
+    const r = await this.getProvenOrRawTx(txid, trx)
+    return r.proven ? r.proven.rawTx : r.rawTx
   }
 
   async getLabelsForTransactionId(transactionId?: number, trx?: TrxToken): Promise<TableTxLabel[]> {

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -1,7 +1,14 @@
 import * as SQLite from 'expo-sqlite'
 import type { SQLiteDatabase } from 'expo-sqlite'
 import { createTables, ensureOfflineActionsColumns } from './schema/createTables'
-import { PROVEN_HEIGHTS_SQL, buildFindSql, columnsExcluding, rangeReadSql } from './methods/findSql'
+import {
+  PROVEN_HEIGHTS_SQL,
+  buildFindSql,
+  columnsExcluding,
+  rangeReadSql,
+  spendingReferencesSql,
+  splitOutpoint
+} from './methods/findSql'
 import { scrubHistoryJson } from './methods/historyNotes'
 import { devLog } from '../utils/logging'
 import { StorageProvider } from '@bsv/wallet-toolbox-mobile'
@@ -1261,6 +1268,32 @@ export class StorageExpoSQLite extends StorageProvider {
    * wallet to build a map of two small columns. On a wallet with vault history
    * that is hundreds of megabytes of transient heap.
    */
+  /**
+   * The transactions reserving the given outpoints, by `reference`.
+   *
+   * Answers in one indexed query (outputs.spentBy is indexed) what the vault's
+   * reservation heal previously answered by paging up to 5,000 actions with
+   * includeInputs — where listActionsSql loads each action's full rawTx and runs
+   * Transaction.fromBinary on it just to read a sequence number.
+   *
+   * `reference`, not `txid`: the reservation being healed belongs to an attempt
+   * that died before signing, so it has no txid. abortAction takes a reference.
+   */
+  async findSpendingReferences(outpoints: string[]): Promise<{ reference: string; status: string }[]> {
+    if (outpoints.length === 0) return []
+    if (!this.isAvailable()) await this.makeAvailable()
+    const pairs = outpoints.map(splitOutpoint).filter((p): p is { txid: string; vout: number } => p !== null)
+    if (pairs.length === 0) return []
+    const params = pairs.flatMap(p => [p.txid, p.vout])
+    const rows = (await this.getDB().getAllAsync(spendingReferencesSql(pairs.length), params)) as {
+      reference?: string
+      status?: string
+    }[]
+    return rows
+      .filter(r => typeof r.reference === 'string' && typeof r.status === 'string')
+      .map(r => ({ reference: r.reference as string, status: r.status as string }))
+  }
+
   async getProvenTxHeights(): Promise<Map<string, number>> {
     if (!this.isAvailable()) await this.makeAvailable()
     const rows = (await this.getDB().getAllAsync(PROVEN_HEIGHTS_SQL)) as { txid?: string; height?: number }[]

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -1253,6 +1253,24 @@ export class StorageExpoSQLite extends StorageProvider {
     return r
   }
 
+  /**
+   * txid -> height for every proven transaction.
+   *
+   * The CSV export used findProvenTxs({ partial: {} }) for this: an unbounded
+   * SELECT * that reads and Array.from-expands every rawTx and merklePath in the
+   * wallet to build a map of two small columns. On a wallet with vault history
+   * that is hundreds of megabytes of transient heap.
+   */
+  async getProvenTxHeights(): Promise<Map<string, number>> {
+    if (!this.isAvailable()) await this.makeAvailable()
+    const rows = (await this.getDB().getAllAsync(PROVEN_HEIGHTS_SQL)) as { txid?: string; height?: number }[]
+    const map = new Map<string, number>()
+    for (const r of rows) {
+      if (r.txid && typeof r.height === 'number') map.set(r.txid, r.height)
+    }
+    return map
+  }
+
   async getRawTxOfKnownValidTransaction(
     txid?: string,
     offset?: number,

--- a/storage/methods/findSql.ts
+++ b/storage/methods/findSql.ts
@@ -203,3 +203,30 @@ export function rangeReadSql(table: 'proven_txs' | 'proven_tx_reqs'): string {
  * merklePath in the wallet to build a map of two small columns.
  */
 export const PROVEN_HEIGHTS_SQL = 'SELECT txid, height FROM proven_txs'
+
+/**
+ * The transactions that have reserved the given outpoints, by `reference`.
+ *
+ * `reference` and not `txid` deliberately: this exists to heal a vault UTXO left
+ * reserved by an attempt that died BEFORE signing, so the reserving row has no
+ * txid at all — which is exactly why the old heal had to page every action and
+ * match on its input list. `abortAction` takes a reference anyway.
+ *
+ * One OR-group per outpoint rather than a row-value IN, so the query works on
+ * any SQLite build.
+ */
+export function spendingReferencesSql(pairCount: number): string {
+  const groups = Array.from({ length: pairCount }, () => '("o"."txid" = ? AND "o"."vout" = ?)').join(' OR ')
+  return (
+    'SELECT DISTINCT "t"."reference" AS reference, "t"."status" AS status ' +
+    'FROM "outputs" "o" JOIN "transactions" "t" ON "t"."transactionId" = "o"."spentBy" ' +
+    `WHERE "o"."spentBy" IS NOT NULL AND (${groups})`
+  )
+}
+
+/** Split a `txid.vout` or `txid:vout` outpoint into its parts, or null. */
+export function splitOutpoint(outpoint: string): { txid: string; vout: number } | null {
+  const m = /^([0-9a-fA-F]{64})[.:](\d+)$/.exec(outpoint.trim())
+  if (!m) return null
+  return { txid: m[1].toLowerCase(), vout: Number(m[2]) }
+}

--- a/storage/methods/findSql.ts
+++ b/storage/methods/findSql.ts
@@ -1,0 +1,205 @@
+/**
+ * SQL construction for the storage layer's read paths.
+ *
+ * Extracted from StorageExpoSQLite so the generated SQL is testable without a
+ * device: everything here is a pure string function.
+ *
+ * The reason this exists at all is `SELECT *`. Every finder used to read every
+ * column, which meant `validateEntity` ran `Array.from` over each BLOB (an
+ * ~8x heap multiplier under Hermes for a byte array) and `findOutputs` /
+ * `findTransactions` then threw the value away when the caller had asked for
+ * `noScript` / `noRawTx`. Five callers already ask for the cheap path. A vault
+ * transaction's rawTx is ~960 KB, so a page of them was tens of megabytes of
+ * transient heap to answer a question about integers.
+ */
+
+/**
+ * Columns of every table this module can project, in schema declaration order.
+ *
+ * SOURCE OF TRUTH: storage/schema/createTables.ts. These lists are duplicated
+ * here deliberately — SQLite has no `SELECT * EXCEPT`, so an explicit projection
+ * needs the names — and __tests__/storage/findSql.test.ts parses createTables.ts
+ * and fails if the two ever diverge. Add a column there and the test tells you
+ * to add it here.
+ */
+export const TABLE_COLUMNS: Record<string, string[]> = {
+  proven_txs: [
+    'provenTxId',
+    'created_at',
+    'updated_at',
+    'txid',
+    'height',
+    'index',
+    'merklePath',
+    'rawTx',
+    'blockHash',
+    'merkleRoot'
+  ],
+  proven_tx_reqs: [
+    'provenTxReqId',
+    'created_at',
+    'updated_at',
+    'txid',
+    'status',
+    'attempts',
+    'notified',
+    'history',
+    'notify',
+    'rawTx',
+    'inputBEEF',
+    'batch',
+    'provenTxId',
+    'wasBroadcast',
+    'rebroadcastAttempts'
+  ],
+  transactions: [
+    'transactionId',
+    'created_at',
+    'updated_at',
+    'userId',
+    'status',
+    'reference',
+    'isOutgoing',
+    'satoshis',
+    'description',
+    'version',
+    'lockTime',
+    'txid',
+    'inputBEEF',
+    'rawTx',
+    'provenTxId'
+  ],
+  outputs: [
+    'outputId',
+    'created_at',
+    'updated_at',
+    'userId',
+    'transactionId',
+    'basketId',
+    'spendable',
+    'change',
+    'outputDescription',
+    'vout',
+    'satoshis',
+    'providedBy',
+    'purpose',
+    'type',
+    'txid',
+    'senderIdentityKey',
+    'derivationPrefix',
+    'derivationSuffix',
+    'customInstructions',
+    'spentBy',
+    'sequenceNumber',
+    'spendingDescription',
+    'scriptLength',
+    'scriptOffset',
+    'lockingScript'
+  ],
+  commissions: [
+    'commissionId',
+    'created_at',
+    'updated_at',
+    'userId',
+    'transactionId',
+    'satoshis',
+    'keyOffset',
+    'isRedeemed',
+    'lockingScript'
+  ]
+}
+
+/** The BLOB columns per table — the ones worth not reading. */
+export const BLOB_COLUMNS: Record<string, string[]> = {
+  proven_txs: ['merklePath', 'rawTx'],
+  proven_tx_reqs: ['rawTx', 'inputBEEF'],
+  transactions: ['inputBEEF', 'rawTx'],
+  outputs: ['lockingScript'],
+  commissions: ['lockingScript']
+}
+
+/**
+ * Every column of `table` except `exclude`, or undefined when nothing is
+ * excluded.
+ *
+ * Undefined means "emit SELECT *" — the pre-existing behaviour. Returning it
+ * rather than the full list keeps the generated SQL identical for every caller
+ * that has no reason to project, so this change cannot alter their result rows.
+ */
+export function columnsExcluding(table: string, exclude: string[]): string[] | undefined {
+  if (exclude.length === 0) return undefined
+  const all = TABLE_COLUMNS[table]
+  if (!all) return undefined
+  const drop = new Set(exclude)
+  return all.filter(c => !drop.has(c))
+}
+
+export interface FindSqlOptions {
+  table: string
+  /** Pre-built WHERE clause (possibly empty) from buildWhere. */
+  whereSql: string
+  hasSince: boolean
+  extraConditions?: string[]
+  pkCol: string
+  orderDescending?: boolean
+  limit?: number
+  offset?: number
+  /** Explicit projection. Undefined emits SELECT *. */
+  columns?: string[]
+}
+
+/**
+ * Build a finder query.
+ *
+ * Clause order and the WHERE/AND choice are copied from the original inline
+ * implementation and must not be reordered: whether `since` and the extra
+ * conditions introduce `WHERE` or extend it with `AND` depends on what came
+ * before them.
+ *
+ * Every identifier is quoted, which is not cosmetic — proven_txs has a column
+ * literally named `index`.
+ */
+export function buildFindSql(opts: FindSqlOptions): string {
+  const projection = opts.columns ? opts.columns.map(c => `"${c}"`).join(', ') : '*'
+  let query = `SELECT ${projection} FROM "${opts.table}" ${opts.whereSql}`
+
+  if (opts.hasSince) {
+    query += `${opts.whereSql ? ' AND' : ' WHERE'} updated_at >= ?`
+  }
+  for (const c of opts.extraConditions ?? []) {
+    query += `${opts.whereSql || opts.hasSince ? ' AND' : ' WHERE'} ${c}`
+  }
+  query += ` ORDER BY "${opts.pkCol}" ${opts.orderDescending ? 'DESC' : 'ASC'}`
+  if (opts.limit) {
+    query += ` LIMIT ${opts.limit}`
+    if (opts.offset) query += ` OFFSET ${opts.offset}`
+  }
+  return query
+}
+
+/**
+ * Byte-range read of a stored rawTx.
+ *
+ * `substr` on a BLOB is byte-based and 1-INDEXED, so a JS offset n is passed as
+ * n + 1. Doing the range in SQL is what stops a caller that wants one output's
+ * locking script from materialising a whole ~960 KB vault transaction (and then
+ * an ~960 K-element JS array) to slice it.
+ *
+ * The proven_tx_reqs variant carries the same status filter getProvenOrRawTx
+ * applies, so the two paths cannot disagree about which rows are usable.
+ */
+export function rangeReadSql(table: 'proven_txs' | 'proven_tx_reqs'): string {
+  const usable = "AND status IN ('unsent','unmined','unconfirmed','sending','nosend','completed')"
+  return `SELECT substr(rawTx, ?, ?) AS chunk FROM "${table}" WHERE txid = ? ${
+    table === 'proven_tx_reqs' ? usable : ''
+  }`.trimEnd()
+}
+
+/**
+ * txid → height for every proven transaction.
+ *
+ * The CSV export used findProvenTxs({ partial: {} }) for this, which is an
+ * unbounded SELECT * that reads and Array.from-expands every rawTx and
+ * merklePath in the wallet to build a map of two small columns.
+ */
+export const PROVEN_HEIGHTS_SQL = 'SELECT txid, height FROM proven_txs'

--- a/storage/methods/historyNotes.ts
+++ b/storage/methods/historyNotes.ts
@@ -1,0 +1,61 @@
+/**
+ * Bounding `proven_tx_reqs.history`.
+ *
+ * Every broadcast provider in the toolbox captures its full payload in an error
+ * note — Arcade keeps the Extended Format hex, WhatsOnChain keeps `beef.toHex()`,
+ * Bitails keeps the joined raw hex — and `transferNotesToReqHistories` copies
+ * those notes verbatim into this TEXT column with no truncation. Worse,
+ * `addHistoryNote`'s dedup does full string equality against every existing
+ * note, so the second failure compares megabyte strings against megabyte
+ * strings.
+ *
+ * A single failing vault broadcast therefore writes multi-megabyte hex into the
+ * database and makes each subsequent attempt quadratic — precisely when things
+ * are already going wrong. No rawTx codec touches this: the bytes arrive as hex
+ * text inside a diagnostic string.
+ *
+ * The cap is deliberately applied to VALUES, not to the note count. History is
+ * the only diagnostic trail for a stuck transaction, so losing entries would
+ * cost real debuggability; losing the tail of one enormous hex string costs
+ * nothing.
+ */
+
+/** Longest string value kept in a history note, including the ellipsis. */
+export const NOTE_VALUE_MAX = 256
+
+const truncate = (s: string): string => (s.length <= NOTE_VALUE_MAX ? s : `${s.slice(0, NOTE_VALUE_MAX - 1)}…`)
+
+/**
+ * Recursive copy of `value` with every over-long string truncated.
+ *
+ * Returns a copy rather than mutating: these objects are handed to us by
+ * provider code that may still be using them, and a note is also frequently a
+ * literal in the caller's own scope.
+ */
+export function scrubNoteValues<T>(value: T): T {
+  if (typeof value === 'string') return truncate(value) as unknown as T
+  if (Array.isArray(value)) return value.map(v => scrubNoteValues(v)) as unknown as T
+  if (value != null && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = scrubNoteValues(v)
+    return out as unknown as T
+  }
+  return value
+}
+
+/**
+ * Scrub the JSON text stored in `proven_tx_reqs.history`.
+ *
+ * Falls back to truncating the raw text when it does not parse: unparseable
+ * history is already a bug, and letting a megabyte through because it was
+ * malformed would defeat the point.
+ */
+export function scrubHistoryJson(history: unknown): unknown {
+  if (typeof history !== 'string') return typeof history === 'undefined' ? history : scrubNoteValues(history)
+  if (history.length <= NOTE_VALUE_MAX) return history
+  try {
+    return JSON.stringify(scrubNoteValues(JSON.parse(history)))
+  } catch {
+    return truncate(history)
+  }
+}

--- a/utils/exportTransactions.ts
+++ b/utils/exportTransactions.ts
@@ -46,13 +46,10 @@ export async function exportTransactionsAsCsv(
 
   if (actions.length === 0) return 0
 
-  const heightMap = new Map<string, number>()
-  if (storage) {
-    const proven = await storage.findProvenTxs({ partial: {} })
-    for (const p of proven) {
-      if (p.txid && typeof p.height === 'number') heightMap.set(p.txid, p.height)
-    }
-  }
+  // Two columns, read as two columns. findProvenTxs({ partial: {} }) would
+  // SELECT * over every proven transaction, expanding each rawTx and merklePath
+  // into a JS array on the way to being ignored.
+  const heightMap = storage ? await storage.getProvenTxHeights() : new Map<string, number>()
 
   const header = [
     'txid',


### PR DESCRIPTION
Step one of [the transaction-size and blob-compression spec](docs/superpowers/specs/2026-08-19-tx-size-limits-and-blob-compression-design.md) — the independent wins that need no codec, no schema change and no toolbox patch. Spec §7 plus B0.

Researched across two multi-agent sweeps; the spec and the [step-one plan](docs/superpowers/plans/2026-08-19-storage-read-path-and-growth-fixes.md) are committed here as the first commit.

## What each commit stops doing

| | |
|---|---|
| `b83fc1a` | `SELECT *` on every finder. `noRawTx`/`noScript` now emit a projection, so BLOBs are not read off disk and `Array.from`-expanded (~8× heap under Hermes) before being discarded. Five callers already asked for the cheap path and paid full price. |
| `0df8a5f` | Loading a whole rawTx to slice a script out of it. `substr` in SQL instead. With `maxOutputScript = 1024`, the outputs taking that path are exactly the ~960 KB vault scripts. |
| `117327d` | Writing multi-megabyte hex into `proven_tx_reqs.history`. Every toolbox broadcast provider captures its full payload in an error note, and `addHistoryNote`'s dedup then does full string equality against every existing note — so the second failure compares megabyte strings. |
| `eeb18d4` | Reading every rawTx and merklePath in the wallet to build a txid→height map for the CSV export. |
| `0eaf499` | Retaining the whole WebView message JSON (a measured 3.6-4.0× the payload in Hermes string memory) across every await of a wallet call. |
| `736cdab` | Parsing thousands of transactions to find one wedged outpoint. One indexed query over `outputs.spentBy` replaces a 25×200-action paged scan whose every page loaded each action's full rawTx to read a sequence number. |

## Notes for review

**`__tests__/storage/` is new** — the storage layer had no test harness at all. These run against real SQLite via `node:sqlite` rather than mocks, because the risk in this diff is arithmetic and SQL, not control flow.

**The drift test is load-bearing.** An explicit projection needs hardcoded column lists, so `findSql.test.ts` parses `createTables.ts` and fails if they diverge — a column added to the schema but not to the list would be silently dropped from every projected read, which nothing else would catch. It immediately caught that `proven_txs` has a column named `index`, so every identifier in a projection has to be quoted.

**Range reads are tested against every boundary that could be off by one.** `substr` on a BLOB is 1-indexed and JS `slice` is 0-indexed. Spec §2.2 traces that mistake to `Services.hashOutputScript` → the chain answering "not a UTXO" → three separate writers persisting `spendable = false`, with nothing in the logs. Each case is asserted against the equivalent slice, including a 1 MB row read one byte from the far end.

**Callers that do not project generate byte-identical SQL to before**, so their result rows cannot change. The post-hoc `undefined` assignments are deliberately kept as the contract for any future caller that arrives without a projection.

**The reservation-heal fast path is injected and optional**: `transfers.ts` stays testable without a database, a caller with no storage handle keeps the original scan, and a storage failure falls through to it rather than costing the retry. The `ABORTABLE` status filter applies identically on both paths — there are tests for both.

## Deliberately not included

"Stop `Array.from`-ing large BLOBs" is in spec §7 but not here: `validateEntity` converts every `Uint8Array` to `number[]` because the toolbox's entity types are declared `number[]`, so changing it at the storage boundary is a cross-cutting type change belonging with spec step B1 (codec to `Uint8Array` end to end). This PR removes the three worst instances without touching the contract.

## Testing

`npx tsc --noEmit` clean (bar the two pre-existing `funding-app/vite.config.ts` errors), `npx jest` 92 suites / 1109 tests pass, 27 of them new, eslint 0 errors.

Not device-verified — every change here is exercised by tests against real SQLite, but the memory claims (Hermes heap multipliers) come from the spec's measurements rather than from a profiler run on this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)