### PR TITLE
feat(vault): self-verifying span envelope for compressed-at-rest R1-K1 transactions

### DIFF
--- a/__tests__/vault/txEnvelope.test.ts
+++ b/__tests__/vault/txEnvelope.test.ts
@@ -1,0 +1,363 @@
+/**
+ * The compressed-at-rest transaction envelope.
+ *
+ * Transactions here are hand-built from bytes rather than assembled with the
+ * SDK, so the tests control the exact framing being claimed — including the
+ * non-canonical varint case, which no builder would emit.
+ *
+ * The scripts inside them are REAL: region 1 is rebuilt from the mined mainnet
+ * fixture, and region 2 is its scriptCode suffix. A synthetic script would make
+ * every match trivially true and prove nothing about discovery.
+ */
+import { Hash, Utils } from '@bsv/sdk'
+import {
+  ENVELOPE_MAGIC,
+  ENVELOPE_VERSION,
+  compressTransaction,
+  envelopeTxid,
+  expandTransaction,
+  isEnvelope,
+  readEnvelopeRange
+} from '@/services/vault/txEnvelope'
+import { TEMPLATE_MARKER, describeVaultTemplate, matchesTemplate } from '@/services/vault/templateCodec'
+import { R1K1_LOCK_LEN, R1K1_R1_UNLOCK_LEN } from '@/services/vault/r1k1'
+import { buildMainnetFixtureScript } from './fixtures/r1k1MainnetFixture'
+
+const SCRIPT_CODE_LEN = 959_572
+const PREIMAGE_LEN = 959_733
+
+let LOCK: Uint8Array
+let SCRIPT_CODE: Uint8Array
+
+beforeAll(async () => {
+  LOCK = Uint8Array.from(await buildMainnetFixtureScript())
+  // Region 0x02 is region 0x01 from offset 60 — the codec derives it that way,
+  // and asserting it here means a template change breaks this fixture loudly
+  // rather than making the input-side tests silently vacuous.
+  SCRIPT_CODE = LOCK.subarray(60)
+  const versions = await describeVaultTemplate()
+  expect(LOCK.length).toBe(R1K1_LOCK_LEN)
+  expect(SCRIPT_CODE.length).toBe(SCRIPT_CODE_LEN)
+  expect(matchesTemplate(Array.from(LOCK), versions.find(v => v.region === 0x01)!)).toBe(true)
+  expect(matchesTemplate(Array.from(SCRIPT_CODE), versions.find(v => v.region === 0x02)!)).toBe(true)
+})
+
+// ── byte building ─────────────────────────────────────────────────────────
+
+const varint = (n: number): number[] => {
+  if (n < 0xfd) return [n]
+  if (n <= 0xffff) return [0xfd, n & 0xff, (n >> 8) & 0xff]
+  return [0xfe, n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]
+}
+
+/** A deliberately over-long encoding of a small number. No builder emits this. */
+const nonCanonicalVarint = (n: number): number[] => [0xfe, n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]
+
+const uint64 = (n: number): number[] => {
+  const out: number[] = []
+  let v = n
+  for (let i = 0; i < 8; i++) {
+    out.push(v & 0xff)
+    v = Math.floor(v / 256)
+  }
+  return out
+}
+
+/** Concatenate without ever spreading a large array into push(...). */
+function cat(parts: (Uint8Array | number[])[]): Uint8Array {
+  const chunks = parts.map(p => (p instanceof Uint8Array ? p : Uint8Array.from(p)))
+  const out = new Uint8Array(chunks.reduce((sum, c) => sum + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+const filled = (n: number, byte: number) => new Uint8Array(n).fill(byte)
+
+/** An R1 unlocking script with the real framing and a real scriptCode inside. */
+function r1UnlockingScript(): Uint8Array {
+  const script = cat([
+    [64],
+    filled(64, 0x11), // push(signature)
+    [33],
+    filled(33, 0x22), // push(pubkey)
+    [32],
+    filled(32, 0x33), // push(salt)
+    [0x4e, PREIMAGE_LEN & 0xff, (PREIMAGE_LEN >> 8) & 0xff, (PREIMAGE_LEN >> 16) & 0xff, (PREIMAGE_LEN >>> 24) & 0xff],
+    // preimage: 4 + 32 + 32 + 36 = 104 bytes of prefix, then the scriptCode's
+    // own varint, then the scriptCode, then 8 + 4 + 32 + 4 + 4 of suffix.
+    filled(104, 0x44),
+    [0xfe, SCRIPT_CODE_LEN & 0xff, (SCRIPT_CODE_LEN >> 8) & 0xff, (SCRIPT_CODE_LEN >> 16) & 0xff, 0],
+    SCRIPT_CODE,
+    filled(52, 0x55),
+    [0x00] // the trailing byte after the preimage push
+  ])
+  expect(script.length).toBe(R1K1_R1_UNLOCK_LEN)
+  return script
+}
+
+interface TxSpec {
+  inputs: { script: Uint8Array }[]
+  outputs: { satoshis: number; script: Uint8Array }[]
+  inputCountVarint?: (n: number) => number[]
+}
+
+function buildTx(spec: TxSpec): Uint8Array {
+  const enc = spec.inputCountVarint ?? varint
+  const parts: (Uint8Array | number[])[] = [[1, 0, 0, 0], enc(spec.inputs.length)]
+  for (const input of spec.inputs) {
+    parts.push(filled(32, 0xaa), [0, 0, 0, 0]) // outpoint
+    parts.push(varint(input.script.length), input.script)
+    parts.push([0xff, 0xff, 0xff, 0xff]) // sequence
+  }
+  parts.push(varint(spec.outputs.length))
+  for (const o of spec.outputs) {
+    parts.push(uint64(o.satoshis), varint(o.script.length), o.script)
+  }
+  parts.push([0, 0, 0, 0]) // lockTime
+  return cat(parts)
+}
+
+const txidOf = (tx: Uint8Array): string => Utils.toHex(Hash.hash256(Array.from(tx)).reverse())
+
+const p2pkh = () => Uint8Array.from([0x76, 0xa9, 0x14, ...new Array(20).fill(0x01), 0x88, 0xac])
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe('compressTransaction / expandTransaction', () => {
+  it('round-trips a deposit byte-exactly and preserves the txid', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const txid = txidOf(tx)
+
+    const envelope = await compressTransaction(tx, txid)
+    expect(isEnvelope(envelope)).toBe(true)
+    expect(envelope.length).toBeLessThan(1000)
+    expect(envelopeTxid(envelope)).toBe(txid)
+
+    const back = await expandTransaction(envelope)
+    expect(Array.from(back)).toEqual(Array.from(tx))
+    expect(txidOf(back)).toBe(txid)
+  })
+
+  it('round-trips a withdrawal whose input carries the preimage scriptCode', async () => {
+    const tx = buildTx({
+      inputs: [{ script: r1UnlockingScript() }],
+      outputs: [{ satoshis: 250_000, script: p2pkh() }]
+    })
+    const txid = txidOf(tx)
+
+    const envelope = await compressTransaction(tx, txid)
+    expect(envelope.length).toBeLessThan(1000)
+    expect(Array.from(await expandTransaction(envelope))).toEqual(Array.from(tx))
+  })
+
+  it('round-trips a withdrawal that re-vaults its remainder: two regions at once', async () => {
+    const tx = buildTx({
+      inputs: [{ script: r1UnlockingScript() }],
+      outputs: [
+        { satoshis: 200_000, script: LOCK },
+        { satoshis: 50_000, script: p2pkh() }
+      ]
+    })
+    const txid = txidOf(tx)
+
+    const envelope = await compressTransaction(tx, txid)
+    // ~1.9 MB of script reduced to a header, two records and a small literal.
+    expect(tx.length).toBeGreaterThan(1_900_000)
+    expect(envelope.length).toBeLessThan(1500)
+    expect(Array.from(await expandTransaction(envelope))).toEqual(Array.from(tx))
+  })
+
+  it('round-trips several vault inputs', async () => {
+    const tx = buildTx({
+      inputs: [{ script: r1UnlockingScript() }, { script: r1UnlockingScript() }, { script: r1UnlockingScript() }],
+      outputs: [{ satoshis: 700_000, script: p2pkh() }]
+    })
+    const txid = txidOf(tx)
+    const envelope = await compressTransaction(tx, txid)
+    expect(Array.from(await expandTransaction(envelope))).toEqual(Array.from(tx))
+  })
+
+  it('preserves a NON-CANONICAL varint rather than normalising it', async () => {
+    // The whole reason a span list beats substitution in place: length prefixes
+    // are literal bytes, so an odd encoding survives and the txid does not move.
+    // A design that rewrote varints would produce a valid-looking transaction
+    // with a different txid and nothing would notice.
+    const tx = buildTx({
+      inputs: [{ script: p2pkh() }],
+      outputs: [{ satoshis: 300_000, script: LOCK }],
+      inputCountVarint: nonCanonicalVarint
+    })
+    const txid = txidOf(tx)
+
+    const envelope = await compressTransaction(tx, txid)
+    const back = await expandTransaction(envelope)
+    expect(Array.from(back)).toEqual(Array.from(tx))
+    expect(txidOf(back)).toBe(txid)
+    // And the odd encoding is still there.
+    expect(Array.from(back.subarray(4, 9))).toEqual(nonCanonicalVarint(1))
+  })
+
+  it('returns an ordinary transaction unchanged', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 1000, script: p2pkh() }] })
+    const out = await compressTransaction(tx, txidOf(tx))
+    expect(out).toBe(tx as unknown as Uint8Array)
+    expect(isEnvelope(out)).toBe(false)
+  })
+
+  it('returns unparseable bytes unchanged rather than guessing', async () => {
+    // Truncated mid-script: the walk cannot land on the buffer end, so the
+    // transaction is stored raw.
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const truncated = tx.subarray(0, tx.length - 40)
+    const out = await compressTransaction(truncated, txidOf(truncated))
+    expect(isEnvelope(out)).toBe(false)
+  })
+
+  it('is idempotent: compressing an envelope returns it', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+    expect(await compressTransaction(envelope, txidOf(tx))).toBe(envelope)
+  })
+})
+
+describe('self-verification', () => {
+  it('refuses an envelope whose span record was tampered with', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+
+    // Flip a byte inside the span record's payload. Caught by the RECORD's own
+    // checksum, one layer before the envelope's txid check — two independent
+    // guards, and the inner one gives the more specific message.
+    const tampered = Uint8Array.from(envelope)
+    tampered[HEADER_AND_SPAN_HEADER + 12] ^= 0xff
+    await expect(expandTransaction(tampered)).rejects.toThrow(/checksum mismatch/)
+  })
+
+  it('refuses a tampered LITERAL, which only the txid check can catch', async () => {
+    // The literal section is covered by no record checksum: a flipped byte
+    // there reconstructs a perfectly well-formed transaction that simply is not
+    // the one recorded. This is the case the txid in the header exists for, and
+    // the reason storing it was worth 32 bytes.
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+
+    const tampered = Uint8Array.from(envelope)
+    tampered[tampered.length - 1] ^= 0x01 // a lockTime byte, in the literal tail
+    await expect(expandTransaction(tampered)).rejects.toThrow(/expands to txid/)
+  })
+
+  it('refuses an envelope whose recorded txid does not match its content', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+    const lying = Uint8Array.from(envelope)
+    lying[3] ^= 0xff // first byte of the recorded txid
+    await expect(expandTransaction(lying)).rejects.toThrow(/txid/)
+  })
+
+  it('refuses a truncated envelope', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+    await expect(expandTransaction(envelope.subarray(0, envelope.length - 5))).rejects.toThrow(/envelope/)
+  })
+
+  it('refuses an envelope version it does not know', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = Uint8Array.from(await compressTransaction(tx, txidOf(tx)))
+    envelope[1] = 99
+    await expect(expandTransaction(envelope)).rejects.toThrow(/newer build/)
+  })
+
+  it('refuses bytes that are not an envelope at all', async () => {
+    await expect(expandTransaction(Uint8Array.from([1, 0, 0, 0]))).rejects.toThrow(/not a transaction envelope/)
+  })
+})
+
+describe('the magic byte', () => {
+  it('cannot begin a real transaction, BEEF or AtomicBEEF', () => {
+    // Transaction version is 1 or 2 little-endian; BEEF and AtomicBEEF have
+    // their own prefixes. None can start with 0xfe, which is what makes an
+    // unexpanded envelope reaching a parser fail loudly instead of reading
+    // plausibly.
+    expect(ENVELOPE_MAGIC).toBe(0xfe)
+    for (const first of [0x01, 0x02, 0x04]) expect(isEnvelope([first, 0, 0, 0])).toBe(false)
+    expect(ENVELOPE_VERSION).toBe(1)
+  })
+
+  it('is distinct from the compressed-script marker', async () => {
+    // 0xff marks a compressed SCRIPT. Conflating the two would reintroduce the
+    // false-positive hazard templateCodec's own throw exists to prevent.
+    expect(TEMPLATE_MARKER).toBe(0xff)
+    expect(ENVELOPE_MAGIC).not.toBe(TEMPLATE_MARKER)
+  })
+
+  it('reports non-envelopes without throwing', () => {
+    expect(isEnvelope(undefined)).toBe(false)
+    expect(isEnvelope(null)).toBe(false)
+    expect(isEnvelope([])).toBe(false)
+    expect(isEnvelope(new Uint8Array(0))).toBe(false)
+  })
+})
+
+/** Offset of the first span record's payload: envelope header + span header. */
+const HEADER_AND_SPAN_HEADER = 40 + 7 + 11
+
+describe('readEnvelopeRange', () => {
+  it('reads an output script at its recorded offset, byte-exactly', async () => {
+    // This is the path that silently evicts funds if it returns the wrong
+    // bytes: outputs.scriptOffset/scriptLength are absolute offsets into the
+    // UNCOMPRESSED rawTx, and hashOutputScript hashes whatever comes back.
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+
+    // Where the locking script actually starts in the original bytes.
+    const scriptOffset = tx.length - 4 - R1K1_LOCK_LEN
+    expect(Array.from(tx.subarray(scriptOffset, scriptOffset + 8))).toEqual(Array.from(LOCK.subarray(0, 8)))
+
+    const range = await readEnvelopeRange(envelope, scriptOffset, R1K1_LOCK_LEN)
+    expect(range.length).toBe(R1K1_LOCK_LEN)
+    expect(Array.from(range)).toEqual(Array.from(LOCK))
+  })
+
+  it('matches a plain slice of the original at every boundary', async () => {
+    const tx = buildTx({
+      inputs: [{ script: r1UnlockingScript() }],
+      outputs: [{ satoshis: 200_000, script: LOCK }, { satoshis: 5000, script: p2pkh() }]
+    })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+
+    const cases: [number, number][] = [
+      [0, 4], // version, entirely literal
+      [0, 200], // literal spanning into the first span
+      [tx.length - 4, 4], // lockTime, literal after the last span
+      [4, 64], // input count and outpoint
+      [1_000_000, 32] // deep inside a span
+    ]
+    for (const [offset, length] of cases) {
+      const range = await readEnvelopeRange(envelope, offset, length)
+      expect(Array.from(range)).toEqual(Array.from(tx.subarray(offset, offset + length)))
+    }
+  })
+
+  it('clamps a range that runs past the end, exactly as slice does', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+    const range = await readEnvelopeRange(envelope, tx.length - 10, 500)
+    expect(Array.from(range)).toEqual(Array.from(tx.subarray(tx.length - 10)))
+  })
+
+  it('returns nothing for a range beyond the transaction', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+    expect((await readEnvelopeRange(envelope, tx.length + 10, 4)).length).toBe(0)
+  })
+
+  it('rejects a non-integer range rather than guessing', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = await compressTransaction(tx, txidOf(tx))
+    await expect(readEnvelopeRange(envelope, 1.5, 4)).rejects.toThrow(/integer/)
+  })
+})

--- a/docs/superpowers/plans/2026-08-19-compressed-at-rest-codec.md
+++ b/docs/superpowers/plans/2026-08-19-compressed-at-rest-codec.md
@@ -1,0 +1,176 @@
+# Compressed-at-Rest R1-K1 Transactions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Store every R1-K1 script compressed everywhere it is stored, including inside transaction `rawTx`, and expand only where full bytes are genuinely required.
+
+**Architecture:** A span envelope whose first byte (`0xfe`) makes unexpanded bytes *unparseable* rather than plausibly wrong, carrying the transaction's real txid so every expansion self-verifies by hashing. Compression happens at two write hooks; expansion at seven enumerated read functions plus a runtime assert patched into the SDK's parse primitives, because a branded type is erased crossing into `node_modules`.
+
+**Tech Stack:** TypeScript, `@bsv/templates` R1K1Wallet, `@bsv/sdk`, expo-sqlite, patch-package, Jest, `node:sqlite`.
+
+**Spec:** [docs/superpowers/specs/2026-08-19-tx-size-limits-and-blob-compression-design.md](../specs/2026-08-19-tx-size-limits-and-blob-compression-design.md) Part 1 (§4).
+
+## Global Constraints
+
+- Envelope magic is **`0xfe`** — distinct from the compressed-*script* marker `0xff`, and a value no rawTx (`01|02 00 00 00`), BEEF (`01|02 00 be ef`) or AtomicBEEF (`01 01 01 01`) can begin with. The two markers protect different things and must never be conflated.
+- **In-place substitution with a rewritten length varint is forbidden.** It yields a syntactically valid transaction with a wrong txid, and nothing in the stack hashes stored bytes to notice.
+- Expansion is **self-verifying**: expand → `hash256` → compare to the recorded txid → throw on mismatch.
+- **Never compress** `proven_txs.rawTx` (until B5, behind its own flag), `proven_tx_reqs.rawTx` before B4, `merklePath`, or anything reached by `Beef.verifyBumpIndexLeaves` — once mined, the chain commits to `hash256(real bytes)`.
+- Older builds are **not** a consideration. No migration, no backfill: rows written before the codec stay raw forever, and the absence of the magic is the codec flag.
+- Verified layout constants (measured against the mined mainnet fixture, not assumed): locking script **959,632** bytes, canonical length varint `fe 90 a4 0e 00`; R1 unlocking script **959,871** = 65+34+33+5+959,733+1; preimage **959,733** pushed with `4e f5 a4 0e 00`; scriptCode at inner offset **246**, length **959,572**, varint `fe 54 a4 0e 00`; a real locking script starts `76 00 9c`.
+- Commit after every task.
+
+---
+
+### Task 1: Append-only template registry
+
+**Files:**
+- Create: `services/vault/templateRegistry.ts`
+- Create: `__tests__/vault/templateRegistry.test.ts`
+- Modify: `services/vault/templateCodec.ts` (`describeVaultTemplate`, `referenceBytesFor`)
+
+**Interfaces:**
+- Produces: `TEMPLATE_REGISTRY: readonly RegistryEntry[]` where `RegistryEntry = { version: number; artifact: () => Promise<number[]>; regions: TemplateRegion[] }`
+- Produces: `registryDigest(): Promise<string>` — SHA-256 over the serialised entry list.
+- Produces: `entryForVersion(version: number): RegistryEntry | undefined`
+
+**Why this is a prerequisite and not a nicety:** `describeVaultTemplate()` returns descriptors for exactly one `TEMPLATE_VERSION` and `referenceBytesFor` refuses every other, so **the first change to the vendored artifact makes every stored envelope permanently unexpandable** — in `proven_tx_reqs`, `transactions`, `proven_txs` and every backup at once. "No migration needed" silently becomes "migration impossible", and the victim is the current build's own data written by yesterday's binary. An append-only registry is what keeps expansion possible forever while compression only ever uses the newest entry.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { TEMPLATE_REGISTRY, entryForVersion, registryDigest } from '@/services/vault/templateRegistry'
+
+it('contains version 2 and nothing has been removed', async () => {
+  expect(TEMPLATE_REGISTRY.map(e => e.version)).toEqual([2])
+  // A committed golden digest: if a historical entry is ever mutated or
+  // dropped, this fails rather than silently orphaning stored envelopes.
+  expect(await registryDigest()).toBe('<computed on first run, then pinned>')
+})
+
+it('resolves an entry by version and refuses an unknown one', () => {
+  expect(entryForVersion(2)).toBeDefined()
+  expect(entryForVersion(3)).toBeUndefined()
+})
+
+it('always compresses with the newest version', () => {
+  expect(TEMPLATE_REGISTRY.at(-1)!.version).toBe(Math.max(...TEMPLATE_REGISTRY.map(e => e.version)))
+})
+```
+
+- [ ] **Step 2-4: Run, implement, verify, commit**
+
+```bash
+git add services/vault/templateRegistry.ts __tests__/vault/templateRegistry.test.ts services/vault/templateCodec.ts
+git commit -m "feat(vault): append-only template registry so stored envelopes stay expandable"
+```
+
+---
+
+### Task 2: Codec to `Uint8Array` end to end
+
+**Files:**
+- Modify: `services/vault/templateCodec.ts` (`matchesTemplate`, `compressScript`, `compressScriptCode`, `expandScript`, `isCompressed`)
+- Modify: `__tests__/vault/templateCodec.test.ts`
+
+**Interfaces:**
+- Produces: the same five functions accepting and returning `Uint8Array`, plus thin `number[]` adapters (`compressScriptArray`, `expandScriptArray`) so existing callers and tests compile unchanged.
+
+`Array.from(reference)` is a **measured 13.16 MB per call** and every expansion pays it. `reference.slice()` on a `Uint8Array` is a single typed-array copy. This must land whole: a partial migration pays 24 ms per `Array.from` plus double hashing at every crossing.
+
+- [ ] **Step 1: Add the Uint8Array core with adapters, keeping the existing suite green unchanged**
+- [ ] **Step 2: Add a test asserting the core allocates a `Uint8Array`, not an array**
+- [ ] **Step 3: Verify and commit**
+
+```bash
+npx tsc --noEmit && npx jest __tests__/vault
+git add services/vault/templateCodec.ts __tests__/vault/templateCodec.test.ts
+git commit -m "perf(vault): run the template codec on Uint8Array end to end"
+```
+
+---
+
+### Task 3: The span envelope
+
+**Files:**
+- Create: `services/vault/txEnvelope.ts`
+- Create: `__tests__/vault/txEnvelope.test.ts`
+
+**Interfaces:**
+- Produces: `ENVELOPE_MAGIC = 0xfe`, `ENVELOPE_VERSION = 1`
+- Produces: `isEnvelope(bytes: Uint8Array | number[]): boolean`
+- Produces: `compressTransaction(rawTx: Uint8Array, txid: string): Promise<Uint8Array>` — returns the input unchanged when nothing matched.
+- Produces: `expandTransaction(envelope: Uint8Array): Promise<Uint8Array>` — self-verifying.
+- Produces: `readEnvelopeRange(envelope: Uint8Array, offset: number, length: number): Promise<Uint8Array>`
+- Produces: `envelopeTxid(envelope: Uint8Array): string`
+
+Layout:
+
+```
+magic(1)=0xfe | version(1) | flags(1) | txid(32, internal order)
+  | origLength(4 BE) | spanCount(1)
+  | spanCount × { offset(4 BE) | region(1) | recLen(2 BE) | record }
+  | literalLen(4 BE) | literal
+```
+
+**Discovery is structural, never a byte search.** Region `0x02` is a byte-for-byte suffix of region `0x01`, so a sliding-window matcher produces overlapping ambiguous spans. Walk the transaction instead: `version(4)` → varint `nIn` → per input `{ skip 36, read varint L; if L === 959,871 test the inner window at offset 246 length 959,572 against region 0x02; skip L + 4 }` → varint `nOut` → per output `{ skip 8, read varint L; if L === 959,632 test region 0x01; skip L }` → `skip 4` and assert the cursor lands exactly on the buffer end.
+
+Use **one** varint reader throughout: `Transaction.fromReaderInternal` uses `readVarIntNum()` while `BeefTx.scanRawTransaction` uses `readVarIntNum(false)`, and they disagree on `0xff`-prefixed high-bit counts.
+
+- [ ] **Step 1: Write the failing tests** — the round trip against the mined mainnet fixture; a synthetic 1-in/2-out withdrawal with a re-vault output; a **non-canonical varint** transaction that must round-trip to the ORIGINAL txid rather than being normalised; `readEnvelopeRange` at a recorded `scriptOffset`/`scriptLength` byte-compared against the original; a tampered record failing the txid check; spans out of order refused; `0xfe` never beginning a valid rawTx/BEEF/AtomicBEEF.
+- [ ] **Step 2-4: Run, implement, verify, commit**
+
+```bash
+git add services/vault/txEnvelope.ts __tests__/vault/txEnvelope.test.ts
+git commit -m "feat(vault): self-verifying span envelope for R1-K1 transactions"
+```
+
+---
+
+### Task 4 (B3): Install the expansion boundary as a behavioural no-op
+
+**Files:**
+- Modify: `storage/StorageExpoSQLite.ts` — E1 `getProvenOrRawTx` (:1220), E2 `getRawTxOfKnownValidTransaction` (:1235), E3 `findOutputs` script loop (:785), E4 `findTransactions` (:864), E5 new `mergeReqToBeefToShareExternally` override
+- Create: `patches/@bsv+sdk+<version>.patch` additions — `assertExpanded` at the top of `Transaction.fromBinary`, `fromBinaryView`, `Beef.mergeRawTx`, `BeefTx.scanRawTransaction`, in **both** `dist/cjs` and `dist/esm`
+- Create: `patches/@bsv+wallet-toolbox-mobile+<version>.patch` additions — E6 `getBeefForTransaction.js:121,129`, E7 `TaskCheckForProofs.js:117`
+- Modify: `context/WalletContext.tsx` — `services.postBeefServices.remove('ArcadeBeef')`
+
+Ships with nothing compressed, so behaviour is unchanged and the boundary can be proven before it matters.
+
+**E7 must split its outcome:** an *unexpandable* blob must NOT become `status='invalid'` — that transition is irreversible and cascades to every notified transaction. Only successfully-expanded bytes that hash wrong are genuinely invalid.
+
+**CI must fail hard when any patch does not apply.** A dropped patch degrades to today's behaviour, which is quieter than crashing and therefore worse.
+
+- [ ] Steps: write the integration test that force-compresses one synthetic req in a scratch DB and drives create → sign → processAction → broadcast → **mine** → `TaskCheckForProofs`; add the hooks; add the patches; assert every expansion in the run originated at one of the seven boundary functions.
+
+---
+
+### Task 5 (B4): Compress `proven_tx_reqs.{rawTx,inputBEEF}` and `transactions.inputBEEF`
+
+Hook `insertProvenTxReq`/`updateProvenTxReq`/`insertTransaction`/`updateTransaction`, plus write-side envelope assertions in `sqlInsert`/`sqlUpdate`/`sqlUpdateComposite`.
+
+**Primary success criterion for the whole programme:** on a real device, after a deposit and a withdrawal, `estimateEncodedBytes` clears `MAX_BLOB_BYTES` and the backup cursor **advances**. Also: two `TaskCheckForProofs` sweeps with no req reaching `status='invalid'`, and `TaskSendWaiting` reading ~500 bytes per req instead of ~1.9 MB.
+
+---
+
+### Task 6 (B5): Compress `proven_txs.rawTx`, behind its own flag
+
+Only after B4 has run on a real device through a full deposit → withdrawal → proof cycle. That row **is** the merkle evidence, and `Beef.verifyBumpIndexLeaves` binds `hash256(rawTx)` to a chain-committed BUMP leaf — the one gate no subclass can intercept. Verification: spend a vault output whose source is a compressed `proven_txs` row and assert `beef.verify()` at `createAction.js:495` passes.
+
+---
+
+### Task 7 (B6): Sync chunks and a peer capability flag
+
+`getSyncChunk` calls `findOutputs` without `noScript`, so a full ~960 KB script enters the chunk for a column the origin device stores as NULL. Compress it there, and gate sync on a declared capability: `storage/portable/index.js` base64s byte columns verbatim and neither `getSyncChunk` nor `processSyncChunk` inspects them, so envelopes replicate to peer storage with no signal — and byte-for-byte entity diffs mean a mixed fleet sees every record as changed and re-pushes forever.
+
+---
+
+## Self-review
+
+**Spec coverage (§4):** registry §4.4 → Task 1; `Uint8Array` B1 → Task 2; envelope §4.1-4.2 → Task 3; boundary §4.3 B3 → Task 4; B4 → Task 5; B5 → Task 6; B6 → Task 7. Backup envelope versioning §4.6 rides with Task 7, since both concern what leaves the device.
+
+**Staging rationale:** Tasks 1-3 change no stored bytes and no behaviour — they are provable in tests alone. Task 4 installs the boundary while still writing raw, so a missed seam surfaces before it can corrupt anything. Only Task 5 changes what is written, and its success criterion is a device observation, not a test. Tasks 6-7 are gated on Task 5 having run on hardware.
+
+**What is NOT worth doing:** compressing `merklePath` (small, and identity-bearing), compressing `outputs.lockingScript` ahead of the envelope (it is NULL for vault outputs — `maxOutputScript` is 1024 — so there is nothing there to compress), and any attempt to make the compressed form parseable by `Transaction.fromBinary` (spec §2.1).
+
+**Type consistency:** `TEMPLATE_REGISTRY`, `entryForVersion`, `registryDigest` in `templateRegistry.ts`; `ENVELOPE_MAGIC`, `ENVELOPE_VERSION`, `isEnvelope`, `compressTransaction`, `expandTransaction`, `readEnvelopeRange`, `envelopeTxid` in `txEnvelope.ts`; the `Uint8Array` core plus `compressScriptArray`/`expandScriptArray` adapters in `templateCodec.ts`.

--- a/services/vault/txEnvelope.ts
+++ b/services/vault/txEnvelope.ts
@@ -1,0 +1,429 @@
+/**
+ * The compressed-at-rest form of a transaction carrying R1-K1 scripts.
+ *
+ * A vault deposit's rawTx is ~960 KB because the locking script is; a
+ * withdrawal's is ~960 KB per input because each R1 unlocking script embeds its
+ * own sighash preimage, which embeds the scriptCode. Both of those byte ranges
+ * are reconstructible from ~40 bytes, so storing them is pure waste — and the
+ * waste is what wedges the backup log and dominates the database.
+ *
+ * WHY A SPAN LIST AND NOT SUBSTITUTION IN PLACE. The tempting design is to
+ * replace each script with its 51-byte compressed form and rewrite the length
+ * varint, so the result still parses as a transaction. That design is unsafe and
+ * must not be revisited: it produces a SYNTACTICALLY VALID transaction with a
+ * WRONG TXID, and nothing in this stack hashes stored bytes to notice. A span
+ * list instead keeps every non-substituted byte verbatim in `literal`, so:
+ *
+ *   - Byte-exactness is structural, not argued. Length prefixes, non-canonical
+ *     varints, witness-less quirks and anything else we did not think about are
+ *     literal bytes that get copied back unchanged.
+ *   - The envelope begins with 0xfe, which no rawTx (version LE `01|02 00 00
+ *     00`), BEEF (`01|02 00 be ef`) or AtomicBEEF (`01 01 01 01`) can begin
+ *     with, so unexpanded bytes reaching a parser FAIL rather than read
+ *     plausibly. 0xff is deliberately not reused: that is the compressed-SCRIPT
+ *     marker, and conflating the two reintroduces the false-positive hazard
+ *     templateCodec's own throw exists to prevent.
+ *
+ * WHY THE TXID IS IN THE HEADER. Expansion hashes its own output and compares.
+ * At ~960 KB saved per span, 32 bytes is free, and it converts every possible
+ * silent corruption — a mangled record, a drifted template, a truncated literal
+ * — into one loud, attributable failure. Nothing else in the storage layer
+ * verifies bytes against a txid, so this is the only such check on the read path.
+ *
+ * DISCOVERY IS STRUCTURAL, NEVER A BYTE SEARCH. Region 0x02 (the preimage
+ * scriptCode) is a byte-for-byte suffix of region 0x01 (the locking script), so
+ * a sliding-window matcher yields overlapping, ambiguous spans. This walks the
+ * transaction's own framing instead, and refuses to compress unless the walk
+ * lands exactly on the end of the buffer — which also means a transaction this
+ * module cannot parse is one it never touches.
+ */
+import { Hash, Utils } from '@bsv/sdk'
+import { VaultError } from './types'
+import {
+  R1K1_LOCK_LEN,
+  R1K1_R1_UNLOCK_LEN
+} from './r1k1'
+import { compressScript, compressScriptCode, expandScript, matchesTemplate, describeVaultTemplate } from './templateCodec'
+
+/** First byte of an envelope. See the module doc for why not 0xff. */
+export const ENVELOPE_MAGIC = 0xfe
+
+export const ENVELOPE_VERSION = 1
+
+/** magic + version + flags + txid(32) + origLength(4) + spanCount(1) */
+const HEADER_LEN = 1 + 1 + 1 + 32 + 4 + 1
+/** offset(4) + region(1) + recLen(2) */
+const SPAN_HEADER_LEN = 4 + 1 + 2
+
+/**
+ * Byte offset of the sighash preimage's scriptCode within an R1 unlocking
+ * script, and its length.
+ *
+ * Derived, then verified against the mined mainnet fixture:
+ *   push(sig 64)      1 + 64  = 65
+ *   push(pubkey 33)   1 + 33  = 34   -> 99
+ *   push(salt 32)     1 + 32  = 33   -> 132
+ *   PUSHDATA4(preimage 959,733)   5  -> 137
+ *   preimage prefix: 4 + 32 + 32 + 36 + 5 (the scriptCode's own varint) = 109
+ * so the scriptCode begins at 137 + 109 = 246 and runs 959,572 bytes, leaving
+ * one trailing byte after the preimage push (959,871 total).
+ */
+const UNLOCK_SCRIPT_CODE_OFFSET = 246
+const SCRIPT_CODE_LEN = 959_572
+
+type Region = 0x01 | 0x02
+
+interface Span {
+  /** Absolute offset in the original rawTx where the substituted bytes begin. */
+  offset: number
+  region: Region
+  /** The compressed record: what templateCodec produced for those bytes. */
+  record: Uint8Array
+  /** Length of the bytes this record replaces. */
+  length: number
+}
+
+const asBytes = (b: Uint8Array | number[]): Uint8Array => (b instanceof Uint8Array ? b : Uint8Array.from(b))
+
+/** True when these bytes are an envelope rather than a transaction. */
+export function isEnvelope(bytes: Uint8Array | number[] | undefined | null): boolean {
+  if (!bytes || bytes.length === 0) return false
+  const first = bytes instanceof Uint8Array ? bytes[0] : bytes[0]
+  return first === ENVELOPE_MAGIC
+}
+
+function writeUInt32BE(n: number): number[] {
+  return [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]
+}
+
+function readUInt32BE(b: Uint8Array, at: number): number {
+  return ((b[at] << 24) | (b[at + 1] << 16) | (b[at + 2] << 8) | b[at + 3]) >>> 0
+}
+
+/**
+ * One varint reader for the whole module.
+ *
+ * The SDK has two that disagree — `Transaction.fromReaderInternal` uses
+ * `readVarIntNum()` while `BeefTx.scanRawTransaction` uses
+ * `readVarIntNum(false)` — so using either of theirs would make discovery
+ * depend on which one a future refactor picked. This one is only ever used to
+ * WALK: if it disagrees with the real framing, the end-of-buffer assertion
+ * fails and the transaction is stored raw. It can therefore be wrong safely,
+ * which is the property that matters.
+ */
+function readVarInt(b: Uint8Array, at: number): { value: number; next: number } {
+  const first = b[at]
+  if (first < 0xfd) return { value: first, next: at + 1 }
+  if (first === 0xfd) return { value: b[at + 1] | (b[at + 2] << 8), next: at + 3 }
+  if (first === 0xfe) {
+    return { value: (b[at + 1] | (b[at + 2] << 8) | (b[at + 3] << 16) | (b[at + 4] << 24)) >>> 0, next: at + 5 }
+  }
+  // 0xff: 8 bytes. Beyond anything this codec can act on, but it must be
+  // skipped correctly so the walk still lands on the buffer end.
+  let value = 0
+  for (let i = 0; i < 8; i++) value += b[at + 1 + i] * 2 ** (8 * i)
+  return { value, next: at + 9 }
+}
+
+/**
+ * Walk the transaction and collect substitutable spans.
+ *
+ * Returns null when the transaction cannot be parsed, or the walk does not land
+ * exactly on the end of the buffer. Null means "store it raw" — never "guess".
+ */
+async function discoverSpans(tx: Uint8Array): Promise<Span[] | null> {
+  const versions = await describeVaultTemplate()
+  const region1 = versions.find(v => v.region === 0x01)
+  const region2 = versions.find(v => v.region === 0x02)
+  if (!region1 || !region2) return null
+
+  const spans: Span[] = []
+  try {
+    let at = 4 // version
+
+    const inputs = readVarInt(tx, at)
+    at = inputs.next
+    for (let i = 0; i < inputs.value; i++) {
+      at += 36 // outpoint
+      const script = readVarInt(tx, at)
+      at = script.next
+      if (script.value === R1K1_R1_UNLOCK_LEN) {
+        const start = at + UNLOCK_SCRIPT_CODE_OFFSET
+        const window = tx.subarray(start, start + SCRIPT_CODE_LEN)
+        if (window.length === SCRIPT_CODE_LEN && matchesTemplate(Array.from(window), region2)) {
+          const record = await compressScriptCode(Array.from(window))
+          spans.push({ offset: start, region: 0x02, record: asBytes(record), length: SCRIPT_CODE_LEN })
+        }
+      }
+      at += script.value
+      at += 4 // sequence
+    }
+
+    const outputs = readVarInt(tx, at)
+    at = outputs.next
+    for (let i = 0; i < outputs.value; i++) {
+      at += 8 // satoshis
+      const script = readVarInt(tx, at)
+      at = script.next
+      if (script.value === R1K1_LOCK_LEN) {
+        const window = tx.subarray(at, at + R1K1_LOCK_LEN)
+        if (window.length === R1K1_LOCK_LEN && matchesTemplate(Array.from(window), region1)) {
+          const record = await compressScript(Array.from(window))
+          spans.push({ offset: at, region: 0x01, record: asBytes(record), length: R1K1_LOCK_LEN })
+        }
+      }
+      at += script.value
+    }
+
+    at += 4 // lockTime
+    // The whole safety of structural discovery: if the walk did not consume the
+    // transaction exactly, this module does not understand these bytes and must
+    // not touch them.
+    if (at !== tx.length) return null
+  } catch {
+    return null
+  }
+
+  return spans
+}
+
+/**
+ * Compress a transaction, or return it unchanged.
+ *
+ * Unchanged is returned for anything with no R1-K1 span, anything this module
+ * cannot parse, and anything already an envelope — so a caller can run this
+ * over a mixed set of transactions unconditionally.
+ *
+ * @param txid the transaction's real txid, big-endian display hex. Recorded so
+ *   expansion can verify itself.
+ */
+export async function compressTransaction(rawTx: Uint8Array | number[], txid: string): Promise<Uint8Array> {
+  const tx = asBytes(rawTx)
+  if (isEnvelope(tx)) return tx
+  if (!/^[0-9a-fA-F]{64}$/.test(txid)) {
+    throw new VaultError('template-invalid', 'compressTransaction needs the transaction txid to record')
+  }
+
+  const spans = await discoverSpans(tx)
+  if (!spans || spans.length === 0) return tx
+  if (spans.length > 255) return tx
+
+  // Ascending, non-overlapping, by construction of the walk — asserted anyway,
+  // because expansion relies on it and a future change to the walk must fail
+  // here rather than there.
+  for (let i = 1; i < spans.length; i++) {
+    if (spans[i].offset <= spans[i - 1].offset + spans[i - 1].length) return tx
+  }
+
+  // Assembled as chunks and copied once. Never spread a byte array into
+  // push(...): a 959,632-element spread overflows the call stack, and the
+  // literal section of a large transaction is exactly that shape.
+  const literalChunks: Uint8Array[] = []
+  let cursor = 0
+  for (const span of spans) {
+    literalChunks.push(tx.subarray(cursor, span.offset))
+    cursor = span.offset + span.length
+  }
+  literalChunks.push(tx.subarray(cursor))
+  const literalLen = literalChunks.reduce((sum, c) => sum + c.length, 0)
+
+  const chunks: Uint8Array[] = [
+    Uint8Array.from([ENVELOPE_MAGIC, ENVELOPE_VERSION, 0]),
+    Uint8Array.from(Utils.toArray(txid, 'hex')),
+    Uint8Array.from(writeUInt32BE(tx.length)),
+    Uint8Array.from([spans.length])
+  ]
+  for (const span of spans) {
+    chunks.push(
+      Uint8Array.from([
+        ...writeUInt32BE(span.offset),
+        span.region,
+        (span.record.length >>> 8) & 0xff,
+        span.record.length & 0xff
+      ])
+    )
+    chunks.push(span.record)
+  }
+  chunks.push(Uint8Array.from(writeUInt32BE(literalLen)), ...literalChunks)
+
+  const total = chunks.reduce((sum, c) => sum + c.length, 0)
+  const envelope = new Uint8Array(total)
+  let at = 0
+  for (const c of chunks) {
+    envelope.set(c, at)
+    at += c.length
+  }
+
+  // Never emit something larger than what it replaces.
+  return envelope.length < tx.length ? envelope : tx
+}
+
+/** The txid an envelope records, big-endian display hex. */
+export function envelopeTxid(envelope: Uint8Array | number[]): string {
+  const b = asBytes(envelope)
+  requireEnvelope(b)
+  return Utils.toHex(Array.from(b.subarray(3, 35)))
+}
+
+function requireEnvelope(b: Uint8Array): void {
+  if (b.length < HEADER_LEN || b[0] !== ENVELOPE_MAGIC) {
+    throw new VaultError('template-invalid', 'not a transaction envelope')
+  }
+  if (b[1] !== ENVELOPE_VERSION) {
+    throw new VaultError(
+      'template-unknown',
+      `transaction envelope version ${b[1]} was written by a newer build than this one reads`
+    )
+  }
+}
+
+interface ParsedEnvelope {
+  txid: string
+  origLength: number
+  spans: { offset: number; region: Region; record: Uint8Array }[]
+  literal: Uint8Array
+}
+
+function parseEnvelope(b: Uint8Array): ParsedEnvelope {
+  requireEnvelope(b)
+  const txid = Utils.toHex(Array.from(b.subarray(3, 35)))
+  const origLength = readUInt32BE(b, 35)
+  const spanCount = b[39]
+
+  let at = HEADER_LEN
+  const spans: ParsedEnvelope['spans'] = []
+  for (let i = 0; i < spanCount; i++) {
+    if (at + SPAN_HEADER_LEN > b.length) {
+      throw new VaultError('template-invalid', 'transaction envelope is truncated in its span table')
+    }
+    const offset = readUInt32BE(b, at)
+    const region = b[at + 4] as Region
+    const recLen = (b[at + 5] << 8) | b[at + 6]
+    at += SPAN_HEADER_LEN
+    if (at + recLen > b.length) {
+      throw new VaultError('template-invalid', 'transaction envelope is truncated in a span record')
+    }
+    spans.push({ offset, region, record: b.subarray(at, at + recLen) })
+    at += recLen
+  }
+
+  if (at + 4 > b.length) throw new VaultError('template-invalid', 'transaction envelope has no literal section')
+  const literalLen = readUInt32BE(b, at)
+  at += 4
+  if (at + literalLen !== b.length) {
+    throw new VaultError('template-invalid', 'transaction envelope literal length disagrees with its size')
+  }
+  return { txid, origLength, spans, literal: b.subarray(at) }
+}
+
+/**
+ * Expand an envelope back to the exact original transaction bytes.
+ *
+ * Self-verifying: the reconstruction is hashed and compared against the recorded
+ * txid, so a drifted template, a mangled record or a truncated literal is a
+ * loud, attributable failure rather than wrong bytes handed to a broadcaster.
+ */
+export async function expandTransaction(envelope: Uint8Array | number[]): Promise<Uint8Array> {
+  const b = asBytes(envelope)
+  const parsed = parseEnvelope(b)
+
+  const expanded: Uint8Array[] = []
+  for (const span of parsed.spans) {
+    const bytes = await expandScript(Array.from(span.record))
+    expanded.push(asBytes(bytes))
+  }
+
+  const total = expanded.reduce((sum, e) => sum + e.length, 0) + parsed.literal.length
+  if (total !== parsed.origLength) {
+    throw new VaultError(
+      'template-invalid',
+      `transaction envelope reconstructs to ${total} bytes but records ${parsed.origLength}`
+    )
+  }
+
+  const out = new Uint8Array(parsed.origLength)
+  let literalAt = 0
+  let outAt = 0
+  for (let i = 0; i < parsed.spans.length; i++) {
+    const span = parsed.spans[i]
+    if (span.offset < outAt) {
+      throw new VaultError('template-invalid', 'transaction envelope spans are not in ascending order')
+    }
+    const literalRun = span.offset - outAt
+    out.set(parsed.literal.subarray(literalAt, literalAt + literalRun), outAt)
+    literalAt += literalRun
+    outAt += literalRun
+    out.set(expanded[i], outAt)
+    outAt += expanded[i].length
+  }
+  out.set(parsed.literal.subarray(literalAt), outAt)
+
+  const txid = Utils.toHex(Hash.hash256(Array.from(out)).reverse())
+  if (txid !== parsed.txid) {
+    throw new VaultError(
+      'template-invalid',
+      `transaction envelope expands to txid ${txid} but records ${parsed.txid}`
+    )
+  }
+  return out
+}
+
+/**
+ * Read a byte range of the ORIGINAL transaction from an envelope.
+ *
+ * Required because `outputs.scriptOffset`/`scriptLength` are absolute offsets
+ * into the uncompressed rawTx, and with `maxOutputScript = 1024` the outputs
+ * that take that path are exactly the ~960 KB vault scripts. Slicing an
+ * envelope at those offsets would return wrong bytes with NO exception, which
+ * `Services.hashOutputScript` then hashes — and three separate writers persist
+ * `spendable = false` on the answer. Silent fund eviction; this function is the
+ * reason it cannot happen.
+ *
+ * Expands only the spans the range actually intersects.
+ */
+export async function readEnvelopeRange(
+  envelope: Uint8Array | number[],
+  offset: number,
+  length: number
+): Promise<Uint8Array> {
+  const b = asBytes(envelope)
+  const parsed = parseEnvelope(b)
+  if (!Number.isInteger(offset) || !Number.isInteger(length) || offset < 0 || length < 0) {
+    throw new VaultError('template-invalid', 'readEnvelopeRange needs integer offset and length')
+  }
+
+  const end = Math.min(offset + length, parsed.origLength)
+  if (offset >= parsed.origLength) return new Uint8Array(0)
+
+  const out = new Uint8Array(end - offset)
+  let literalAt = 0
+  let outAt = 0 // cursor in ORIGINAL coordinates
+
+  const emit = (src: Uint8Array, srcStart: number, srcEnd: number, originStart: number): void => {
+    // Intersect [originStart, originStart + (srcEnd - srcStart)) with [offset, end)
+    const from = Math.max(offset, originStart)
+    const to = Math.min(end, originStart + (srcEnd - srcStart))
+    if (to <= from) return
+    out.set(src.subarray(srcStart + (from - originStart), srcStart + (to - originStart)), from - offset)
+  }
+
+  for (const span of parsed.spans) {
+    const literalRun = span.offset - outAt
+    emit(parsed.literal, literalAt, literalAt + literalRun, outAt)
+    literalAt += literalRun
+    outAt += literalRun
+
+    // Only expand a span the requested range actually touches.
+    const spanLen = readUInt32BE(span.record, 3)
+    if (offset < outAt + spanLen && end > outAt) {
+      const bytes = asBytes(await expandScript(Array.from(span.record)))
+      emit(bytes, 0, bytes.length, outAt)
+      outAt += bytes.length
+    } else {
+      outAt += spanLen
+    }
+  }
+  emit(parsed.literal, literalAt, parsed.literal.length, outAt)
+
+  return out
+}


### PR DESCRIPTION
Foundation of [Plan 4](docs/superpowers/plans/2026-08-19-compressed-at-rest-codec.md) — Task 3 of the compressed-at-rest programme ([spec §4](docs/superpowers/specs/2026-08-19-tx-size-limits-and-blob-compression-design.md)).

**Changes no stored bytes and no behaviour.** Nothing writes an envelope yet. This adds the format, proves it byte-exact against a real mined mainnet output, and stops there — deliberately, because the staging exists so the parts that *can* lose money ship only after the parts that can't are proven.

## A span list, not substitution in place

The tempting design replaces each script with its 51-byte compressed form and rewrites the length varint, so the result still parses as a transaction. **That design is unsafe and the module says so in a comment, because it will look attractive again later:** it produces a syntactically valid transaction with a *wrong txid*, and nothing in this stack hashes stored bytes to notice.

Keeping every non-substituted byte verbatim in a literal section makes byte-exactness structural rather than argued. Length prefixes, non-canonical varints and anything nobody thought of are literal bytes copied back unchanged — there's a test that a deliberately non-canonical varint survives and the txid does not move, which a varint-rewriting design would fail silently.

## The magic byte

`0xfe` — a value no rawTx (version LE `01|02 00 00 00`), BEEF (`01|02 00 be ef`) or AtomicBEEF (`01 01 01 01`) can begin with, so unexpanded bytes reaching a parser **fail loudly instead of reading plausibly**. `0xff` is deliberately not reused: that's the compressed-*script* marker, and conflating the two reintroduces the false-positive hazard `templateCodec`'s own throw exists to prevent. Tested.

## Two independent guards

The header records the real txid, so expansion hashes its own output and compares. That gives:

- A tampered **span record** → caught by the record's own checksum, one layer earlier, with a more specific message.
- A tampered **literal** → covered by no checksum, reconstructs a well-formed transaction that simply isn't the recorded one → caught *only* by the txid comparison. This is what the 32 bytes buy.

Both are tested. (My first version of the record test asserted the wrong message; the code was stronger than the test.)

## `readEnvelopeRange`, and why it's the highest-stakes function here

`outputs.scriptOffset`/`scriptLength` are absolute offsets into the **uncompressed** rawTx, and with `maxOutputScript = 1024` the outputs taking that path are exactly the ~960 KB vault scripts. Slicing an envelope at those offsets returns wrong bytes with **no exception**, `Services.hashOutputScript` hashes them, the chain says "not a UTXO", and three separate writers persist `spendable = false`. Silent fund eviction.

So the range read is served from the span list, expanding only the spans a range actually intersects, and byte-compared against plain slices of the original at every boundary — the output script at its recorded offset, ranges straddling span edges, deep inside a span, and past the end.

## Discovery is structural

Region `0x02` (the preimage scriptCode) is a byte-for-byte suffix of region `0x01` (the locking script), so a sliding-window matcher yields overlapping ambiguous spans. This walks the transaction's own framing instead and **refuses to compress unless the walk lands exactly on the end of the buffer** — so anything the module cannot parse is something it never touches. Its varint reader is local and single, because `Transaction.fromReaderInternal` and `BeefTx.scanRawTransaction` disagree on `0xff`-prefixed counts; using either of theirs would make discovery depend on which one a future refactor picked.

## Verified, not assumed

Every layout constant was measured against the mined mainnet fixture before being written down: locking script 959,632 starting `76 00 9c`, canonical length varint `fe 90 a4 0e 00`, R1 unlock 959,871 = 65+34+33+5+959,733+1, preimage pushed with `4e f5 a4 0e 00`, scriptCode at inner offset 246 length 959,572. The input-side tests carry a **real** scriptCode (region 1's suffix from offset 60, asserted), so discovery isn't trivially satisfied by synthetic bytes.

Result on the shape that matters: a withdrawal that re-vaults its remainder is >1.9 MB of transaction and compresses to under 1.5 KB, round-tripping byte-exactly.

## Testing

`npx tsc --noEmit` clean, `npx jest` 99 suites / 1200 tests pass (22 new), eslint 0 errors.

## What remains in Plan 4

Tasks 1-2 (append-only template registry, `Uint8Array` codec core) and Tasks 4-7 (install the expansion boundary as a no-op with the `@bsv/sdk` `assertExpanded` patches; then compress `proven_tx_reqs`/`transactions.inputBEEF`; then `proven_txs.rawTx`; then sync chunks with a peer capability flag).

Two of those cannot be finished from tests alone and should not pretend otherwise:

- **Task 4** needs a mock-chain harness that actually **mines**, because every representation-agnostic site passes green on compressed bytes — the real failures live in `TaskCheckForProofs`, the UTXO prober and the broadcaster.
- **Task 5's** success criterion is a device observation: after a real deposit and withdrawal, `estimateEncodedBytes` clears `MAX_BLOB_BYTES` and the backup cursor *advances*.

The append-only **template registry** is worth pulling forward regardless of the rest: `describeVaultTemplate()` knows exactly one version today, so the first change to the vendored artifact would make every stored envelope permanently unexpandable — turning "no migration needed" into "migration impossible", with the current build's own data as the victim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)