### PR TITLE
feat(vault): append-only template registry, cross-checked against @bsv/templates

### DIFF
--- a/__tests__/vault/templateRegistry.test.ts
+++ b/__tests__/vault/templateRegistry.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The append-only template registry.
+ *
+ * The pinned fingerprint below is the point of this file. Compression writes a
+ * version number into every record; expansion looks that number up here. So
+ * removing, renumbering or editing an entry orphans every record already written
+ * with it — in the database and in every backup chunk on the server — and the
+ * failure would surface as `template-unknown` on someone's wallet rather than in
+ * CI. Pinning the table means that mutation fails here instead.
+ *
+ * When you legitimately add a version: append the entry, update the pin in the
+ * same commit, and leave every historical entry exactly as it was.
+ */
+import {
+  CURRENT_TEMPLATE_VERSION,
+  TEMPLATE_REGISTRY,
+  currentEntry,
+  entryForVersion,
+  registryFingerprint
+} from '@/services/vault/templateRegistry'
+import { describeCurrentVaultTemplate, describeVaultTemplate } from '@/services/vault/templateCodec'
+
+/**
+ * Every field of every shipped entry, pinned.
+ *
+ * Append when a version is added. NEVER edit an existing segment: doing so is
+ * the mutation this pin exists to catch.
+ */
+const PINNED_FINGERPRINT =
+  '2|959632|60|17:20,959609:20|' +
+  '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b|' +
+  'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
+
+describe('template registry', () => {
+  it('matches the pinned fingerprint of every shipped version', () => {
+    expect(registryFingerprint()).toBe(PINNED_FINGERPRINT)
+  })
+
+  it('is append-only: versions ascend and none repeats', () => {
+    const versions = TEMPLATE_REGISTRY.map(e => e.version)
+    expect(versions).toEqual([...versions].sort((a, b) => a - b))
+    expect(new Set(versions).size).toBe(versions.length)
+  })
+
+  it('writes with the newest version', () => {
+    // Compression must never pick an older entry: a record written with an old
+    // version would be expanded against old reference bytes, which is correct
+    // only by luck.
+    expect(CURRENT_TEMPLATE_VERSION).toBe(Math.max(...TEMPLATE_REGISTRY.map(e => e.version)))
+    expect(currentEntry().version).toBe(CURRENT_TEMPLATE_VERSION)
+  })
+
+  it('resolves a registered version and refuses an unregistered one', () => {
+    expect(entryForVersion(CURRENT_TEMPLATE_VERSION)).toBeDefined()
+    expect(entryForVersion(999)).toBeUndefined()
+    // v1's header carried no integrity check over its payload and no record of
+    // it was ever written outside a test, so it is deliberately absent.
+    expect(entryForVersion(1)).toBeUndefined()
+  })
+
+  it('has a plausible geometry for every entry', () => {
+    for (const e of TEMPLATE_REGISTRY) {
+      expect(e.rawLength).toBeGreaterThan(e.preimageScriptCodeOffset)
+      expect(e.gzipBase64.length).toBeGreaterThan(0)
+      expect(e.constantHash).toMatch(/^[0-9a-f]{64}$/)
+      expect(e.constantHashScriptCode).toMatch(/^[0-9a-f]{64}$/)
+      expect(e.variableRuns.length).toBeGreaterThan(0)
+      for (const r of e.variableRuns) {
+        expect(r.offset).toBeGreaterThanOrEqual(0)
+        expect(r.offset + r.length).toBeLessThanOrEqual(e.rawLength)
+      }
+    }
+  })
+})
+
+describe('codec descriptors follow the registry', () => {
+  it('describes two regions per registered version', async () => {
+    const all = await describeVaultTemplate()
+    expect(all.length).toBe(TEMPLATE_REGISTRY.length * 2)
+    for (const entry of TEMPLATE_REGISTRY) {
+      expect(all.filter(v => v.version === entry.version).map(v => v.region).sort()).toEqual([0x01, 0x02])
+    }
+  })
+
+  it('describes only the current version when asked for it', async () => {
+    const current = await describeCurrentVaultTemplate()
+    expect(current.map(v => v.version)).toEqual([CURRENT_TEMPLATE_VERSION, CURRENT_TEMPLATE_VERSION])
+    expect(current.map(v => v.region)).toEqual([0x01, 0x02])
+  })
+
+  it('derives region 0x02 from region 0x01 rather than declaring it', async () => {
+    const [region1, region2] = await describeCurrentVaultTemplate()
+    const entry = currentEntry()
+    expect(region2.totalLength).toBe(region1.totalLength - entry.preimageScriptCodeOffset)
+    // Region 0x02's runs are region 0x01's runs that SURVIVE the cut, shifted by
+    // it. The R1 commitment lives at offset 17, inside the 60 bytes unlockR1
+    // drops, so it is not part of the scriptCode at all — only the
+    // k1PublicKeyHash is. Asserting the survivors (rather than assuming both
+    // runs shift) is what makes preimageScriptCodeOffset the single constant to
+    // change if that cut ever moves.
+    const survivors = region1.variableRuns
+      .filter(r => r.offset >= entry.preimageScriptCodeOffset)
+      .map(r => r.offset - entry.preimageScriptCodeOffset)
+    expect(region2.variableRuns.map(r => r.offset)).toEqual(survivors)
+    expect(survivors).toEqual([959549])
+  })
+
+  it('hands out fresh run objects, never the registry\'s own', async () => {
+    const first = await describeCurrentVaultTemplate()
+    first[0].variableRuns[0].offset = -1
+    const second = await describeCurrentVaultTemplate()
+    expect(second[0].variableRuns[0].offset).toBe(currentEntry().variableRuns[0].offset)
+  })
+})

--- a/__tests__/vault/templateUpstream.test.ts
+++ b/__tests__/vault/templateUpstream.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The registry's geometry, cross-checked against @bsv/templates.
+ *
+ * WHY BOTH EXIST. Upstream is the AUTHORITY for the R1-K1 layout: it declares
+ * the compiled template length, the k1 slot offset, the artifact digest and the
+ * artifact itself. Duplicating those numbers in our registry would be pointless
+ * if we simply read them at runtime — but reading them at runtime is exactly
+ * what we must not do, because @bsv/templates is a caret dependency and stored
+ * records outlive it. If a `^1.10.0` minor bump moved the layout, a codec that
+ * derived its geometry from whatever version happened to be installed would
+ * silently start reconstructing the WRONG bytes for records already written.
+ *
+ * So the registry pins, and this test derives-and-compares. Upstream changes the
+ * layout, this fails, and the fix is to mint a NEW registry version rather than
+ * to edit the existing one — which is precisely the decision that has to be
+ * made by a human rather than by a version range.
+ *
+ * WHAT IS NOT COVERED. `R1_K1_R1_SLOT_OFFSET` is declared in the upstream
+ * artifact source but absent from its export list, so the R1 commitment's run
+ * offset (17) cannot be derived here. It stays guarded by the registry's own
+ * `constantHash`, which masks that exact window and is verified against the
+ * vendored bytes on every process start.
+ */
+import { R1K1Wallet } from '@bsv/templates'
+// The package maps this subpath through its `exports` map, which neither
+// eslint-plugin-import's resolver nor this project's classic tsconfig resolution
+// reads. It resolves at runtime, and types/bsv-templates-artifact.d.ts supplies
+// the types.
+import {
+  R1_K1_K1_SLOT_OFFSET,
+  R1_K1_TEMPLATE_BYTE_LENGTH,
+  R1_K1_TEMPLATE_SHA256
+  // eslint-disable-next-line import/no-unresolved
+} from '@bsv/templates/R1K1Wallet.artifact.ts'
+import { currentEntry } from '@/services/vault/templateRegistry'
+
+/** Bytes each 1-byte constructor slot becomes once baked (a 21-byte push). */
+const slotExpansion = (): number =>
+  (R1K1Wallet.lockingScriptByteLength - R1K1Wallet.compiledTemplateByteLength) / 2
+
+describe('registry geometry against @bsv/templates', () => {
+  const entry = currentEntry()
+
+  it('agrees with upstream on the baked locking-script length', () => {
+    expect(entry.rawLength).toBe(R1K1Wallet.lockingScriptByteLength)
+  })
+
+  it('derives the baked length from upstream template plus two expanded slots', () => {
+    // 959,592 + 2 x 20 = 959,632. If upstream ever recompiles the template to a
+    // different size, this is the first thing that fails.
+    expect(R1K1Wallet.compiledTemplateByteLength).toBe(R1_K1_TEMPLATE_BYTE_LENGTH)
+    expect(slotExpansion()).toBe(20)
+    expect(R1_K1_TEMPLATE_BYTE_LENGTH + 2 * slotExpansion()).toBe(entry.rawLength)
+  })
+
+  it('derives the k1PublicKeyHash run offset from upstream slot offset', () => {
+    // Upstream's slot offset is into the UNBAKED template and names the slot
+    // byte; ours is into the baked script and names where the 20 data bytes
+    // start. The difference is one prior slot's expansion plus the push opcode.
+    const derived = R1_K1_K1_SLOT_OFFSET + slotExpansion() + 1
+    const k1Run = entry.variableRuns[entry.variableRuns.length - 1]
+    expect(derived).toBe(k1Run.offset)
+    expect(k1Run.length).toBe(slotExpansion())
+  })
+
+  it('pins the upstream artifact digest, so an upstream artifact swap is visible', () => {
+    // Not compared against our own vendored artifact — ours is BAKED and this
+    // digest is of the unbaked template — but pinned so that upstream shipping a
+    // different template cannot pass unnoticed.
+    expect(R1_K1_TEMPLATE_SHA256).toBe('d5a824bfb1d3ea48ca4e9f70ba987f545d4d171aad689c1264b7339fa6928f2b')
+  })
+
+  it('keeps the scriptCode cut in step with what unlockR1 actually drops', () => {
+    // R1K1Wallet.unlockR1 commits `lockingBytes.subarray(60)` as the preimage's
+    // scriptCode. That 60 is a literal in upstream's source and is not exported,
+    // so the registry pins it — and region 0x02's own constantHash, which is
+    // computed from the slice this offset produces, is what catches a change.
+    expect(entry.preimageScriptCodeOffset).toBe(60)
+    expect(entry.rawLength - entry.preimageScriptCodeOffset).toBe(959_572)
+  })
+})

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -48,7 +48,13 @@
 import { Hash, Utils } from '@bsv/sdk'
 import { gunzipSync } from 'fflate'
 import { R1K1_LOCK_LEN } from './r1k1'
-import { VAULT_TEMPLATE_GZIP_BASE64, VAULT_TEMPLATE_RAW_LENGTH } from './vaultTemplateArtifact'
+import {
+  CURRENT_TEMPLATE_VERSION,
+  TEMPLATE_REGISTRY,
+  type TemplateRegistryEntry,
+  currentEntry,
+  entryForVersion
+} from './templateRegistry'
 import { VaultError } from './types'
 
 /** Marker byte for a compressed script. OP_INVALIDOPCODE (0xff) — NEVER
@@ -94,7 +100,15 @@ export interface TemplateVersion {
  * over its payload (see the checksum doc below for exactly why that shape
  * was replaced), for records that provably do not exist.
  */
-const TEMPLATE_VERSION = 2
+/**
+ * The version new records are written with.
+ *
+ * Sourced from the append-only registry rather than declared here: this codec
+ * must be able to EXPAND every version that has ever shipped, while only ever
+ * COMPRESSING with the newest. See services/vault/templateRegistry.ts for why
+ * that asymmetry is not optional.
+ */
+const TEMPLATE_VERSION = CURRENT_TEMPLATE_VERSION
 
 /** Number of bytes `R1K1Wallet.unlockR1` drops from the FRONT of the locking
  * script before committing the remainder into the sighash preimage's
@@ -111,7 +125,7 @@ const TEMPLATE_VERSION = 2
  * many bytes `unlockR1` drops, this is the one constant to update —
  * everything else in region 0x02 (its length, its variable run, its pinned
  * constant hash) recomputes from it automatically. */
-const PREIMAGE_SCRIPT_CODE_OFFSET = 60
+const PREIMAGE_SCRIPT_CODE_OFFSET = currentEntry().preimageScriptCodeOffset
 
 /**
  * The region-0x01 (R1-K1 locking script) template's `constantHash` (see
@@ -139,7 +153,7 @@ const PREIMAGE_SCRIPT_CODE_OFFSET = 60
  * `vaultTemplateArtifact.ts` — never as a silent "make the assertion pass
  * again" edit.
  */
-const PINNED_CONSTANT_HASH = '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b'
+const PINNED_CONSTANT_HASH = currentEntry().constantHash
 
 /**
  * The region-0x01 template's variable-run geometry — the plan's Global
@@ -151,10 +165,10 @@ const PINNED_CONSTANT_HASH = '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a630861
  * positions would produce the wrong hash), rather than merely trusting this
  * literal — see that constant's doc comment for exactly how.
  */
-const PINNED_VARIABLE_RUNS: { offset: number; length: number }[] = [
-  { offset: 17, length: 20 },
-  { offset: 959609, length: 20 }
-]
+const PINNED_VARIABLE_RUNS: { offset: number; length: number }[] = currentEntry().variableRuns.map(r => ({
+  offset: r.offset,
+  length: r.length
+}))
 
 /**
  * The region-0x02 (preimage scriptCode) template's `constantHash`, pinned the
@@ -176,7 +190,7 @@ const PINNED_VARIABLE_RUNS: { offset: number; length: number }[] = [
  * `PREIMAGE_SCRIPT_CODE_OFFSET`, deliberately, as one act) is tied to minting
  * a new version, never a silent "make the assertion pass again" edit.
  */
-const PINNED_CONSTANT_HASH_SCRIPT_CODE = 'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
+const PINNED_CONSTANT_HASH_SCRIPT_CODE = currentEntry().constantHashScriptCode
 
 /** Shift a set of runs by subtracting `offset` from each, dropping any run
  * that falls entirely below zero and clipping one that straddles it — the
@@ -233,7 +247,12 @@ interface TemplateCacheEntry {
   region2: Uint8Array
 }
 
-let templateCache: TemplateCacheEntry | undefined
+/**
+ * Per-version cache. Keyed because expansion must serve any version that has
+ * ever shipped, and a build carrying several artifacts would otherwise thrash a
+ * single slot.
+ */
+const templateCache = new Map<number, TemplateCacheEntry>()
 
 /**
  * Populate (or reuse) `templateCache`: base64-decode and gunzip the vendored
@@ -256,42 +275,54 @@ let templateCache: TemplateCacheEntry | undefined
  * version in `expandScript` — a broken vendored asset is always a build
  * problem, never a legitimately-different-but-unsupported one.
  */
-function ensureTemplateCache(): TemplateCacheEntry {
-  if (templateCache) return templateCache
+function ensureTemplateCache(version: number = TEMPLATE_VERSION): TemplateCacheEntry {
+  const cached = templateCache.get(version)
+  if (cached) return cached
 
-  const gzip = Uint8Array.from(Utils.toArray(VAULT_TEMPLATE_GZIP_BASE64, 'base64'))
+  const entry = entryForVersion(version)
+  if (!entry) {
+    throw new VaultError(
+      'template-unknown',
+      `no vendored template for version ${version} — this build cannot reconstruct records written with it`
+    )
+  }
+
+  const gzip = Uint8Array.from(Utils.toArray(entry.gzipBase64, 'base64'))
   const region1 = gunzipSync(gzip)
 
-  if (region1.length !== VAULT_TEMPLATE_RAW_LENGTH || region1.length !== R1K1_LOCK_LEN) {
+  if (region1.length !== entry.rawLength || region1.length !== R1K1_LOCK_LEN) {
     throw new VaultError(
       'template-invalid',
-      `vendored template inflated to ${region1.length} bytes, expected ${VAULT_TEMPLATE_RAW_LENGTH} ` +
+      `vendored template v${version} inflated to ${region1.length} bytes, expected ${entry.rawLength} ` +
         `(R1K1_LOCK_LEN ${R1K1_LOCK_LEN}) — the committed asset is corrupt or was built for a different version`
     )
   }
 
-  const constantHash = constantHashOf(region1, PINNED_VARIABLE_RUNS)
-  if (constantHash !== PINNED_CONSTANT_HASH) {
+  const runs = entry.variableRuns.map(r => ({ offset: r.offset, length: r.length }))
+  const constantHash = constantHashOf(region1, runs)
+  if (constantHash !== entry.constantHash) {
     throw new VaultError(
       'template-invalid',
-      `vendored template's masked constantHash ${constantHash} disagrees with the pinned ${PINNED_CONSTANT_HASH} ` +
-        '— the committed asset is corrupt, or PINNED_VARIABLE_RUNS no longer names the positions it was zeroed at'
+      `vendored template v${version}'s masked constantHash ${constantHash} disagrees with the pinned ` +
+        `${entry.constantHash} — the committed asset is corrupt, or its variableRuns no longer name the ` +
+        'positions it was zeroed at'
     )
   }
 
-  const region2 = region1.subarray(PREIMAGE_SCRIPT_CODE_OFFSET)
-  const scriptCodeRuns = shiftRuns(PINNED_VARIABLE_RUNS, PREIMAGE_SCRIPT_CODE_OFFSET)
+  const region2 = region1.subarray(entry.preimageScriptCodeOffset)
+  const scriptCodeRuns = shiftRuns(runs, entry.preimageScriptCodeOffset)
   const scriptCodeConstantHash = constantHashOf(region2, scriptCodeRuns)
-  if (scriptCodeConstantHash !== PINNED_CONSTANT_HASH_SCRIPT_CODE) {
+  if (scriptCodeConstantHash !== entry.constantHashScriptCode) {
     throw new VaultError(
       'template-invalid',
-      `vendored scriptCode's masked constantHash ${scriptCodeConstantHash} disagrees with the pinned ` +
-        `${PINNED_CONSTANT_HASH_SCRIPT_CODE}`
+      `vendored scriptCode v${version}'s masked constantHash ${scriptCodeConstantHash} disagrees with the ` +
+        `pinned ${entry.constantHashScriptCode}`
     )
   }
 
-  templateCache = { region1, region2 }
-  return templateCache
+  const populated: TemplateCacheEntry = { region1, region2 }
+  templateCache.set(version, populated)
+  return populated
 }
 
 /**
@@ -318,7 +349,7 @@ function ensureTemplateCache(): TemplateCacheEntry {
  * batch, not to avoid holding it for the (short) duration of one.
  */
 export function releaseTemplateCache(): void {
-  templateCache = undefined
+  templateCache.clear()
 }
 
 /** Sum of every variable run's length — the payload size a version's header
@@ -336,9 +367,10 @@ function payloadLengthOf(v: TemplateVersion): number {
  * one supported version.
  */
 function referenceBytesFor(version: number, region: TemplateRegion): Uint8Array | undefined {
-  if (version !== TEMPLATE_VERSION || !templateCache) return undefined
-  if (region === 0x01) return templateCache.region1
-  if (region === 0x02) return templateCache.region2
+  const cached = templateCache.get(version)
+  if (!cached) return undefined
+  if (region === 0x01) return cached.region1
+  if (region === 0x02) return cached.region2
   return undefined
 }
 
@@ -357,23 +389,41 @@ function referenceBytesFor(version: number, region: TemplateRegion): Uint8Array 
  * sample-diffing implementation, nothing here actually awaits anything.
  */
 export async function describeVaultTemplate(): Promise<TemplateVersion[]> {
-  const cache = ensureTemplateCache()
+  // Every registered version, so expansion can serve a record written by any
+  // build that has ever shipped. Oldest first, matching the registry's order.
+  return TEMPLATE_REGISTRY.flatMap(entry => describeEntry(entry))
+}
 
-  const region1: TemplateVersion = {
-    version: TEMPLATE_VERSION,
-    region: 0x01,
-    totalLength: cache.region1.length,
-    variableRuns: PINNED_VARIABLE_RUNS.map(r => ({ ...r })), // fresh copies, not the live module array/objects
-    constantHash: PINNED_CONSTANT_HASH
-  }
-  const region2: TemplateVersion = {
-    version: TEMPLATE_VERSION,
-    region: 0x02,
-    totalLength: cache.region2.length,
-    variableRuns: shiftRuns(PINNED_VARIABLE_RUNS, PREIMAGE_SCRIPT_CODE_OFFSET),
-    constantHash: PINNED_CONSTANT_HASH_SCRIPT_CODE
-  }
-  return [region1, region2]
+/**
+ * Descriptors for the version new records are written with.
+ *
+ * Compression must use exactly one version — the newest — so a caller matching
+ * candidate bytes should ask for this rather than picking an element out of
+ * `describeVaultTemplate()`, which grows a pair per registered version.
+ */
+export async function describeCurrentVaultTemplate(): Promise<TemplateVersion[]> {
+  return describeEntry(currentEntry())
+}
+
+function describeEntry(entry: TemplateRegistryEntry): TemplateVersion[] {
+  const cache = ensureTemplateCache(entry.version)
+  const runs = entry.variableRuns.map(r => ({ offset: r.offset, length: r.length }))
+  return [
+    {
+      version: entry.version,
+      region: 0x01,
+      totalLength: cache.region1.length,
+      variableRuns: runs.map(r => ({ ...r })), // fresh copies, never the registry's own objects
+      constantHash: entry.constantHash
+    },
+    {
+      version: entry.version,
+      region: 0x02,
+      totalLength: cache.region2.length,
+      variableRuns: shiftRuns(runs, entry.preimageScriptCodeOffset),
+      constantHash: entry.constantHashScriptCode
+    }
+  ]
 }
 
 /**

--- a/services/vault/templateRegistry.ts
+++ b/services/vault/templateRegistry.ts
@@ -1,0 +1,112 @@
+/**
+ * Every R1-K1 template version this build can reconstruct.
+ *
+ * WHY THIS EXISTS. Before it, the codec knew exactly one version: a single
+ * `TEMPLATE_VERSION` constant, one vendored artifact, and a `referenceBytesFor`
+ * that refused every other version. That is fine while nothing is stored — and
+ * catastrophic the moment something is. The first change to the vendored asset
+ * would make every compressed record written by yesterday's binary permanently
+ * unexpandable: in `proven_tx_reqs`, in `transactions`, in `proven_txs`, and in
+ * every backup chunk already on the server, all at once. "No migration needed"
+ * would have quietly become "migration impossible", with the current build's own
+ * data as the victim.
+ *
+ * So this table is APPEND-ONLY. Compression always uses the newest entry;
+ * expansion must keep working for every entry that has ever shipped, forever.
+ * Removing or editing a historical entry orphans stored data, which is why
+ * __tests__/vault/templateRegistry.test.ts pins a fingerprint over the whole
+ * table: a mutation fails there rather than in someone's wallet.
+ *
+ * ADDING A VERSION. Mint a new number, vendor the new artifact alongside the old
+ * one (do not replace it), append an entry, and update the pinned fingerprint in
+ * the test in the same commit. Never renumber, never delete.
+ */
+import { VAULT_TEMPLATE_GZIP_BASE64, VAULT_TEMPLATE_RAW_LENGTH } from './vaultTemplateArtifact'
+
+export interface TemplateRegistryEntry {
+  /** Wire-format version, as written into a compressed record's header. */
+  version: number
+  /** Base64 gzip of the region-0x01 reference template. */
+  gzipBase64: string
+  /** Inflated length of that reference, asserted at load. */
+  rawLength: number
+  /**
+   * Bytes `R1K1Wallet.unlockR1` drops from the FRONT of the locking script
+   * before committing the remainder as the preimage's scriptCode. The one
+   * load-bearing constant region 0x02 is derived from — its length, its variable
+   * run and its constant hash all recompute from this.
+   */
+  preimageScriptCodeOffset: number
+  /** Region-0x01 variable runs: the R1 commitment and the k1PublicKeyHash. */
+  variableRuns: readonly { readonly offset: number; readonly length: number }[]
+  /** SHA-256 of the reference with its variable runs masked to zero. */
+  constantHash: string
+  /** The same, for the region-0x02 slice. */
+  constantHashScriptCode: string
+}
+
+/**
+ * Version 2.
+ *
+ * The pinned hashes were computed from a real per-instance sample built by
+ * `@bsv/templates` with its genuinely-random variable runs masked out, BEFORE
+ * the template was vendored — which is what makes verifying against them a
+ * cross-check rather than a tautology. Changing either literal is a deliberate
+ * act that accompanies minting a new version, never a "make the assertion pass
+ * again" edit.
+ *
+ * (There is no version 1 entry. The v1 header shape carried no integrity check
+ * over its payload and no record of it was ever written outside a test.)
+ */
+const V2: TemplateRegistryEntry = {
+  version: 2,
+  gzipBase64: VAULT_TEMPLATE_GZIP_BASE64,
+  rawLength: VAULT_TEMPLATE_RAW_LENGTH,
+  preimageScriptCodeOffset: 60,
+  variableRuns: [
+    { offset: 17, length: 20 },
+    { offset: 959609, length: 20 }
+  ],
+  constantHash: '41f6fcbbc46fe0eeb64a176fd66709694331b2327b1a63086105529e34a7493b',
+  constantHashScriptCode: 'f759656aadfcdbd531531c9806b8bce89f7ed4363c7d3f07578455fb1b96a990'
+}
+
+/** Append-only. Oldest first. */
+export const TEMPLATE_REGISTRY: readonly TemplateRegistryEntry[] = [V2]
+
+/** The version new records are written with: always the newest registered. */
+export const CURRENT_TEMPLATE_VERSION: number = TEMPLATE_REGISTRY.reduce(
+  (newest, e) => (e.version > newest ? e.version : newest),
+  0
+)
+
+export function entryForVersion(version: number): TemplateRegistryEntry | undefined {
+  return TEMPLATE_REGISTRY.find(e => e.version === version)
+}
+
+export function currentEntry(): TemplateRegistryEntry {
+  const entry = entryForVersion(CURRENT_TEMPLATE_VERSION)
+  if (!entry) throw new Error('template registry is empty')
+  return entry
+}
+
+/**
+ * A stable fingerprint of the whole table, excluding the artifact bytes
+ * themselves (those have their own per-entry `constantHash`).
+ *
+ * Pinned by a test so an entry cannot be silently removed, renumbered or
+ * edited — the three ways this table could orphan stored records.
+ */
+export function registryFingerprint(): string {
+  return TEMPLATE_REGISTRY.map(
+    e =>
+      [
+        e.version,
+        e.rawLength,
+        e.preimageScriptCodeOffset,
+        e.variableRuns.map(r => `${r.offset}:${r.length}`).join(','),
+        e.constantHash,
+        e.constantHashScriptCode
+      ].join('|')
+  ).join(';')
+}

--- a/services/vault/txEnvelope.ts
+++ b/services/vault/txEnvelope.ts
@@ -43,7 +43,13 @@ import {
   R1K1_LOCK_LEN,
   R1K1_R1_UNLOCK_LEN
 } from './r1k1'
-import { compressScript, compressScriptCode, expandScript, matchesTemplate, describeVaultTemplate } from './templateCodec'
+import {
+  compressScript,
+  compressScriptCode,
+  describeCurrentVaultTemplate,
+  expandScript,
+  matchesTemplate
+} from './templateCodec'
 
 /** First byte of an envelope. See the module doc for why not 0xff. */
 export const ENVELOPE_MAGIC = 0xfe
@@ -132,7 +138,12 @@ function readVarInt(b: Uint8Array, at: number): { value: number; next: number } 
  * exactly on the end of the buffer. Null means "store it raw" — never "guess".
  */
 async function discoverSpans(tx: Uint8Array): Promise<Span[] | null> {
-  const versions = await describeVaultTemplate()
+  // The CURRENT version's descriptors, not every registered version's:
+  // compression must write exactly one version, and describeVaultTemplate()
+  // grows a pair per registered entry — so a `find` over it would silently pick
+  // the oldest once a second version exists. Expansion is unaffected: a record's
+  // own header names the version expandScript looks up.
+  const versions = await describeCurrentVaultTemplate()
   const region1 = versions.find(v => v.region === 0x01)
   const region2 = versions.find(v => v.region === 0x02)
   if (!region1 || !region2) return null

--- a/types/bsv-templates-artifact.d.ts
+++ b/types/bsv-templates-artifact.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Types for `@bsv/templates/R1K1Wallet.artifact.ts`.
+ *
+ * The package maps that subpath through its `exports` map (`./*.ts` ->
+ * `./dist/src/*.d.ts`), but this project's tsconfig inherits Expo's classic
+ * `node` module resolution, which does not read `exports` — so the subpath
+ * resolves at runtime and is untyped at compile time. Declaring it here keeps
+ * the upstream cross-check in __tests__/vault/templateUpstream.test.ts fully
+ * typed instead of pushing it through an `any`.
+ *
+ * Only the names upstream actually exports are declared. `R1_K1_R1_SLOT_OFFSET`
+ * and `R1_K1_R1_CODE_SEPARATOR_OFFSET` exist in its source but are absent from
+ * its export list, and adding them here would compile against something that is
+ * `undefined` at runtime.
+ */
+declare module '@bsv/templates/R1K1Wallet.artifact.ts' {
+  /** Length of the compiled, UNBAKED R1-K1 template. */
+  export const R1_K1_TEMPLATE_BYTE_LENGTH: number
+  /** SHA-256 of that template. */
+  export const R1_K1_TEMPLATE_SHA256: string
+  /** Offset of the k1 constructor slot within the unbaked template. */
+  export const R1_K1_K1_SLOT_OFFSET: number
+  /** Base64 gzip of the unbaked template. */
+  export const R1_K1_TEMPLATE_GZIP_BASE64: string
+}


### PR DESCRIPTION
Plan 4 Task 1. Prerequisite for anything that writes a compressed record, and cheap.

## The footgun this closes

The codec knew exactly one template version: one constant, one vendored artifact, and a `referenceBytesFor` that refused every other version. That is fine while nothing is stored, and catastrophic once something is — **the first change to the vendored asset would make every compressed record written by yesterday's binary permanently unexpandable**, in `proven_tx_reqs`, `transactions`, `proven_txs` and every backup chunk already on the server, all at once. "No migration needed" would have quietly become "migration impossible", with the current build's own data as the victim.

So: append-only table, compression always writes the newest entry, expansion keeps serving every entry that has ever shipped. Cache keyed by version. A pinned fingerprint over the whole table fails in CI if an entry is removed, renumbered or edited — the three ways this could orphan stored records.

`describeVaultTemplate()` now returns descriptors for every registered version; `describeCurrentVaultTemplate()` returns just the newest, and that's what `txEnvelope`'s discovery uses — a `find` over the all-versions list would silently pick the *oldest* once a second version exists.

## @bsv/templates is the authority, and now says so

Prompted by review feedback that this geometry probably belongs upstream — correct, and more so than expected. `@bsv/templates` already exports everything the registry pins:

| upstream | ours | relation |
|---|---|---|
| `R1_K1_TEMPLATE_BYTE_LENGTH` = 959,592 | `rawLength` = 959,632 | + 2 × 20 (slot expansion) |
| `R1_K1_K1_SLOT_OFFSET` = 959,588 | k1 run offset 959,609 | + 20 + 1 (push opcode) |
| `R1K1Wallet.lockingScriptByteLength` | `rawLength` | equal |
| `R1_K1_TEMPLATE_SHA256` | — | pinned, so an upstream artifact swap is visible |

A new test derives each and compares.

**It deliberately does not read them at runtime.** `@bsv/templates` is a caret dependency and stored records outlive it: a codec deriving its geometry from whatever version happens to be installed would silently reconstruct the *wrong bytes* for already-written records after a `^1.10.0` minor bump. So the registry pins and the test compares — upstream moves, CI fails, and a human mints a new version instead of a version range doing it silently.

Two constants can't be derived and the test says so rather than pretending otherwise: `R1_K1_R1_SLOT_OFFSET` is declared in upstream's artifact source but absent from its **export list**, and the scriptCode cut (`lockingBytes.subarray(60)`) is an unexported literal inside `unlockR1`. Both stay guarded by the registry's own `constantHash`/`constantHashScriptCode`, which mask exactly those windows and are verified against the vendored bytes on every process start.

## Testing

`npx tsc --noEmit` clean, `npx jest` 101 suites / 1214 tests pass (14 new), eslint 0 errors. The existing codec suite and the mined-mainnet drift test pass unchanged through the refactor, which is the main evidence that the behaviour is identical with one registered version.

`types/bsv-templates-artifact.d.ts` declares the upstream subpath: the package maps it through its `exports` map, which this project's classic tsconfig resolution does not read. Only the names upstream actually exports are declared — adding the two it doesn't would compile against `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)