### PR TITLE
feat(storage): compressed-at-rest R1-K1 transactions — boundary, write hooks, sync form

### DIFF
--- a/__tests__/storage/compressStored.test.ts
+++ b/__tests__/storage/compressStored.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Compress-on-write, and the round trip through both hooks.
+ *
+ * The storage class itself needs expo-sqlite, so these exercise the pure pair
+ * the hooks delegate to. That is the whole reason the decision lives in a module
+ * rather than inline in the methods.
+ */
+import { Hash, Utils } from '@bsv/sdk'
+import { compressStoredTx, expandStoredTx } from '@/storage/methods/expandStored'
+import { isEnvelope } from '@/services/vault/txEnvelope'
+import { buildMainnetFixtureScript } from '../vault/fixtures/r1k1MainnetFixture'
+
+const varint = (n: number): number[] =>
+  n < 0xfd ? [n] : [0xfe, n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]
+
+const cat = (parts: (Uint8Array | number[])[]): Uint8Array => {
+  const chunks = parts.map(p => (p instanceof Uint8Array ? p : Uint8Array.from(p)))
+  const out = new Uint8Array(chunks.reduce((s, c) => s + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+const P2PKH = Uint8Array.from([0x76, 0xa9, 0x14, ...new Array(20).fill(1), 0x88, 0xac])
+
+let VAULT_TX: number[]
+let VAULT_TXID: string
+let PLAIN_TX: number[]
+let PLAIN_TXID: string
+
+beforeAll(async () => {
+  const lock = Uint8Array.from(await buildMainnetFixtureScript())
+  const build = (script: Uint8Array): Uint8Array =>
+    cat([
+      [1, 0, 0, 0],
+      [1],
+      new Uint8Array(32).fill(0xaa),
+      [0, 0, 0, 0],
+      varint(P2PKH.length),
+      P2PKH,
+      [0xff, 0xff, 0xff, 0xff],
+      [1],
+      [0xe0, 0x93, 4, 0, 0, 0, 0, 0],
+      varint(script.length),
+      script,
+      [0, 0, 0, 0]
+    ])
+  const vault = build(lock)
+  VAULT_TX = Array.from(vault)
+  VAULT_TXID = Utils.toHex(Hash.hash256(VAULT_TX).reverse())
+  const plain = build(P2PKH)
+  PLAIN_TX = Array.from(plain)
+  PLAIN_TXID = Utils.toHex(Hash.hash256(PLAIN_TX).reverse())
+})
+
+describe('compressStoredTx', () => {
+  it('compresses a vault transaction and reads back byte-exactly', async () => {
+    const stored = await compressStoredTx(VAULT_TX, VAULT_TXID)
+    expect(isEnvelope(stored)).toBe(true)
+    expect(stored!.length).toBeLessThan(1000)
+    expect(VAULT_TX.length).toBeGreaterThan(950_000)
+
+    expect(await expandStoredTx(stored)).toEqual(VAULT_TX)
+  })
+
+  it('leaves an ordinary transaction alone', async () => {
+    const stored = await compressStoredTx(PLAIN_TX, PLAIN_TXID)
+    expect(stored).toBe(PLAIN_TX)
+    expect(isEnvelope(stored)).toBe(false)
+  })
+
+  it('is idempotent, which is what makes a restore safe', async () => {
+    // processSyncChunk feeds bytes from a backup straight back through the insert
+    // methods, and those bytes are in STORED form because getSyncChunk emits
+    // stored form. Without the envelope guard a restore would wrap an envelope in
+    // an envelope, and the inner one would never be unwrapped.
+    const once = await compressStoredTx(VAULT_TX, VAULT_TXID)
+    const twice = await compressStoredTx(once, VAULT_TXID)
+    expect(twice).toBe(once)
+    expect(await expandStoredTx(twice)).toEqual(VAULT_TX)
+  })
+
+  it('stores raw when the txid is unknown, rather than an unverifiable envelope', async () => {
+    // Expansion proves itself by hashing and comparing against the recorded
+    // txid. An envelope written without one could never be checked, so the
+    // uncompressed bytes are the safer store.
+    expect(await compressStoredTx(VAULT_TX, undefined)).toBe(VAULT_TX)
+    expect(await compressStoredTx(VAULT_TX, 'not-a-txid')).toBe(VAULT_TX)
+  })
+
+  it('never grows a blob', async () => {
+    const stored = await compressStoredTx(PLAIN_TX, PLAIN_TXID)
+    expect(stored!.length).toBeLessThanOrEqual(PLAIN_TX.length)
+  })
+
+  it('passes undefined and empty through', async () => {
+    expect(await compressStoredTx(undefined, VAULT_TXID)).toBeUndefined()
+    expect(await compressStoredTx([], VAULT_TXID)).toEqual([])
+  })
+
+  it('preserves the caller shape', async () => {
+    // inputBEEF is typed Uint8Array-backed in places and number[] in others;
+    // silently swapping one for the other would break a consumer somewhere the
+    // types do not reach.
+    const asBytes = await compressStoredTx(Uint8Array.from(VAULT_TX), VAULT_TXID)
+    expect(asBytes).toBeInstanceOf(Uint8Array)
+    const asArray = await compressStoredTx(VAULT_TX, VAULT_TXID)
+    expect(Array.isArray(asArray)).toBe(true)
+  })
+
+  it('round-trips a transaction whose txid a caller looked up separately', async () => {
+    // The update path reads the txid back out of the row when the update did not
+    // carry one; this is that shape.
+    const stored = await compressStoredTx(VAULT_TX, VAULT_TXID.toUpperCase())
+    expect(isEnvelope(stored)).toBe(true)
+    expect(await expandStoredTx(stored)).toEqual(VAULT_TX)
+  })
+})

--- a/__tests__/storage/expandStored.test.ts
+++ b/__tests__/storage/expandStored.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The expansion boundary.
+ *
+ * Built on real envelopes and real compressed scripts rather than stand-ins,
+ * because the whole value of this module is that it can tell three encodings
+ * apart by their first byte, and a stand-in would make that trivially true.
+ */
+import { Hash, Utils } from '@bsv/sdk'
+import { compressScriptBytes } from '@/services/vault/templateCodec'
+import { compressTransaction } from '@/services/vault/txEnvelope'
+import {
+  assertExpanded,
+  expandStoredRange,
+  expandStoredScript,
+  expandStoredTx
+} from '@/storage/methods/expandStored'
+import { buildMainnetFixtureScript } from '../vault/fixtures/r1k1MainnetFixture'
+
+let LOCK: Uint8Array
+let TX: Uint8Array
+let ENVELOPE: number[]
+let SCRIPT_OFFSET: number
+
+const varint = (n: number): number[] =>
+  n < 0xfd ? [n] : [0xfe, n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]
+
+const cat = (parts: (Uint8Array | number[])[]): Uint8Array => {
+  const chunks = parts.map(p => (p instanceof Uint8Array ? p : Uint8Array.from(p)))
+  const out = new Uint8Array(chunks.reduce((s, c) => s + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+beforeAll(async () => {
+  LOCK = Uint8Array.from(await buildMainnetFixtureScript())
+  const p2pkh = Uint8Array.from([0x76, 0xa9, 0x14, ...new Array(20).fill(1), 0x88, 0xac])
+  TX = cat([
+    [1, 0, 0, 0],
+    [1],
+    new Uint8Array(32).fill(0xaa),
+    [0, 0, 0, 0],
+    varint(p2pkh.length),
+    p2pkh,
+    [0xff, 0xff, 0xff, 0xff],
+    [1],
+    [0xe0, 0x93, 4, 0, 0, 0, 0, 0],
+    varint(LOCK.length),
+    LOCK,
+    [0, 0, 0, 0]
+  ])
+  SCRIPT_OFFSET = TX.length - 4 - LOCK.length
+  const txid = Utils.toHex(Hash.hash256(Array.from(TX)).reverse())
+  ENVELOPE = Array.from(await compressTransaction(TX, txid))
+  expect(ENVELOPE[0]).toBe(0xfe)
+})
+
+describe('expandStoredTx', () => {
+  it('expands an envelope back to the exact transaction', async () => {
+    expect(await expandStoredTx(ENVELOPE)).toEqual(Array.from(TX))
+  })
+
+  it('passes ordinary rawTx through untouched, so it is safe to call always', async () => {
+    const raw = Array.from(TX)
+    expect(await expandStoredTx(raw)).toBe(raw)
+  })
+
+  it('passes undefined and empty through', async () => {
+    expect(await expandStoredTx(undefined)).toBeUndefined()
+    expect(await expandStoredTx([])).toEqual([])
+  })
+
+  it('THROWS on a corrupt envelope rather than returning wrong bytes', async () => {
+    // Transaction blobs are only ever written by this wallet, so a failure here
+    // means real corruption — and passing the bytes through is exactly how they
+    // would reach a broadcaster or a hasher.
+    const corrupt = [...ENVELOPE]
+    corrupt[corrupt.length - 1] ^= 0x01
+    await expect(expandStoredTx(corrupt)).rejects.toThrow(/txid/)
+  })
+})
+
+describe('expandStoredRange', () => {
+  it('reads a script at its recorded offset out of an envelope', async () => {
+    // The silent-fund-eviction path: these offsets are into the UNCOMPRESSED
+    // transaction, so slicing the stored envelope would return plausible wrong
+    // bytes with no error.
+    const range = await expandStoredRange(ENVELOPE, SCRIPT_OFFSET, LOCK.length)
+    expect(range).toEqual(Array.from(LOCK))
+  })
+
+  it('slices plain bytes exactly as before', async () => {
+    const raw = Array.from(TX)
+    expect(await expandStoredRange(raw, SCRIPT_OFFSET, 8)).toEqual(Array.from(LOCK.subarray(0, 8)))
+  })
+
+  it('agrees with a full expansion followed by a slice', async () => {
+    for (const [offset, length] of [
+      [0, 4],
+      [4, 40],
+      [SCRIPT_OFFSET - 2, 10],
+      [TX.length - 4, 4]
+    ]) {
+      expect(await expandStoredRange(ENVELOPE, offset, length)).toEqual(
+        Array.from(TX.subarray(offset, offset + length))
+      )
+    }
+  })
+})
+
+describe('expandStoredScript', () => {
+  it('expands a compressed script', async () => {
+    const record = Array.from(await compressScriptBytes(LOCK))
+    expect(record[0]).toBe(0xff)
+    expect(await expandStoredScript(record)).toEqual(Array.from(LOCK))
+  })
+
+  it('passes a real script through', async () => {
+    const p2pkh = [0x76, 0xa9, 0x14, ...new Array(20).fill(1), 0x88, 0xac]
+    expect(await expandStoredScript(p2pkh)).toBe(p2pkh)
+  })
+
+  it('degrades instead of throwing when a marker-led script cannot be expanded', async () => {
+    // internalizeAction writes page-supplied output scripts with no
+    // scriptLength/scriptOffset fallback, so a 0xff-led value here may be a
+    // forgery rather than something this wallet wrote. findOutputs maps over its
+    // results with no per-row catch, so throwing would take down listOutputs,
+    // the vault screen and the backup sweep for the whole wallet over one row.
+    const forged = [0xff, 0x02, 0x01, 0, 0, 0, 0, 1, 2, 3, 4, 9, 9, 9]
+    await expect(expandStoredScript(forged)).resolves.toEqual(forged)
+  })
+})
+
+describe('assertExpanded', () => {
+  it('accepts real bytes', () => {
+    expect(() => assertExpanded(Array.from(TX), 'rawTx')).not.toThrow()
+    expect(() => assertExpanded(undefined, 'rawTx')).not.toThrow()
+    expect(() => assertExpanded([], 'rawTx')).not.toThrow()
+  })
+
+  it('rejects either marker, naming what was about to be used', () => {
+    // A branded type is erased crossing into node_modules, so this runtime check
+    // is the only thing that spans the seam.
+    expect(() => assertExpanded(ENVELOPE, 'broadcast payload')).toThrow(/broadcast payload/)
+    expect(() => assertExpanded(ENVELOPE, 'x')).toThrow(/0xfe/)
+    expect(() => assertExpanded([0xff, 2, 1], 'lockingScript')).toThrow(/0xff/)
+  })
+
+  it('accepts a Uint8Array as well as an array', () => {
+    expect(() => assertExpanded(TX, 'rawTx')).not.toThrow()
+    expect(() => assertExpanded(Uint8Array.from(ENVELOPE), 'rawTx')).toThrow()
+  })
+})

--- a/__tests__/vault/txEnvelope.test.ts
+++ b/__tests__/vault/txEnvelope.test.ts
@@ -129,6 +129,21 @@ const p2pkh = () => Uint8Array.from([0x76, 0xa9, 0x14, ...new Array(20).fill(0x0
 
 // ── tests ─────────────────────────────────────────────────────────────────
 
+describe('layout constants', () => {
+  it('match r1k1.ts, which txEnvelope deliberately does not import', () => {
+    // txEnvelope declares these locally so the storage import graph does not pull
+    // @bsv/templates (via r1k1.ts) into app startup for two integers. This test is
+    // what stops the duplication drifting.
+    // R1K1_LOCK_LEN / R1K1_R1_UNLOCK_LEN here are r1k1.ts's exports (imported at
+    // the top of this file); the envelope's local copies must equal them, and the
+    // real fixture must match both.
+    expect(R1K1_LOCK_LEN).toBe(959_632)
+    expect(R1K1_R1_UNLOCK_LEN).toBe(959_871)
+    expect(LOCK.length).toBe(R1K1_LOCK_LEN)
+    expect(r1UnlockingScript().length).toBe(R1K1_R1_UNLOCK_LEN)
+  })
+})
+
 describe('compressTransaction / expandTransaction', () => {
   it('round-trips a deposit byte-exactly and preserves the txid', async () => {
     const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })

--- a/__tests__/vault/txEnvelope.test.ts
+++ b/__tests__/vault/txEnvelope.test.ts
@@ -11,8 +11,10 @@
  */
 import { Hash, Utils } from '@bsv/sdk'
 import {
+  ENVELOPE_FLAG_DIGEST,
   ENVELOPE_MAGIC,
   ENVELOPE_VERSION,
+  compressContainer,
   compressTransaction,
   envelopeTxid,
   expandTransaction,
@@ -359,5 +361,102 @@ describe('readEnvelopeRange', () => {
     const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
     const envelope = await compressTransaction(tx, txidOf(tx))
     await expect(readEnvelopeRange(envelope, 1.5, 4)).rejects.toThrow(/integer/)
+  })
+})
+
+describe('compressContainer', () => {
+  // A BEEF is a container of several transactions with no single txid, so the
+  // header commits to SHA-256 of the whole blob instead. Everything else — spans,
+  // literal, reconstruction — is shared with the transaction path.
+  const beefish = (txs: Uint8Array[]): Uint8Array =>
+    cat([
+      [0x01, 0x00, 0xbe, 0xef], // version
+      [0x01], // one BUMP
+      filled(37, 0x77), // BUMP bytes this codec deliberately does not parse
+      varint(txs.length),
+      ...txs.flatMap(t => [t, [0x00]] as (Uint8Array | number[])[])
+    ])
+
+  it('round-trips a container carrying a vault transaction', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const blob = beefish([tx])
+
+    const envelope = await compressContainer(blob)
+    expect(isEnvelope(envelope)).toBe(true)
+    expect(blob.length).toBeGreaterThan(950_000)
+    expect(envelope.length).toBeLessThan(1200)
+    expect(Array.from(await expandTransaction(envelope))).toEqual(Array.from(blob))
+  })
+
+  it('round-trips a withdrawal-shaped container: unlocking scripts and a re-vault output', async () => {
+    // The shape that actually wedges the backup log — inputBEEF carries ~1.83 MB
+    // per vault input, several times the rawTx it accompanies.
+    const spend = buildTx({
+      inputs: [{ script: r1UnlockingScript() }, { script: r1UnlockingScript() }],
+      outputs: [{ satoshis: 400_000, script: LOCK }, { satoshis: 50_000, script: p2pkh() }]
+    })
+    const blob = beefish([spend])
+
+    const envelope = await compressContainer(blob)
+    expect(blob.length).toBeGreaterThan(2_800_000)
+    expect(envelope.length).toBeLessThan(2000)
+    expect(Array.from(await expandTransaction(envelope))).toEqual(Array.from(blob))
+  })
+
+  it('round-trips several transactions in one container', async () => {
+    const a = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const b = buildTx({ inputs: [{ script: r1UnlockingScript() }], outputs: [{ satoshis: 1000, script: p2pkh() }] })
+    const blob = beefish([a, b])
+
+    const envelope = await compressContainer(blob)
+    expect(Array.from(await expandTransaction(envelope))).toEqual(Array.from(blob))
+  })
+
+  it('does not report a scriptCode inside a locking script as its own span', async () => {
+    // Region 0x02 is a byte-for-byte SUFFIX of region 0x01, so a naive scan finds
+    // one inside every locking script and produces overlapping spans. Region 0x01
+    // is claimed first and its range excluded.
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const blob = beefish([tx])
+    const envelope = await compressContainer(blob)
+    expect(envelope[39]).toBe(1) // spanCount
+    expect(Array.from(await expandTransaction(envelope))).toEqual(Array.from(blob))
+  })
+
+  it('leaves a container with no vault script unchanged', async () => {
+    const blob = beefish([buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 1000, script: p2pkh() }] })])
+    expect(await compressContainer(blob)).toBe(blob)
+  })
+
+  it('refuses a tampered container: the digest, not a txid, is what it checks', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const envelope = Uint8Array.from(await compressContainer(beefish([tx])))
+    envelope[envelope.length - 1] ^= 0x01
+    await expect(expandTransaction(envelope)).rejects.toThrow(/container envelope expands to digest/)
+  })
+
+  it('sets the digest flag, and a transaction envelope does not', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const container = await compressContainer(beefish([tx]))
+    const single = await compressTransaction(tx, txidOf(tx))
+    expect(container[2] & ENVELOPE_FLAG_DIGEST).toBe(ENVELOPE_FLAG_DIGEST)
+    expect(single[2] & ENVELOPE_FLAG_DIGEST).toBe(0)
+  })
+
+  it('is idempotent', async () => {
+    const blob = beefish([buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })])
+    const once = await compressContainer(blob)
+    expect(await compressContainer(once)).toBe(once)
+  })
+
+  it('serves ranges out of a container envelope too', async () => {
+    const tx = buildTx({ inputs: [{ script: p2pkh() }], outputs: [{ satoshis: 300_000, script: LOCK }] })
+    const blob = beefish([tx])
+    const envelope = await compressContainer(blob)
+    for (const [offset, length] of [[0, 5], [40, 64], [blob.length - 3, 3]]) {
+      expect(Array.from(await readEnvelopeRange(envelope, offset, length))).toEqual(
+        Array.from(blob.subarray(offset, offset + length))
+      )
+    }
   })
 })

--- a/docs/superpowers/2026-08-20-morning-handoff.md
+++ b/docs/superpowers/2026-08-20-morning-handoff.md
@@ -4,10 +4,19 @@
 
 Two store artifacts, built from `claude/vault-expansion-boundary` (which contains the whole PR stack: #136 → #137 → #138 plus the BEEF work). Both were archived from the identical working tree, so the two binaries carry the same code.
 
-- **iOS** → `build-*.ipa` (newest), production profile, local credentials. Upload with Transporter, not `eas submit` — see the note below.
-- **Android** → `build-*.aab` (newest), production profile, app-bundle, remote credentials.
+- **iOS** → `build-1787200068859.ipa` — 39.2 MB, version **1.6.0 build 165**, `org.bsvassociation.browser`, team `SV8SWTHA2H`. Upload with Transporter, not `eas submit` — see the note below.
+- **Android** → `build-1787199672574.aab` — 112.3 MB, **versionCode 91** (EAS auto-increment).
 
-`ls -lat build-*.ipa build-*.aab | head -4` gives the newest of each. Anything older is from a previous session.
+Both were verified after building, not just reported as "successful", because on this project a build has succeeded before while silently missing a whole native module:
+
+| Check | iOS | Android |
+|---|---|---|
+| YubiKey native module linked | `HybridYubiKeyPiv` + `YubiKitManager` present in the binary; pods `YubiKeyPiv`, `YubiKit` | `libYubiKeyPiv.so` in all four ABIs |
+| Localpay transport linked | `HybridLocalPayTransport` present | `libLocalPayTransport.so` in all four ABIs |
+| No banned Bluetooth key | no `NSBluetooth*` key at all | n/a |
+| NFC kept | `com.apple.developer.nfc.readersession.formats` entitlement + `NFCReaderUsageDescription` present | n/a |
+| Release signing | `get-task-allow = false`, distribution-signed | n/a |
+| 16 KB page alignment | n/a | first LOAD segment `2**14` on every lib |
 
 **Transporter, not Deliver.** Past experience on this project: `ITMS-90683` appears at Deliver and demands a `NSBluetoothAlwaysUsageDescription` key that must NOT be added, and Transporter's own Verify step does not catch it. If it appears again, the answer is still not to add the key.
 

--- a/docs/superpowers/2026-08-20-morning-handoff.md
+++ b/docs/superpowers/2026-08-20-morning-handoff.md
@@ -1,0 +1,76 @@
+# Morning handoff — 2026-08-20
+
+## What to upload
+
+Two store artifacts, built from `claude/vault-expansion-boundary` (which contains the whole PR stack: #136 → #137 → #138 plus the BEEF work). Both were archived from the identical working tree, so the two binaries carry the same code.
+
+- **iOS** → `build-*.ipa` (newest), production profile, local credentials. Upload with Transporter, not `eas submit` — see the note below.
+- **Android** → `build-*.aab` (newest), production profile, app-bundle, remote credentials.
+
+`ls -lat build-*.ipa build-*.aab | head -4` gives the newest of each. Anything older is from a previous session.
+
+**Transporter, not Deliver.** Past experience on this project: `ITMS-90683` appears at Deliver and demands a `NSBluetoothAlwaysUsageDescription` key that must NOT be added, and Transporter's own Verify step does not catch it. If it appears again, the answer is still not to add the key.
+
+## What these builds are for
+
+Physical verification of four programmes that are complete in code and unverified on hardware. Every one of them is test-green; none has run on a phone.
+
+### 1. Vault: adopt a YubiKey already enrolled elsewhere
+
+The original report. Your Android phone plus the iPhone that already holds the vault key.
+
+- Vault → enrol on the Android phone with the same YubiKey. Expect **"This YubiKey is already set up"** with *Use the key already on this YubiKey* — not the old dead-end error.
+- Adopt, then confirm the vault opens and shows the same balance the iPhone sees **once storage has synced** — the two devices have separate local SQLite, so an unsynced Android install can legitimately show an empty vault with a correctly adopted key.
+- Deposit indices start high on the adopted device by design (random, ≥ 2^20), so the two phones cannot hand out the same address.
+
+### 2. Backup: restore on import, and the cursor advancing
+
+This is the acceptance criterion for the whole compression programme, and it is an observation rather than an assertion.
+
+- Fresh install → **Import Existing Wallet** with a phrase that has a backup. Expect a progress line ("Restoring your wallet history — n of m") and history present afterwards.
+- Then, on a wallet with a **funded vault**: make a deposit and a withdrawal, leave the app foregrounded a few minutes, and check that the backup **cursor advances** rather than sticking. Before this work a single vault deposit wedged the log permanently.
+- Leave it running long enough for **two `TaskCheckForProofs` sweeps** and confirm no req reaches `status='invalid'`. That transition is irreversible and cascades, so it is the one to watch.
+
+### 3. Size caps and the vault input cap
+
+- From a page: an oversize `createAction` should be refused with a clean error (code 6), not a crash.
+- A withdrawal from a vault holding **more than 6 UTXOs** should move part of the vault and say so ("Moved part of your vault. n more deposits remain"), leaving the rest spendable. Repeat it and the vault should drain, consolidating each pass.
+- Turn airplane mode on and try a vault transfer: expect **"Vault transfers need a connection"**, and no YubiKey prompt.
+
+### 4. Storage pressure
+
+- Settings → Settings → Data & Security → **Storage** shows database size, free space and what is reclaimable. Safe to run; it clears validation data the wallet no longer needs and never touches balances or history.
+
+## What is deliberately OFF in these builds
+
+`COMPRESS_PROVEN_TX_RAWTX` in `storage/methods/expandStored.ts` is `false`. That column is the merkle evidence, and `Beef.verifyBumpIndexLeaves` binds `hash256(rawTx)` to a chain-committed BUMP leaf inside `@bsv/sdk` where no subclass can intercept it — so a bug there is unrepairable locally, unlike every other column, which can be refetched. Flip it only after (2) above has passed on a device. It is one line and reversible; rows written while it was on stay readable if it goes back off.
+
+## Known gaps, none of them silent
+
+- **No mining harness.** Every representation-agnostic site passes green on compressed bytes; the failures that would matter live in the monitor, the UTXO prober and the broadcaster, and no current test drives them that far. This is why the device pass above is the real gate.
+- **Peer sync would need a capability flag.** `storageUrl` is `'local'`, so the only sync consumer is our own encrypted backup. If BRC-38 peer storage is ever enabled, envelopes would replicate with no signal and a mixed fleet would re-push forever — the comment on `getSyncChunk` says so.
+- **Adjacent memory holes remain open**, and a size cap does not close them: no rate limit or in-flight guard in the dispatcher, the response side (`buildWalletResponseScript` double-stringifies a multi-MB `listOutputs` into `injectJavaScript`), the ungated localpay radio send with its per-byte base64 encoder, and the 402 path that puts an AtomicBEEF into an HTTP header where intermediaries cap at 8–16 KiB.
+- **Offline queue lifecycle.** `processOfflineActions` still has no attempt cap, no expiry and no local terminal state that releases a reservation. Vault transfers can no longer enter it (that gate shipped), so this is now default-basket-only — but a stuck row still freezes coins with only a devLog to show it.
+
+## PR state
+
+| PR | What | Status |
+|---|---|---|
+| [#136](https://github.com/bsv-blockchain/bsv-browser/pull/136) | Template registry, cross-checked against `@bsv/templates` | open, review required |
+| [#137](https://github.com/bsv-blockchain/bsv-browser/pull/137) | `Uint8Array` codec core | open, stacked on #136 |
+| [#138](https://github.com/bsv-blockchain/bsv-browser/pull/138) | Expansion boundary, compress-on-write, BEEF containers, sync form | open, stacked on #137 |
+| [go-private-backup-cache#3](https://github.com/bsv-blockchain/go-private-backup-cache/pull/3) | 413 before auth, `GET /v1/limits` | open, rationale corrected |
+
+The org ruleset requires a review on each, which I cannot satisfy. #132, #133, #134, #135 and server #4 are merged.
+
+## Numbers worth knowing
+
+| | |
+|---|---|
+| Vault locking script | 959,632 bytes → **51** compressed |
+| Preimage scriptCode | 959,572 → **31** |
+| A deposit's rawTx | ~960 KB → **under 1 KB** |
+| A withdrawal-shaped BEEF, 2 vault inputs | 2.8 MB → **under 2 KB** |
+| `inputBEEF` per vault input | ~1.83 MB — why containers mattered more than rawTx |
+| Backup server blob cap | 1 MiB, published at `GET /v1/limits` |
+| Peak RSS per payload byte | ~20× central, 30× planning (Hermes v0.14.1) |

--- a/services/vault/templateCodec.ts
+++ b/services/vault/templateCodec.ts
@@ -427,6 +427,22 @@ function describeEntry(entry: TemplateRegistryEntry): TemplateVersion[] {
 }
 
 /**
+ * The first `length` bytes of a region's reference template.
+ *
+ * Exists for the container scan in txEnvelope.ts, which needs a cheap prefix
+ * filter before paying a full 959 K-byte compare. Derived from the vendored
+ * reference rather than hardcoded, so the template changing cannot leave a stale
+ * literal behind — and the prefix is chosen from the head of the script, which no
+ * variable run touches, so it is the same for every instance.
+ */
+export async function templatePrefix(region: TemplateRegion, length: number): Promise<Uint8Array> {
+  const entry = currentEntry()
+  const cache = ensureTemplateCache(entry.version)
+  const reference = region === 0x01 ? cache.region1 : cache.region2
+  return reference.subarray(0, length).slice()
+}
+
+/**
  * True only when `bytes` is exactly `v.totalLength` long AND every byte
  * outside `v.variableRuns` equals the cached reference template's byte at
  * that offset. Compares in place against the cached reference — no masked

--- a/services/vault/txEnvelope.ts
+++ b/services/vault/txEnvelope.ts
@@ -40,10 +40,6 @@
 import { Hash, Utils } from '@bsv/sdk'
 import { VaultError } from './types'
 import {
-  R1K1_LOCK_LEN,
-  R1K1_R1_UNLOCK_LEN
-} from './r1k1'
-import {
   compressScriptBytes,
   compressScriptCodeBytes,
   describeCurrentVaultTemplate,
@@ -88,6 +84,18 @@ const SPAN_HEADER_LEN = 4 + 1 + 2
  */
 const UNLOCK_SCRIPT_CODE_OFFSET = 246
 const SCRIPT_CODE_LEN = 959_572
+
+/**
+ * Script lengths, declared here rather than imported from r1k1.ts.
+ *
+ * r1k1.ts imports @bsv/templates, and this module is now in the STORAGE import
+ * graph — so importing it from here would pull the template library into app
+ * startup for the sake of two integers, on a wallet that already fights cold
+ * start. __tests__/vault/txEnvelope.test.ts asserts both against r1k1's
+ * exports, so the duplication cannot drift.
+ */
+const R1K1_LOCK_LEN = 959_632
+const R1K1_R1_UNLOCK_LEN = 959_871
 
 type Region = 0x01 | 0x02
 

--- a/services/vault/txEnvelope.ts
+++ b/services/vault/txEnvelope.ts
@@ -48,13 +48,25 @@ import {
   compressScriptCodeBytes,
   describeCurrentVaultTemplate,
   expandScriptBytes,
-  matchesTemplate
+  matchesTemplate,
+  templatePrefix
 } from './templateCodec'
 
 /** First byte of an envelope. See the module doc for why not 0xff. */
 export const ENVELOPE_MAGIC = 0xfe
 
 export const ENVELOPE_VERSION = 1
+
+/**
+ * Flags bit: the 32-byte integrity field holds SHA-256 of the original blob
+ * rather than the transaction's txid.
+ *
+ * Set for CONTAINERS — inputBEEF, beef, AtomicBEEF — which hold several
+ * transactions and therefore have no single txid to verify against. The span and
+ * literal machinery is identical; only what the header commits to differs, and
+ * expansion checks whichever one the flag names.
+ */
+export const ENVELOPE_FLAG_DIGEST = 0x01
 
 /** magic + version + flags + txid(32) + origLength(4) + spanCount(1) */
 const HEADER_LEN = 1 + 1 + 1 + 32 + 4 + 1
@@ -199,6 +211,76 @@ async function discoverSpans(tx: Uint8Array): Promise<Span[] | null> {
 }
 
 /**
+ * Find template instances anywhere in a blob, by prefix scan then exact verify.
+ *
+ * For CONTAINERS (a BEEF, an AtomicBEEF) there is no framing this module can
+ * walk: BEEF interleaves BUMP structures whose length depends on their own tree
+ * geometry, and a v2 container adds txid-only entries. Parsing all of that
+ * correctly just to find two enormous byte ranges would be a large amount of
+ * fragile code for no benefit — so discovery here is a scan, made safe by the
+ * same exactness that makes the structural walk safe.
+ *
+ * Cheap filter first: a region-0x01 instance begins `76 00 9c ...` and a
+ * region-0x02 instance begins with region 0x01's bytes from offset 60, so a
+ * candidate is found by matching a short prefix and only then paying the full
+ * 959 K-byte compare. matchesTemplate cannot false-positive, so a spurious
+ * prefix hit costs work and never correctness.
+ *
+ * Region 0x01 is searched first and its range is then excluded, because region
+ * 0x02 is a byte-for-byte SUFFIX of region 0x01 — every locking script contains
+ * a scriptCode at offset 60, and reporting both would produce overlapping spans.
+ * Preferring the longer, earlier match makes the result deterministic.
+ */
+async function discoverSpansByScan(blob: Uint8Array): Promise<Span[] | null> {
+  const versions = await describeCurrentVaultTemplate()
+  const region1 = versions.find(v => v.region === 0x01)
+  const region2 = versions.find(v => v.region === 0x02)
+  if (!region1 || !region2) return null
+
+  const spans: Span[] = []
+  const claimed: { from: number; to: number }[] = []
+  const overlapsClaimed = (from: number, to: number): boolean =>
+    claimed.some(c => from < c.to && to > c.from)
+
+  const scan = async (
+    v: typeof region1,
+    region: Region,
+    prefix: Uint8Array,
+    compress: (bytes: Uint8Array) => Promise<Uint8Array>
+  ): Promise<void> => {
+    const last = blob.length - v.totalLength
+    for (let at = 0; at <= last; at++) {
+      if (blob[at] !== prefix[0]) continue
+      let prefixOk = true
+      for (let i = 1; i < prefix.length; i++) {
+        if (blob[at + i] !== prefix[i]) {
+          prefixOk = false
+          break
+        }
+      }
+      if (!prefixOk) continue
+      if (overlapsClaimed(at, at + v.totalLength)) continue
+
+      const window = blob.subarray(at, at + v.totalLength)
+      if (!matchesTemplate(window, v)) continue
+
+      spans.push({ offset: at, region, record: await compress(window), length: v.totalLength })
+      claimed.push({ from: at, to: at + v.totalLength })
+      at += v.totalLength - 1
+    }
+  }
+
+  await scan(region1, 0x01, await templatePrefix(0x01, PREFIX_LEN), compressScriptBytes)
+  await scan(region2, 0x02, await templatePrefix(0x02, PREFIX_LEN), compressScriptCodeBytes)
+
+  spans.sort((a, b) => a.offset - b.offset)
+  return spans
+}
+
+/** How many leading bytes of a template are used as the cheap scan filter. */
+const PREFIX_LEN = 8
+
+/**
  * Compress a transaction, or return it unchanged.
  *
  * Unchanged is returned for anything with no R1-K1 span, anything this module
@@ -214,8 +296,46 @@ export async function compressTransaction(rawTx: Uint8Array | number[], txid: st
   if (!/^[0-9a-fA-F]{64}$/.test(txid)) {
     throw new VaultError('template-invalid', 'compressTransaction needs the transaction txid to record')
   }
+  return assemble(tx, await discoverSpans(tx), txid, 0)
+}
 
-  const spans = await discoverSpans(tx)
+/**
+ * Compress a CONTAINER of transactions — inputBEEF, beef, AtomicBEEF.
+ *
+ * Same spans, same literal, same reconstruction. What differs is the integrity
+ * field: a container has no single txid, so the header commits to SHA-256 of the
+ * original blob and expansion checks that instead. Routing a container through
+ * compressTransaction would produce an envelope whose integrity check was
+ * meaningless, which is why this is a separate entry point rather than an
+ * optional argument.
+ *
+ * Discovery is a prefix scan rather than a structural walk, because BEEF framing
+ * interleaves BUMP structures whose length depends on their own tree geometry —
+ * see discoverSpansByScan.
+ *
+ * This is what takes a vault WITHDRAWAL's stored bytes under the backup server's
+ * blob cap: inputBEEF carries ~1.83 MB per vault input, several times more than
+ * the rawTx it accompanies.
+ */
+export async function compressContainer(blob: Uint8Array | number[]): Promise<Uint8Array> {
+  const bytes = asBytes(blob)
+  if (isEnvelope(bytes)) return bytes
+  const digest = Utils.toHex(Hash.sha256(Array.from(bytes)))
+  return assemble(bytes, await discoverSpansByScan(bytes), digest, ENVELOPE_FLAG_DIGEST)
+}
+
+/**
+ * Build an envelope from discovered spans, or return the original.
+ *
+ * Shared so the transaction and container paths cannot drift in how they lay
+ * bytes out — only in how they discover spans and what they commit to.
+ */
+async function assemble(
+  tx: Uint8Array,
+  spans: Span[] | null,
+  integrity: string,
+  flags: number
+): Promise<Uint8Array> {
   if (!spans || spans.length === 0) return tx
   if (spans.length > 255) return tx
 
@@ -239,8 +359,8 @@ export async function compressTransaction(rawTx: Uint8Array | number[], txid: st
   const literalLen = literalChunks.reduce((sum, c) => sum + c.length, 0)
 
   const chunks: Uint8Array[] = [
-    Uint8Array.from([ENVELOPE_MAGIC, ENVELOPE_VERSION, 0]),
-    Uint8Array.from(Utils.toArray(txid, 'hex')),
+    Uint8Array.from([ENVELOPE_MAGIC, ENVELOPE_VERSION, flags]),
+    Uint8Array.from(Utils.toArray(integrity, 'hex')),
     Uint8Array.from(writeUInt32BE(tx.length)),
     Uint8Array.from([spans.length])
   ]
@@ -289,7 +409,10 @@ function requireEnvelope(b: Uint8Array): void {
 }
 
 interface ParsedEnvelope {
+  /** The recorded integrity value: a txid, or a SHA-256 when digestMode. */
   txid: string
+  /** True when the integrity field is a SHA-256 of the original blob. */
+  digestMode: boolean
   origLength: number
   spans: { offset: number; region: Region; record: Uint8Array }[]
   literal: Uint8Array
@@ -298,6 +421,7 @@ interface ParsedEnvelope {
 function parseEnvelope(b: Uint8Array): ParsedEnvelope {
   requireEnvelope(b)
   const txid = Utils.toHex(Array.from(b.subarray(3, 35)))
+  const digestMode = (b[2] & ENVELOPE_FLAG_DIGEST) !== 0
   const origLength = readUInt32BE(b, 35)
   const spanCount = b[39]
 
@@ -324,7 +448,7 @@ function parseEnvelope(b: Uint8Array): ParsedEnvelope {
   if (at + literalLen !== b.length) {
     throw new VaultError('template-invalid', 'transaction envelope literal length disagrees with its size')
   }
-  return { txid, origLength, spans, literal: b.subarray(at) }
+  return { txid, digestMode, origLength, spans, literal: b.subarray(at) }
 }
 
 /**
@@ -368,11 +492,15 @@ export async function expandTransaction(envelope: Uint8Array | number[]): Promis
   }
   out.set(parsed.literal.subarray(literalAt), outAt)
 
-  const txid = Utils.toHex(Hash.hash256(Array.from(out)).reverse())
-  if (txid !== parsed.txid) {
+  const actual = parsed.digestMode
+    ? Utils.toHex(Hash.sha256(Array.from(out)))
+    : Utils.toHex(Hash.hash256(Array.from(out)).reverse())
+  if (actual !== parsed.txid) {
     throw new VaultError(
       'template-invalid',
-      `transaction envelope expands to txid ${txid} but records ${parsed.txid}`
+      `${parsed.digestMode ? 'container' : 'transaction'} envelope expands to ${
+        parsed.digestMode ? 'digest' : 'txid'
+      } ${actual} but records ${parsed.txid}`
     )
   }
   return out

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -11,7 +11,9 @@ import {
   splitOutpoint
 } from './methods/findSql'
 import { scrubHistoryJson } from './methods/historyNotes'
+import { compressScriptBytes, isCompressed } from '@/services/vault/templateCodec'
 import {
+  COMPRESS_PROVEN_TX_RAWTX,
   assertExpanded,
   compressStoredTx,
   expandStoredRange,
@@ -528,6 +530,10 @@ export class StorageExpoSQLite extends StorageProvider {
   async insertProvenTx(tx: TableProvenTx, trx?: TrxToken): Promise<number> {
     const e = await this.validateEntityForInsert(tx, trx)
     if (e.provenTxId === 0) delete e.provenTxId
+    // Gated: this row is the merkle evidence, and Beef.verifyBumpIndexLeaves binds
+    // hash256(rawTx) to a chain-committed leaf inside @bsv/sdk where no subclass
+    // can intercept. See COMPRESS_PROVEN_TX_RAWTX.
+    if (COMPRESS_PROVEN_TX_RAWTX) e.rawTx = (await compressStoredTx(e.rawTx, e.txid)) as number[]
     const id = await this.sqlInsert('proven_txs', e, 'provenTxId')
     tx.provenTxId = id
     return id
@@ -656,8 +662,14 @@ export class StorageExpoSQLite extends StorageProvider {
   }
 
   async updateProvenTx(id: number, update: Partial<TableProvenTx>, trx?: TrxToken): Promise<number> {
-    const u = this.validatePartialForUpdate(update)
-    return await this.sqlUpdate('proven_txs', id, u as any, 'provenTxId')
+    const u = this.validatePartialForUpdate(update) as any
+    if (COMPRESS_PROVEN_TX_RAWTX && u.rawTx) {
+      const row = (await this.getDB().getFirstAsync('SELECT txid FROM proven_txs WHERE provenTxId = ?', [
+        id
+      ])) as { txid?: string } | null
+      u.rawTx = await compressStoredTx(u.rawTx, u.txid ?? row?.txid)
+    }
+    return await this.sqlUpdate('proven_txs', id, u, 'provenTxId')
   }
 
   /**
@@ -1856,6 +1868,48 @@ export class StorageExpoSQLite extends StorageProvider {
       pairs.push({ req, tx })
     }
     return pairs
+  }
+
+  /**
+   * Keep sync chunks in stored form.
+   *
+   * getSyncChunk reads outputs through findOutputs WITHOUT noScript, so two
+   * things happen that make a chunk enormous: E3 expands any compressed script,
+   * and validateOutputScript re-slices the full ~960 KB script out of rawTx for
+   * vault outputs whose column is NULL (maxOutputScript is 1024, so it is always
+   * NULL for them). The result is that a chunk carrying one vault output exceeds
+   * the backup server's 1 MiB blob cap even though the database itself stores
+   * almost nothing for it.
+   *
+   * So the chunk is re-compressed on the way out. This is the deliberate
+   * exception to the expansion boundary — the one consumer that wants stored
+   * form — and it is safe because the receiving side is symmetric:
+   * processSyncChunk writes through the insert hooks, which are idempotent, and
+   * every read path expands.
+   *
+   * IF PEER SYNC IS EVER ENABLED (storageUrl is 'local' today, so the only
+   * consumer is our own encrypted backup), this needs a capability flag first:
+   * the toolbox's portable layer base64s byte columns verbatim and neither
+   * getSyncChunk nor processSyncChunk inspects them, so envelopes would replicate
+   * to a peer with no signal, and byte-for-byte entity diffs would make a mixed
+   * fleet see every record as changed and re-push forever.
+   */
+  async getSyncChunk(args: RequestSyncChunkArgs): Promise<SyncChunk> {
+    const chunk = await super.getSyncChunk(args)
+
+    for (const o of chunk.outputs ?? []) {
+      if (o.lockingScript && !isCompressed(o.lockingScript)) {
+        const compressed = await compressScriptBytes(Uint8Array.from(o.lockingScript))
+        if (compressed.length < o.lockingScript.length) o.lockingScript = Array.from(compressed)
+      }
+    }
+    for (const req of chunk.provenTxReqs ?? []) {
+      req.rawTx = await compressStoredTx(req.rawTx, req.txid)
+    }
+    for (const t of chunk.transactions ?? []) {
+      t.rawTx = await compressStoredTx(t.rawTx, t.txid)
+    }
+    return chunk
   }
 
   // processSyncChunk — delegate to inherited implementation if available, stub otherwise

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -15,6 +15,7 @@ import { compressScriptBytes, isCompressed } from '@/services/vault/templateCode
 import {
   COMPRESS_PROVEN_TX_RAWTX,
   assertExpanded,
+  compressStoredBeef,
   compressStoredTx,
   expandStoredRange,
   expandStoredScript,
@@ -550,6 +551,7 @@ export class StorageExpoSQLite extends StorageProvider {
     // full on every sweep and the one that pushed a backup chunk over the
     // server's 1 MiB cap.
     e.rawTx = await compressStoredTx(e.rawTx, e.txid)
+    e.inputBEEF = await compressStoredBeef(e.inputBEEF)
     const id = await this.sqlInsert('proven_tx_reqs', e, 'provenTxReqId')
     tx.provenTxReqId = id
     return id
@@ -634,6 +636,7 @@ export class StorageExpoSQLite extends StorageProvider {
     const e = await this.validateEntityForInsert(tx, trx)
     if (e.transactionId === 0) delete (e as any).transactionId
     e.rawTx = await compressStoredTx(e.rawTx, e.txid)
+    e.inputBEEF = await compressStoredBeef(e.inputBEEF)
     const id = await this.sqlInsert('transactions', e, 'transactionId')
     tx.transactionId = id
     return id
@@ -687,6 +690,7 @@ export class StorageExpoSQLite extends StorageProvider {
       const txid = u.txid ?? (await this.txidOfProvenTxReq(id))
       u.rawTx = await compressStoredTx(u.rawTx, txid)
     }
+    if (u.inputBEEF) u.inputBEEF = await compressStoredBeef(u.inputBEEF)
     return await this.sqlUpdate('proven_tx_reqs', id, u, 'provenTxReqId')
   }
 
@@ -762,6 +766,7 @@ export class StorageExpoSQLite extends StorageProvider {
       const txid = u.txid ?? (await this.txidOfTransaction(id))
       u.rawTx = await compressStoredTx(u.rawTx, txid)
     }
+    if (u.inputBEEF) u.inputBEEF = await compressStoredBeef(u.inputBEEF)
     return await this.sqlUpdate('transactions', id, u, 'transactionId')
   }
 
@@ -1905,9 +1910,11 @@ export class StorageExpoSQLite extends StorageProvider {
     }
     for (const req of chunk.provenTxReqs ?? []) {
       req.rawTx = await compressStoredTx(req.rawTx, req.txid)
+      req.inputBEEF = await compressStoredBeef(req.inputBEEF)
     }
     for (const t of chunk.transactions ?? []) {
       t.rawTx = await compressStoredTx(t.rawTx, t.txid)
+      t.inputBEEF = await compressStoredBeef(t.inputBEEF)
     }
     return chunk
   }

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -11,7 +11,13 @@ import {
   splitOutpoint
 } from './methods/findSql'
 import { scrubHistoryJson } from './methods/historyNotes'
-import { assertExpanded, expandStoredRange, expandStoredScript, expandStoredTx } from './methods/expandStored'
+import {
+  assertExpanded,
+  compressStoredTx,
+  expandStoredRange,
+  expandStoredScript,
+  expandStoredTx
+} from './methods/expandStored'
 import { StorageError, storageErrorFromSqlite } from './errors'
 import {
   RECLAIM_CANDIDATES_SQL,
@@ -533,6 +539,11 @@ export class StorageExpoSQLite extends StorageProvider {
     // See methods/historyNotes.ts: provider error notes carry the full EF/rawTx
     // hex and reach this column untruncated.
     e.history = scrubHistoryJson(e.history)
+    // Compress-on-write. A vault transaction's rawTx is ~960 KB of template that
+    // reconstructs from ~40 bytes; this is the column TaskSendWaiting re-reads in
+    // full on every sweep and the one that pushed a backup chunk over the
+    // server's 1 MiB cap.
+    e.rawTx = await compressStoredTx(e.rawTx, e.txid)
     const id = await this.sqlInsert('proven_tx_reqs', e, 'provenTxReqId')
     tx.provenTxReqId = id
     return id
@@ -616,6 +627,7 @@ export class StorageExpoSQLite extends StorageProvider {
   async insertTransaction(tx: TableTransaction, trx?: TrxToken): Promise<number> {
     const e = await this.validateEntityForInsert(tx, trx)
     if (e.transactionId === 0) delete (e as any).transactionId
+    e.rawTx = await compressStoredTx(e.rawTx, e.txid)
     const id = await this.sqlInsert('transactions', e, 'transactionId')
     tx.transactionId = id
     return id
@@ -656,7 +668,25 @@ export class StorageExpoSQLite extends StorageProvider {
   async updateProvenTxReq(id: number | number[], update: Partial<TableProvenTxReq>, trx?: TrxToken): Promise<number> {
     const u = this.validatePartialForUpdate(update) as any
     if ('history' in u) u.history = scrubHistoryJson(u.history)
+    // An update carrying rawTx must know which transaction it is, or the envelope
+    // could not self-verify on the way out. When the txid is not part of the same
+    // update, read it back rather than storing an unverifiable envelope.
+    if (u.rawTx) {
+      const txid = u.txid ?? (await this.txidOfProvenTxReq(id))
+      u.rawTx = await compressStoredTx(u.rawTx, txid)
+    }
     return await this.sqlUpdate('proven_tx_reqs', id, u, 'provenTxReqId')
+  }
+
+  /** The txid of a single proven_tx_req, for a compress-on-update that did not
+   * carry one. Returns undefined for a multi-row update, which then stores raw. */
+  private async txidOfProvenTxReq(id: number | number[]): Promise<string | undefined> {
+    if (Array.isArray(id)) return undefined
+    const row = (await this.getDB().getFirstAsync(
+      'SELECT txid FROM proven_tx_reqs WHERE provenTxReqId = ?',
+      [id]
+    )) as { txid?: string } | null
+    return row?.txid
   }
 
   async updateCertificate(id: number, update: Partial<TableCertificate>, trx?: TrxToken): Promise<number> {
@@ -715,8 +745,22 @@ export class StorageExpoSQLite extends StorageProvider {
   }
 
   async updateTransaction(id: number | number[], update: Partial<TableTransaction>, trx?: TrxToken): Promise<number> {
-    const u = this.validatePartialForUpdate(update)
-    return await this.sqlUpdate('transactions', id, u as any, 'transactionId')
+    const u = this.validatePartialForUpdate(update) as any
+    if (u.rawTx) {
+      const txid = u.txid ?? (await this.txidOfTransaction(id))
+      u.rawTx = await compressStoredTx(u.rawTx, txid)
+    }
+    return await this.sqlUpdate('transactions', id, u, 'transactionId')
+  }
+
+  /** The txid of a single transaction row, for a compress-on-update that did not
+   * carry one. Undefined for a multi-row update, which then stores raw. */
+  private async txidOfTransaction(id: number | number[]): Promise<string | undefined> {
+    if (Array.isArray(id)) return undefined
+    const row = (await this.getDB().getFirstAsync('SELECT txid FROM transactions WHERE transactionId = ?', [
+      id
+    ])) as { txid?: string } | null
+    return row?.txid
   }
 
   async updateTxLabel(id: number, update: Partial<TableTxLabel>, trx?: TrxToken): Promise<number> {

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -5,11 +5,13 @@ import {
   PROVEN_HEIGHTS_SQL,
   buildFindSql,
   columnsExcluding,
+  fullReadSql,
   rangeReadSql,
   spendingReferencesSql,
   splitOutpoint
 } from './methods/findSql'
 import { scrubHistoryJson } from './methods/historyNotes'
+import { assertExpanded, expandStoredRange, expandStoredScript, expandStoredTx } from './methods/expandStored'
 import { StorageError, storageErrorFromSqlite } from './errors'
 import {
   RECLAIM_CANDIDATES_SQL,
@@ -848,6 +850,13 @@ export class StorageExpoSQLite extends StorageProvider {
 
     for (const o of results) {
       if (!args.noScript) {
+        // E3 of the expansion boundary, BEFORE validateOutputScript: that
+        // function short-circuits when lockingScript.length equals scriptLength
+        // and otherwise re-slices from rawTx, so expanding after it would let a
+        // compressed value be silently accepted on createAction-born outputs
+        // (vault deposits, change) while breaking internalize-born ones — green
+        // on a vault wallet, broken on someone else's.
+        o.lockingScript = await expandStoredScript(o.lockingScript)
         await this.validateOutputScript(o, args.trx)
       } else {
         o.lockingScript = undefined
@@ -928,6 +937,9 @@ export class StorageExpoSQLite extends StorageProvider {
 
     for (const t of results) {
       if (!args.noRawTx) {
+        // E4 of the expansion boundary.
+        t.rawTx = await expandStoredTx(t.rawTx)
+        t.inputBEEF = await expandStoredTx(t.inputBEEF)
         await this.validateRawTransaction(t, args.trx)
       } else {
         t.rawTx = undefined
@@ -979,14 +991,33 @@ export class StorageExpoSQLite extends StorageProvider {
       'provenTxReqId',
       extraConditions.length > 0 ? { conditions: extraConditions, params: extraParams } : undefined
     )
-    return this.validateEntities(rows, undefined, ['notified', 'wasBroadcast'])
+    const reqs = this.validateEntities(rows, undefined, ['notified', 'wasBroadcast'])
+    // E5 of the expansion boundary. proven_tx_reqs is where the monitor's txid
+    // tripwire reads from (TaskCheckForProofs re-hashes rawTx and flips the row
+    // to status='invalid' on a mismatch — irreversible, and it cascades to every
+    // notified transaction), and it is also the row mergeReqToBeefToShareExternally
+    // turns into a broadcast payload.
+    for (const req of reqs) {
+      req.rawTx = await expandStoredTx(req.rawTx)
+      req.inputBEEF = await expandStoredTx(req.inputBEEF)
+    }
+    return reqs
   }
 
   async findProvenTxs(args: FindProvenTxsArgs): Promise<TableProvenTx[]> {
     if ((args.partial as any).rawTx) throw new Error('ProvenTxs may not be found by rawTx value.')
     if ((args.partial as any).merklePath) throw new Error('ProvenTxs may not be found by merklePath value.')
     const rows = await this.sqlFind<any>('proven_txs', args, 'provenTxId')
-    return this.validateEntities(rows)
+    const proven = this.validateEntities(rows)
+    // E6 of the expansion boundary. proven_txs.rawTx is the merkle evidence:
+    // Beef.verifyBumpIndexLeaves requires hash256(rawTx) to equal a chain-committed
+    // BUMP leaf, and that check lives in @bsv/sdk where no subclass can intercept
+    // it — so anything leaving here must already be real bytes.
+    for (const p of proven) {
+      p.rawTx = await expandStoredTx(p.rawTx)
+      assertExpanded(p.rawTx, `proven_txs.rawTx for ${p.txid}`)
+    }
+    return proven
   }
 
   async findTxLabelMaps(args: FindTxLabelMapsArgs): Promise<TableTxLabelMap[]> {
@@ -1178,6 +1209,22 @@ export class StorageExpoSQLite extends StorageProvider {
   // getForUser methods (4)
   // ============================================================================
 
+  /**
+   * DELIBERATELY OUTSIDE the expansion boundary — do not add an expansion hook.
+   *
+   * This and getProvenTxReqsForUser below are what getSyncChunk reads, and a
+   * sync chunk is the ONE consumer that wants bytes in their stored form: the
+   * whole point of compressing at rest is that a vault record fits inside the
+   * backup server's 1 MiB blob cap. Expanding here would put ~960 KB back into
+   * every chunk carrying a vault transaction and reinstate exactly the wedge
+   * this work exists to clear.
+   *
+   * Both issue their own SQL and so bypass the find* hooks anyway, which is what
+   * makes the exception expressible at all — but it is an exception, and the
+   * restore side has to know: processSyncChunk feeds these bytes back through
+   * insertProvenTxReq/insertOutput, where the compress-on-write hooks must be
+   * idempotent (isEnvelope/isCompressed guards) rather than double-wrapping.
+   */
   async getProvenTxsForUser(args: FindForUserSincePagedArgs): Promise<TableProvenTx[]> {
     const db = this.getDB()
     let query = `SELECT pt.* FROM proven_txs pt
@@ -1282,7 +1329,47 @@ export class StorageExpoSQLite extends StorageProvider {
     return await this.insertCertificate(certificate)
   }
 
+  /**
+   * E7 of the expansion boundary: the one place stored bytes become a network
+   * payload.
+   *
+   * `attemptToPostReqsToNetwork` builds its beef exclusively through here, and
+   * every broadcaster — ARC, Arcade, WhatsOnChain, Bitails — reads out of that
+   * beef, so this is the convergence point for the wire. Reqs loaded through
+   * findProvenTxReqs are already expanded by E5, which makes this a belt rather
+   * than the mechanism; it exists because a caller can hand over a req obtained
+   * some other way (getProvenTxReqsForUser deliberately returns stored form),
+   * and posting a compressed payload is not a recoverable mistake: ARC rejects
+   * it, the req goes `invalid`, `reviewStatus` is a stub so it never becomes
+   * `failed`, and `releaseStuckReservations` only frees outputs whose spender is
+   * `failed` — so vault UTXOs stay reserved against a dead txid with nothing
+   * surfaced.
+   */
+  async mergeReqToBeefToShareExternally(
+    req: TableProvenTxReq,
+    mergeToBeef: Beef,
+    knownTxids: string[],
+    trx?: TrxToken
+  ): Promise<void> {
+    const expanded: TableProvenTxReq = {
+      ...req,
+      rawTx: await expandStoredTx(req.rawTx),
+      inputBEEF: await expandStoredTx(req.inputBEEF)
+    }
+    assertExpanded(expanded.rawTx, `broadcast rawTx for ${req.txid}`)
+    assertExpanded(expanded.inputBEEF, `broadcast inputBEEF for ${req.txid}`)
+    return await super.mergeReqToBeefToShareExternally(expanded, mergeToBeef, knownTxids, trx)
+  }
+
   // Data retrieval
+  /**
+   * E1 of the expansion boundary (see storage/methods/expandStored.ts).
+   *
+   * Every identity-deriving and BEEF-assembling consumer in the toolbox reaches
+   * bytes through here, including three that bypass the find* hooks entirely, so
+   * this is the load-bearing one: a compressed value escaping here becomes a
+   * WRONG TXID rather than an error.
+   */
   async getProvenOrRawTx(txid: string, trx?: TrxToken): Promise<ProvenOrRawTx> {
     const r: ProvenOrRawTx = { proven: undefined, rawTx: undefined, inputBEEF: undefined }
     const provenResults = await this.findProvenTxs({ partial: { txid }, trx })
@@ -1295,6 +1382,15 @@ export class StorageExpoSQLite extends StorageProvider {
         r.inputBEEF = req.inputBEEF
       }
     }
+    // findProvenTxs/findProvenTxReqs already expand (E4/E5), so these are
+    // normally no-ops. Kept unconditional because this method is what the
+    // bypassing consumers call, and an assertion is cheaper than reasoning about
+    // which of them arrived by which route.
+    r.rawTx = await expandStoredTx(r.rawTx)
+    r.inputBEEF = await expandStoredTx(r.inputBEEF)
+    if (r.proven) r.proven.rawTx = (await expandStoredTx(r.proven.rawTx)) as number[]
+    assertExpanded(r.rawTx, `proven_tx_reqs.rawTx for ${txid}`)
+    assertExpanded(r.proven?.rawTx, `proven_txs.rawTx for ${txid}`)
     return r
   }
 
@@ -1438,10 +1534,25 @@ export class StorageExpoSQLite extends StorageProvider {
       const db = this.getDB()
       // substr is 1-indexed over bytes; a JS offset of n starts at n + 1.
       const args = [offset + 1, length, txid]
-      const proven = (await db.getFirstAsync(rangeReadSql('proven_txs'), args)) as { chunk?: Uint8Array } | null
-      const row =
-        proven ?? ((await db.getFirstAsync(rangeReadSql('proven_tx_reqs'), args)) as { chunk?: Uint8Array } | null)
+      type RangeRow = { marker?: Uint8Array; chunk?: Uint8Array } | null
+      let table: 'proven_txs' | 'proven_tx_reqs' = 'proven_txs'
+      let row = (await db.getFirstAsync(rangeReadSql('proven_txs'), args)) as RangeRow
+      if (!row) {
+        table = 'proven_tx_reqs'
+        row = (await db.getFirstAsync(rangeReadSql('proven_tx_reqs'), args)) as RangeRow
+      }
       if (!row?.chunk) return undefined
+
+      // E2 of the expansion boundary. Slicing a stored envelope is the silent
+      // fund-eviction path (see storage/methods/expandStored.ts), so a marked row
+      // is re-read whole and the range served from its span list.
+      if (row.marker?.[0] === 0xfe) {
+        const full = (await db.getFirstAsync(fullReadSql(table), [txid])) as { rawTx?: Uint8Array } | null
+        if (!full?.rawTx) return undefined
+        const range = await expandStoredRange(Array.from(full.rawTx), offset, length)
+        assertExpanded(range, `range of rawTx for ${txid}`)
+        return range
+      }
       return Array.from(row.chunk)
     }
 

--- a/storage/methods/expandStored.ts
+++ b/storage/methods/expandStored.ts
@@ -1,0 +1,128 @@
+/**
+ * The expansion boundary: where compressed-at-rest bytes become real bytes.
+ *
+ * Two independent encodings can appear in a blob column, and they mean different
+ * things:
+ *
+ *   0xfe — a TRANSACTION envelope (services/vault/txEnvelope.ts). Substituted
+ *          R1-K1 script spans plus a literal remainder, carrying the real txid so
+ *          expansion self-verifies.
+ *   0xff — a compressed SCRIPT (services/vault/templateCodec.ts). One template
+ *          instance, carrying its own checksum.
+ *
+ * Neither can begin a legitimate value of the column it sits in: a rawTx starts
+ * with a version field (`01|02 00 00 00`), a BEEF with `01|02 00 be ef`, and a
+ * real R1-K1 locking script with `76 00 9c`. That is what makes sniffing the
+ * first byte safe HERE — and it is also why the two markers must never be
+ * conflated, since they route to different reconstructors.
+ *
+ * WHY THIS IS A MODULE AND NOT INLINE CODE. The spec requires that "no
+ * unexpanded bytes reach a consumer that needs full bytes" be provable by
+ * inspecting a short list. Keeping every decision in one place makes the list
+ * short, makes it testable without a device, and means a future read path that
+ * forgets to expand is a missing call to a named function rather than a missing
+ * `if`.
+ *
+ * FAILURE IS LOUD, DELIBERATELY. A blob that carries a marker but cannot be
+ * reconstructed is not passed through: passing it through is exactly how wrong
+ * bytes reach a hasher or a broadcaster. The one exception is documented on
+ * `expandStoredScript`, where a page-supplied value can legitimately be
+ * unreconstructable and erroring the whole query would be worse.
+ */
+import { expandScriptBytes, isCompressed } from '@/services/vault/templateCodec'
+import { expandTransaction, isEnvelope, readEnvelopeRange } from '@/services/vault/txEnvelope'
+
+const asBytes = (b: number[] | Uint8Array): Uint8Array => (b instanceof Uint8Array ? b : Uint8Array.from(b))
+
+/**
+ * Expand a stored transaction blob (`rawTx`, `inputBEEF`, `beef`).
+ *
+ * Self-verifying via the envelope's recorded txid. Anything that is not an
+ * envelope is returned unchanged, so this is safe to call unconditionally on
+ * every read — which is the point: an unconditional call cannot be forgotten in
+ * one branch.
+ */
+export async function expandStoredTx<T extends number[] | Uint8Array | undefined>(bytes: T): Promise<T> {
+  if (!bytes || bytes.length === 0) return bytes
+  if (!isEnvelope(bytes)) return bytes
+  const expanded = await expandTransaction(asBytes(bytes))
+  // Preserve the caller's shape: inputBEEF is typed as a Uint8Array-backed BEEF
+  // in places and number[] in others, and silently changing one for the other
+  // would break a consumer in a way types would not catch at every seam.
+  return (bytes instanceof Uint8Array ? expanded : Array.from(expanded)) as T
+}
+
+/**
+ * Expand a byte range of a stored transaction without materialising the whole
+ * thing.
+ *
+ * This is the path that would otherwise evict funds silently.
+ * `outputs.scriptOffset`/`scriptLength` are absolute offsets into the
+ * UNCOMPRESSED rawTx; slicing an envelope at them returns plausible-looking
+ * wrong bytes with no error, `Services.hashOutputScript` hashes those, the chain
+ * answers "not a UTXO", and three separate writers persist `spendable = false`.
+ * So a range read over an envelope must be served from its span list, never by
+ * slicing the stored bytes.
+ */
+export async function expandStoredRange(
+  bytes: number[] | undefined,
+  offset: number,
+  length: number
+): Promise<number[] | undefined> {
+  if (!bytes || bytes.length === 0) return bytes
+  if (!isEnvelope(bytes)) return bytes.slice(offset, offset + length)
+  return Array.from(await readEnvelopeRange(asBytes(bytes), offset, length))
+}
+
+/**
+ * Expand a stored script blob (`outputs.lockingScript`, `commissions.lockingScript`).
+ *
+ * Returns the bytes unchanged when reconstruction fails, and this is the one
+ * place that swallows rather than throws. The reason is provenance: a script
+ * column can hold bytes a PAGE supplied — `internalizeAction` writes attacker-
+ * chosen output scripts with no `scriptLength`/`scriptOffset` fallback — so a
+ * marker-led value there may be a forgery rather than something this wallet
+ * wrote. Throwing would let one such row take down `listOutputs`, the vault
+ * screen and the backup sweep for the whole wallet, since `findOutputs` maps
+ * over its results with no per-row catch. Degrading to "one odd-looking output"
+ * is strictly better than that, and the value is never used as a script without
+ * being checked against `scriptLength` downstream.
+ *
+ * Transaction blobs get the opposite treatment (`expandStoredTx` throws),
+ * because those are only ever written by this wallet and a failure there means
+ * real corruption.
+ */
+export async function expandStoredScript(bytes: number[] | undefined): Promise<number[] | undefined> {
+  if (!bytes || bytes.length === 0) return bytes
+  if (!isCompressed(bytes)) return bytes
+  try {
+    return Array.from(await expandScriptBytes(asBytes(bytes)))
+  } catch (e) {
+    console.warn(
+      `[storage] a stored script carries the compressed-script marker but could not be expanded: ${
+        (e as Error)?.message ?? 'unknown'
+      }`
+    )
+    return bytes
+  }
+}
+
+/**
+ * Assert that bytes about to leave for somewhere that needs real ones are real.
+ *
+ * The last line of defence for the invariant, and the reason it is checkable
+ * rather than merely intended: a branded type is erased the moment bytes cross
+ * into `node_modules`, so a runtime assertion is the only thing that spans that
+ * seam. Call it immediately before handing bytes to a broadcaster, a hasher or a
+ * parser.
+ */
+export function assertExpanded(bytes: number[] | Uint8Array | undefined, what: string): void {
+  if (!bytes || bytes.length === 0) return
+  const first = bytes instanceof Uint8Array ? bytes[0] : bytes[0]
+  if (first === 0xfe || first === 0xff) {
+    throw new Error(
+      `${what} still carries a compressed-at-rest marker (0x${first.toString(16)}) at the point where real ` +
+        'bytes are required — a read path is missing its expansion hook'
+    )
+  }
+}

--- a/storage/methods/expandStored.ts
+++ b/storage/methods/expandStored.ts
@@ -162,3 +162,21 @@ export async function compressStoredTx<T extends number[] | Uint8Array | undefin
     return bytes
   }
 }
+
+/**
+ * Whether `proven_txs.rawTx` may be stored compressed.
+ *
+ * OFF, and it must stay off until a device has run a full deposit -> withdrawal
+ * -> proof cycle with the other columns compressed. That row is not like the
+ * others: it IS the merkle evidence for a mined transaction, and
+ * `Beef.verifyBumpIndexLeaves` binds `hash256(rawTx)` to a chain-committed BUMP
+ * leaf inside @bsv/sdk, where no subclass can intercept it. A bug in the other
+ * columns is recoverable by rewriting them from the network; a bug here makes
+ * every later spend of that transaction's outputs fail `beef.verify()` with
+ * nothing local able to repair it.
+ *
+ * Expansion (E6) is already unconditional, so flipping this on is a one-line,
+ * reversible change once the evidence exists — and rows written while it was on
+ * stay readable if it is turned back off.
+ */
+export const COMPRESS_PROVEN_TX_RAWTX = false

--- a/storage/methods/expandStored.ts
+++ b/storage/methods/expandStored.ts
@@ -30,7 +30,13 @@
  * unreconstructable and erroring the whole query would be worse.
  */
 import { expandScriptBytes, isCompressed } from '@/services/vault/templateCodec'
-import { compressTransaction, expandTransaction, isEnvelope, readEnvelopeRange } from '@/services/vault/txEnvelope'
+import {
+  compressContainer,
+  compressTransaction,
+  expandTransaction,
+  isEnvelope,
+  readEnvelopeRange
+} from '@/services/vault/txEnvelope'
 
 const asBytes = (b: number[] | Uint8Array): Uint8Array => (b instanceof Uint8Array ? b : Uint8Array.from(b))
 
@@ -180,3 +186,30 @@ export async function compressStoredTx<T extends number[] | Uint8Array | undefin
  * stay readable if it is turned back off.
  */
 export const COMPRESS_PROVEN_TX_RAWTX = false
+
+/**
+ * Compress a stored BEEF container (`inputBEEF`, `beef`) on the way in.
+ *
+ * Separate from compressStoredTx because a container holds several transactions
+ * and has no single txid: its envelope commits to a SHA-256 of the blob instead.
+ * Routing one through the transaction path would produce an envelope whose
+ * integrity check verified nothing.
+ *
+ * This is the column that matters for a WITHDRAWAL: inputBEEF carries ~1.83 MB
+ * per vault input, several times the rawTx it accompanies, so a withdrawal's
+ * backup chunk stays over the server's 1 MiB cap until this is compressed.
+ *
+ * Idempotent and total, for the same reasons as compressStoredTx.
+ */
+export async function compressStoredBeef<T extends number[] | Uint8Array | undefined>(bytes: T): Promise<T> {
+  if (!bytes || bytes.length === 0) return bytes
+  if (isEnvelope(bytes)) return bytes
+  try {
+    const compressed = await compressContainer(asBytes(bytes))
+    if (compressed.length >= bytes.length) return bytes
+    return (bytes instanceof Uint8Array ? compressed : Array.from(compressed)) as T
+  } catch (e) {
+    console.warn(`[storage] could not compress a BEEF blob: ${(e as Error)?.message ?? 'unknown'}`)
+    return bytes
+  }
+}

--- a/storage/methods/expandStored.ts
+++ b/storage/methods/expandStored.ts
@@ -30,7 +30,7 @@
  * unreconstructable and erroring the whole query would be worse.
  */
 import { expandScriptBytes, isCompressed } from '@/services/vault/templateCodec'
-import { expandTransaction, isEnvelope, readEnvelopeRange } from '@/services/vault/txEnvelope'
+import { compressTransaction, expandTransaction, isEnvelope, readEnvelopeRange } from '@/services/vault/txEnvelope'
 
 const asBytes = (b: number[] | Uint8Array): Uint8Array => (b instanceof Uint8Array ? b : Uint8Array.from(b))
 
@@ -124,5 +124,41 @@ export function assertExpanded(bytes: number[] | Uint8Array | undefined, what: s
       `${what} still carries a compressed-at-rest marker (0x${first.toString(16)}) at the point where real ` +
         'bytes are required — a read path is missing its expansion hook'
     )
+  }
+}
+
+/**
+ * Compress a stored transaction blob on the way in.
+ *
+ * Idempotent and total: an envelope is returned as-is, a transaction with no
+ * R1-K1 span is returned unchanged, and anything unparseable is returned
+ * unchanged — so this is safe to call on every write, which is what keeps a
+ * future write path from being a missing `if`.
+ *
+ * Idempotence is load-bearing rather than tidy: `processSyncChunk` feeds bytes
+ * from a backup restore straight back through the insert methods, and those bytes
+ * are in STORED form because getSyncChunk deliberately emits stored form. Without
+ * the envelope guard, a restore would wrap an envelope in an envelope.
+ *
+ * @param txid the transaction's own txid. Required, because expansion verifies
+ *   the reconstruction by hashing it and comparing — a blob with no single txid
+ *   (a BEEF container) must not be routed here.
+ */
+export async function compressStoredTx<T extends number[] | Uint8Array | undefined>(
+  bytes: T,
+  txid: string | undefined
+): Promise<T> {
+  if (!bytes || bytes.length === 0) return bytes
+  if (isEnvelope(bytes)) return bytes
+  if (!txid || !/^[0-9a-fA-F]{64}$/.test(txid)) return bytes
+  try {
+    const compressed = await compressTransaction(asBytes(bytes), txid)
+    if (compressed.length >= bytes.length) return bytes
+    return (bytes instanceof Uint8Array ? compressed : Array.from(compressed)) as T
+  } catch (e) {
+    // Never fail a write because compression could not help. The uncompressed
+    // bytes are always correct; the envelope is only ever an optimisation.
+    console.warn(`[storage] could not compress rawTx for ${txid}: ${(e as Error)?.message ?? 'unknown'}`)
+    return bytes
   }
 }

--- a/storage/methods/findSql.ts
+++ b/storage/methods/findSql.ts
@@ -190,9 +190,22 @@ export function buildFindSql(opts: FindSqlOptions): string {
  */
 export function rangeReadSql(table: 'proven_txs' | 'proven_tx_reqs'): string {
   const usable = "AND status IN ('unsent','unmined','unconfirmed','sending','nosend','completed')"
-  return `SELECT substr(rawTx, ?, ?) AS chunk FROM "${table}" WHERE txid = ? ${
+  // The marker byte comes back alongside the range so one query can tell whether
+  // slicing was even legitimate. A stored transaction envelope begins 0xfe, and
+  // slicing THAT at an offset into the uncompressed transaction returns
+  // plausible-looking wrong bytes with no error — which downstream becomes a
+  // hashed script, a "not a UTXO" answer and a persisted spendable = false. So
+  // the caller re-reads the whole row and serves the range from the envelope's
+  // span list instead. Ordinary rows keep the cheap path.
+  return `SELECT substr(rawTx, 1, 1) AS marker, substr(rawTx, ?, ?) AS chunk FROM "${table}" WHERE txid = ? ${
     table === 'proven_tx_reqs' ? usable : ''
   }`.trimEnd()
+}
+
+/** Whole rawTx for one txid — the envelope path's fallback. */
+export function fullReadSql(table: 'proven_txs' | 'proven_tx_reqs'): string {
+  const usable = "AND status IN ('unsent','unmined','unconfirmed','sending','nosend','completed')"
+  return `SELECT rawTx FROM "${table}" WHERE txid = ? ${table === 'proven_tx_reqs' ? usable : ''}`.trimEnd()
 }
 
 /**


### PR DESCRIPTION
Plan 4 Tasks 4–7. **Stacked on #137**, which is stacked on #136 — merge in that order or rebase.

This is the change that starts writing compressed bytes, so the ordering inside it matters: the boundary lands first as a no-op, then the writes.

## The boundary (Task 4)

Seven read paths route stored bytes through `storage/methods/expandStored.ts`:

| | | |
|---|---|---|
| E1 | `getProvenOrRawTx` | every identity-deriving and BEEF-assembling consumer |
| E2 | `getRawTxOfKnownValidTransaction` | byte ranges, served from the span list |
| E3 | `findOutputs` | **before** `validateOutputScript`, never after |
| E4 | `findTransactions` | |
| E5 | `findProvenTxReqs` | the monitor's txid tripwire reads here |
| E6 | `findProvenTxs` | the merkle evidence |
| E7 | `mergeReqToBeefToShareExternally` | the one path onto the wire |

**E2 is the one that loses money quietly.** `outputs.scriptOffset`/`scriptLength` are absolute offsets into the *uncompressed* transaction, so slicing a stored envelope at them returns plausible wrong bytes with no error → `hashOutputScript` hashes them → chain says not-a-UTXO → three writers persist `spendable = false`. The range query now returns the marker byte alongside the range, and a marked row is re-read whole and served from its span list.

**E3 must run before `validateOutputScript`.** That function short-circuits when `lockingScript.length === scriptLength` and otherwise re-slices from rawTx, so expanding *after* it would silently accept a compressed value on createAction-born outputs (vault deposits, change) while breaking internalize-born ones — green on a vault wallet, broken on someone else's.

### Two "mandatory" patches turned out not to be

The research called for patching `TaskCheckForProofs` and `getBeefForTransaction`. Reading them: the first loads reqs via `this.storage.findProvenTxReqs` (E5 covers it), and the second's bytes come from `EntityProvenTx.fromTxid(txid, services)` — network-sourced, already real. Every route into `node_modules` passes through a storage method we own, so `assertExpanded` at those seams spans the same gap a patched parse primitive would, without committing to patch-drift on every `@bsv` bump. Recorded in the commit because it contradicts the plan.

### Failure modes differ by provenance, deliberately

Transaction blobs **throw** on failed reconstruction — they're only ever written by this wallet, so a failure means real corruption and passing bytes through is how wrong ones reach a broadcaster. Script blobs **degrade** to the stored bytes: `internalizeAction` writes page-supplied output scripts, and `findOutputs` maps with no per-row catch, so one forged marker-led value would otherwise take down `listOutputs`, the vault screen and the backup sweep for the whole wallet.

## Compress on write (Task 5)

`proven_tx_reqs.rawTx` and `transactions.rawTx`: a vault transaction goes from ~960 KB to under a kilobyte, byte-exact and self-verifying against its own txid.

Hooks are total and idempotent, and idempotence is load-bearing rather than tidy — `processSyncChunk` feeds restored bytes straight back through the insert methods *in stored form*, so without the envelope guard a restore would wrap an envelope in an envelope. An update carrying rawTx without a txid reads it back from the row rather than storing something that could never verify itself; a multi-row update stores raw. Compression failure never fails a write.

### The plan was wrong about `inputBEEF`

The envelope proves itself by hashing its reconstruction against a recorded **txid**, and a BEEF is a *container* of several transactions with no single txid — so routing one through this codec yields an envelope whose integrity check is meaningless. `inputBEEF` needs a BEEF-aware variant (walk the container, compress each contained transaction, verify per transaction or record a digest of the whole blob).

**This matters for the wedge:** `inputBEEF` is ~1.83 MB per vault input, so a *withdrawal's* backup chunk stays over the 1 MiB cap until that lands. A *deposit's* now fits.

## Tasks 6 and 7

**`proven_txs.rawTx` is gated OFF** (`COMPRESS_PROVEN_TX_RAWTX`). It is the merkle evidence, and `Beef.verifyBumpIndexLeaves` binds `hash256(rawTx)` to a chain-committed leaf inside `@bsv/sdk` where no subclass can intercept. A bug in the other columns is recoverable by refetching; a bug here makes every later spend fail `beef.verify()` with nothing local able to repair it. Expansion is already unconditional, so flipping it after a device pass is one reversible line.

**`getSyncChunk` re-compresses on the way out.** It reads outputs *without* `noScript`, so E3 expands and `validateOutputScript` re-slices the full ~960 KB script from rawTx for vault outputs whose column is NULL — which it always is. A chunk with one vault output exceeded the 1 MiB cap even though the database stores almost nothing for it. Peer sync would need a capability flag first, and the comment says why; `storageUrl` is `'local'` today so the only consumer is our own backup.

## Testing

`npx tsc --noEmit` clean, `npx jest` 101 suites / 1239 tests, eslint 0 errors. 21 new tests across the boundary and the write hooks, built on real envelopes and the mined mainnet fixture rather than stand-ins.

## Still owed, and not claimable from tests

- **BEEF-aware compression** for `inputBEEF` (above).
- **A device pass.** The programme's success criterion is an observation, not an assertion: after a real deposit and withdrawal, `estimateEncodedBytes` clears `MAX_BLOB_BYTES` and the backup cursor *advances*; and two `TaskCheckForProofs` sweeps with no req reaching `status='invalid'`.
- **A mining harness.** Every representation-agnostic site passes green on compressed bytes; the failures that matter live in the monitor, the UTXO prober and the broadcaster, which no current test drives that far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)