### PR TITLE
Fix SQLite statement finalization use-after-free bug

### DIFF
--- a/patches/expo-sqlite+55.0.16.patch
+++ b/patches/expo-sqlite+55.0.16.patch
@@ -1,0 +1,44 @@
+diff --git a/node_modules/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt b/node_modules/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+index ac800ac..8c3a6e4 100644
+--- a/node_modules/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
++++ b/node_modules/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+@@ -475,10 +475,15 @@ class SQLiteModule : Module() {
+   private fun finalize(statement: NativeStatement, database: NativeDatabase) {
+     maybeThrowForClosedDatabase(database)
+     maybeThrowForFinalizedStatement(statement)
+-    if (statement.ref.sqlite3_finalize() != NativeDatabaseBinding.SQLITE_OK) {
++    // sqlite3_finalize always frees the statement; a non-OK result only
++    // reports the error from the statement's most recent evaluation. Mark
++    // the statement finalized before throwing so the freed pointer can
++    // never be finalized again (use-after-free / heap corruption).
++    val ret = statement.ref.sqlite3_finalize()
++    statement.isFinalized = true
++    if (ret != NativeDatabaseBinding.SQLITE_OK) {
+       throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+     }
+-    statement.isFinalized = true
+   }
+ 
+   private fun addUpdateHook(database: NativeDatabase) {
+diff --git a/node_modules/expo-sqlite/ios/SQLiteModule.swift b/node_modules/expo-sqlite/ios/SQLiteModule.swift
+index 15c784f..9b44dbf 100644
+--- a/node_modules/expo-sqlite/ios/SQLiteModule.swift
++++ b/node_modules/expo-sqlite/ios/SQLiteModule.swift
+@@ -467,10 +467,15 @@ public final class SQLiteModule: Module {
+   private func finalize(statement: NativeStatement, database: NativeDatabase) throws {
+     try maybeThrowForClosedDatabase(database)
+     try maybeThrowForFinalizedStatement(statement)
+-    if exsqlite3_finalize(statement.pointer) != SQLITE_OK {
++    // sqlite3_finalize always frees the statement; a non-OK result only
++    // reports the error from the statement's most recent evaluation. Mark
++    // the statement finalized before throwing so the freed pointer can
++    // never be finalized again (use-after-free / heap corruption).
++    let ret = exsqlite3_finalize(statement.pointer)
++    statement.isFinalized = true
++    if ret != SQLITE_OK {
+       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+     }
+-    statement.isFinalized = true
+   }
+ 
+   private func convertSqlLiteErrorToString(_ db: OpaquePointer?) -> String {

--- a/storage/StorageExpoSQLite.ts
+++ b/storage/StorageExpoSQLite.ts
@@ -106,6 +106,10 @@ export class StorageExpoSQLite extends StorageProvider {
 
   async migrate(storageName: string, storageIdentityKey: string): Promise<string> {
     this.db = await SQLite.openDatabaseAsync(this.dbName)
+    // Wait out writer contention instead of failing immediately with
+    // "Error code 5: database is locked" (seen from finalizeAsync on device,
+    // where it turned into a native use-after-free — see patches/expo-sqlite).
+    await this.db.execAsync('PRAGMA busy_timeout = 5000')
     await createTables(this.db)
     await ensureOfflineActionsColumns(this.db)
 


### PR DESCRIPTION
## Summary
This PR fixes a critical use-after-free vulnerability in SQLite statement finalization by ensuring the statement is marked as finalized before any error is thrown, preventing double-finalization of freed pointers.

## Key Changes

- **expo-sqlite patch (Android & iOS)**: Reordered the finalization logic to mark statements as finalized immediately after calling `sqlite3_finalize()`, before checking the return code. This prevents the freed pointer from being finalized again if an error is thrown.
  - The underlying SQLite library always frees the statement regardless of the return code
  - A non-OK return only indicates an error from the statement's most recent evaluation
  - By marking `isFinalized = true` before throwing, we prevent heap corruption from use-after-free

- **StorageExpoSQLite.ts**: Added a `PRAGMA busy_timeout = 5000` call after opening the database to handle writer contention gracefully instead of failing immediately with "database is locked" errors. This prevents the finalization bug from being triggered on device during concurrent database access.

## Implementation Details
The fix applies the same logic to both Android (Kotlin) and iOS (Swift) implementations to ensure consistent behavior across platforms. The pragma timeout allows the database to wait up to 5 seconds for locks to be released rather than failing immediately, which was causing the finalization code path to be hit under contention.

https://claude.ai/code/session_01GHtySHJ1DEpnRbLGgbAXYB