### PR TITLE
fix(vault): restore this-binding in guardVaultAccess for privileged-capable methods

### DIFF
--- a/__tests__/vault/guard.test.ts
+++ b/__tests__/vault/guard.test.ts
@@ -75,6 +75,30 @@ test('passes non-privileged-capable methods straight through, even privileged-lo
   expect(calls.map(c => c.method).sort()).toEqual(['createAction', 'listOutputs'])
 })
 
+test('preserves `this` for privileged-capable methods that read instance state', async () => {
+  // Regression test: the real wallet (SimpleWalletManager) implements
+  // getPublicKey as `async getPublicKey(args, originator) { this.ensureCanCall(...);
+  // return this.underlying.getPublicKey(...) }` -- it reads `this` internally.
+  // fakeWallet()'s methods above are closures that ignore `this` entirely, so
+  // they can't catch a guard that invokes the real method unbound. This wallet
+  // is deliberately shaped like the real one: a class instance method that
+  // throws if called without its `this` context, exactly as
+  // `this.ensureCanCall is not a function` did in production when
+  // guardVaultAccess called `value(args, originator)` instead of
+  // `value.call(target, args, originator)`.
+  class RealisticWallet {
+    marker = 'instance-state'
+    async getPublicKey(_args: any, _originator?: string) {
+      return { publicKey: this.marker }
+    }
+  }
+  const wallet = new RealisticWallet() as any
+  const guarded = guardVaultAccess(wallet, ADMIN)
+  await expect(guarded.getPublicKey({ protocolID: [1, 'x'], keyID: '1' } as any, 'evil.com')).resolves.toEqual({
+    publicKey: 'instance-state'
+  })
+})
+
 test('treats missing/false privileged flag as allowed', async () => {
   const { wallet, calls } = fakeWallet()
   const guarded = guardVaultAccess(wallet, ADMIN)

--- a/services/vault/guard.ts
+++ b/services/vault/guard.ts
@@ -82,7 +82,16 @@ export function guardVaultAccess<T extends WalletInterface>(wallet: T, adminOrig
         if (privileged && originator !== adminOriginator) {
           return Promise.reject(new VaultAccessDenied(String(prop), originator ?? ''))
         }
-        return (value as (a: unknown, o?: string) => unknown)(args, originator)
+        // .call(target, ...), not a bare invocation -- `value` is the real
+        // wallet's own method (e.g. SimpleWalletManager.prototype.getPublicKey),
+        // which reads `this.ensureCanCall`/`this.underlying` internally. A bare
+        // call left `this` unbound, so every PRIVILEGED_CAPABLE method (every
+        // ordinary, non-privileged getPublicKey call included, not just
+        // privileged ones) threw "undefined is not a function" the instant it
+        // touched `this` -- silently breaking wallet connections for any site
+        // opened in the in-app browser, since getPublicKey is the first call
+        // a BRC-100 connect makes.
+        return (value as (a: unknown, o?: string) => unknown).call(target, args, originator)
       }
     }
   })


### PR DESCRIPTION
## Summary
`guardVaultAccess` (`services/vault/guard.ts`) wraps every `PRIVILEGED_CAPABLE` method (`getPublicKey`, `encrypt`, `decrypt`, `createHmac`, `verifyHmac`, `createSignature`, `verifySignature`, `revealCounterpartyKeyLinkage`, `revealSpecificKeyLinkage`, `acquireCertificate`, `proveCertificate`, `listCertificates`) with a privilege check before passing the call through to the real wallet. The pass-through was a **bare invocation** — `value(args, originator)` — which drops `this`. The sibling branch two lines above (for methods *not* in `PRIVILEGED_CAPABLE`) already does this correctly via `value.bind(target)`; this branch never got the same treatment.

Real wallet implementations (e.g. `@bsv/wallet-toolbox-mobile`'s `SimpleWalletManager`) read `this` internally:

```js
async getPublicKey(args, originator) {
    this.ensureCanCall(originator);
    return await this.underlying.getPublicKey(args, originator);
}
```

With `this` unbound, `this.ensureCanCall` resolves to `undefined`, and calling it throws `undefined is not a function` — with no property name in the message, since it's a computed/member call inside a dynamically-evaluated WebView script, which made this very hard to trace from the app side.

**Impact:** this broke every *ordinary, non-privileged* `getPublicKey` call from the in-tab CWI bridge, not just the privileged ones the guard was meant to block — and `getPublicKey` is the first call a BRC-100 connect makes. That means any website opened in BSV Browser's own in-app browser, using the injected `window.CWI` substrate (and the same `guardVaultAccess` call site backing the desktop-pairing `WalletClient`), silently fails to connect. Found this by chasing a real "wallet won't connect" report through the whole stack, down to a bare `err.message` with no context, before finding this line.

## Why the existing tests didn't catch it
`__tests__/vault/guard.test.ts`'s `fakeWallet()` stubs are plain closures that ignore `this` entirely — they can't distinguish a bound call from an unbound one. Added a regression test using a real class instance method that reads `this` (matching how `SimpleWalletManager` actually behaves), confirmed it fails against the unfixed code and passes against the fix.

## Test plan
- [x] All 16 existing + 1 new test in `__tests__/vault/guard.test.ts` pass
- [x] New regression test verified load-bearing (fails on unfixed code with the exact `this`-loss symptom, passes with the fix)
- [x] `tsc --noEmit` clean (two pre-existing, unrelated errors in `__tests__/manual/` predate this change)
- [x] Manually reproduced and confirmed fixed on-device: BRC-100 connect via injected `window.CWI` now succeeds against a real website

🤖 Generated with [Claude Code](https://claude.com/claude-code)