### PR TITLE
chore(deps): prepare toolbox 0.2.3 SVG icon update

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@bsv/backup-cache-client": "^0.1.0",
     "@bsv/btms": "^1.1.0",
     "@bsv/btms-permission-module": "^1.1.0",
-    "@bsv/expo-wallet-toolbox": "0.2.1",
+    "@bsv/expo-wallet-toolbox": "0.2.3",
     "@bsv/react-native-localpay-transport": "0.1.1",
     "@bsv/message-box-client": "^2.2.1",
     "@bsv/sdk": "^2.4.1",


### PR DESCRIPTION
Update @bsv/expo-wallet-toolbox from 0.2.1 to the proposed 0.2.3 release containing SVG certifier icon support from https://github.com/bsv-blockchain/bsv-wallet/pull/12.

That change moves trust-icon validation, provider preview, and saved-list rendering to Expo Image. BSV Browser already depends on expo-image ~55.0.11, so no new native dependency is introduced here.

BLOCKED — do not merge yet:
- The upstream fix must merge and @bsv/expo-wallet-toolbox containing it must be published. 0.2.3 is the proposed version; adjust this pin if maintainers choose a different release.
- Regenerate package-lock.json against the actual published package and commit it. The current lockfile deliberately remains unchanged because 0.2.3 is unpublished; this draft is not npm-ci-ready. No tarball URL or integrity hash has been fabricated.
- Run the normal install/test/build checks and smoke-test importing Sigma on iOS and Android, including the provider preview and saved icon, plus an existing PNG provider.

Validation so far: package.json parses, the intended dependency pin and existing Expo Image dependency are verified, and git diff --check passes. Install/build/device testing is pending the upstream release.
